### PR TITLE
Added Reinhard Tonemapper & UpgradeToneMap function

### DIFF
--- a/Shaders/Includes/Reinhard.hlsl
+++ b/Shaders/Includes/Reinhard.hlsl
@@ -1,0 +1,132 @@
+
+ 
+#include "Color.hlsl"
+
+// Erik Reinhard, Michael Stark, Peter Shirley, and James Ferwerda.
+// "Photographic Tone Reproduction for Digital Images."
+// ACM Transactions on Graphics (SIGGRAPH), 2002.
+namespace Reinhard  {
+
+  float ReinhardSimple(float x, float peak = 1.f) {
+    return x / (x / peak + 1.f);
+  }
+
+  float3 ReinhardSimple(float3 x, float peak = 1.f) {
+    return x / (x / peak + 1.f);
+  }
+
+  float ReinhardExtended(float color, float white_max = 1000.f / 203.f, float peak = 1.f) {
+    return ReinhardSimple(color, peak) * (1.f + (peak * color) / (white_max * white_max));
+  }
+
+  float3 ReinhardExtended(float3 color, float white_max = 1000.f / 203.f, float peak = 1.f) {
+    return ReinhardSimple(color, peak) * (1.f + (peak * color) / (white_max * white_max));
+  }
+
+  float ComputeReinhardScale(float channel_max = 1.f, float channel_min = 0.f, float gray_in = 0.18f, float gray_out = 0.18f) {
+    return (channel_max * (channel_min * gray_out + channel_min - gray_out))
+          / (gray_in * (gray_out - channel_max));
+  }
+
+  float ReinhardScalable(float x, float x_max = 1.f, float x_min = 0.f, float gray_in = 0.18f, float gray_out = 0.18f) {
+    float exposure = ComputeReinhardScale(x_max, x_min, gray_in, gray_out);
+    return mad(x, exposure, x_min) / mad(x, exposure / x_max, 1.f - x_min);
+  }
+
+  float3 ReinhardScalable(float3 x, float x_max = 1.f, float x_min = 0.f, float gray_in = 0.18f, float gray_out = 0.18f) {
+    float exposure = ComputeReinhardScale(x_max, x_min, gray_in, gray_out);
+    return mad(x, exposure, x_min) / mad(x, exposure / x_max, 1.f - x_min);
+  }
+
+  float ComputeReinhardExtendableScale(float w = 100.f, float p = 1.f, float m = 0.f, float x = 0.18f, float y = 0.18f) {
+    // y = (sx / (sx/p + 1) * (1 + (psx)/(sw*sw))
+    // solve for s (scale)
+    // Min not currently supported
+    return p * (w * w * y - (p * x * x)) / (w * w * x * (p - y));
+  }
+
+  float ReinhardScalableExtended(float x, float white_max = 100.f, float x_max = 1.f, float x_min = 0.f, float gray_in = 0.18f, float gray_out = 0.18f) {
+    float exposure = ComputeReinhardExtendableScale(white_max, x_max, x_min, gray_in, gray_out);
+    float extended = ReinhardExtended(x * exposure, white_max * exposure, x_max);
+    return min(extended, x_max);
+  }
+
+  float3 ReinhardScalableExtended(float3 x, float white_max = 100.f, float x_max = 1.f, float x_min = 0.f, float gray_in = 0.18f, float gray_out = 0.18f) {
+    float exposure = ComputeReinhardExtendableScale(white_max, x_max, x_min, gray_in, gray_out);
+    float3 extended = ReinhardExtended(x * exposure, white_max * exposure, x_max);
+    return min(extended, x_max);
+  }
+
+}
+
+
+struct ReinhardSettings
+{
+  float mid_grey_value;
+  float mid_grey_nits;
+  float white_clip;
+  float reference_white;
+
+  bool by_luminance;
+};
+
+ReinhardSettings DefaultReinhardSettings()
+{
+  ReinhardSettings settings;
+  settings.mid_grey_value = 0.18f;
+  settings.mid_grey_nits = 18.f;
+  settings.white_clip = 100.f;
+  settings.reference_white = 100.f;
+  settings.by_luminance = true;
+  return settings;
+}
+
+
+
+float3 ReinhardTonemap(float3 color, float peak_nits, float diffuse_nits, ReinhardSettings settings)   {
+
+    // this equation should also involve reference white 
+    float peak = (peak_nits / diffuse_nits); 
+
+    if (settings.by_luminance)  {
+
+      float y = GetLuminance(color, CS_BT709);
+      float peak = (peak_nits / diffuse_nits); 
+
+
+      float3 y_new = Reinhard::ReinhardScalableExtended(
+            y,
+            settings.white_clip,
+            peak,
+            0.f,
+            settings.mid_grey_value,
+            settings.mid_grey_nits / settings.reference_white);
+
+
+      float3 color_output = color * (y > 0 ? (y_new / y) : 0);
+
+      return color_output;
+
+    } else {
+      
+      float3 color_output = color;
+      
+      float3 signs = sign(color);
+
+      color_output = abs(color_output);
+      
+      color_output = Reinhard::ReinhardScalableExtended(
+          color_output,
+          settings.white_clip,
+          peak,
+          0,
+          settings.mid_grey_value,
+          settings.mid_grey_nits / settings.reference_white);
+
+      color_output *= signs;
+
+      return color_output;
+    };
+
+}
+

--- a/Shaders/Includes/Reinhard.hlsl
+++ b/Shaders/Includes/Reinhard.hlsl
@@ -1,12 +1,10 @@
-
- 
 #include "Color.hlsl"
 
 // Erik Reinhard, Michael Stark, Peter Shirley, and James Ferwerda.
 // "Photographic Tone Reproduction for Digital Images."
 // ACM Transactions on Graphics (SIGGRAPH), 2002.
-namespace Reinhard  {
-
+namespace Reinhard 
+{
   float ReinhardSimple(float x, float peak = 1.f) {
     return x / (x / peak + 1.f);
   }
@@ -59,7 +57,6 @@ namespace Reinhard  {
 
 }
 
-
 struct ReinhardSettings
 {
   float mid_grey_value;
@@ -81,15 +78,13 @@ ReinhardSettings DefaultReinhardSettings()
   return settings;
 }
 
-
-
+// TODO: align with other tonemappers mode and add call to Tonemap.hlsl
 float3 ReinhardTonemap(float3 color, float peak_nits, float diffuse_nits, ReinhardSettings settings)   {
 
     // this equation should also involve reference white 
     float peak = (peak_nits / diffuse_nits); 
 
     if (settings.by_luminance)  {
-
       float y = GetLuminance(color, CS_BT709);
       float peak = (peak_nits / diffuse_nits); 
 
@@ -106,9 +101,7 @@ float3 ReinhardTonemap(float3 color, float peak_nits, float diffuse_nits, Reinha
       float3 color_output = color * (y > 0 ? (y_new / y) : 0);
 
       return color_output;
-
     } else {
-      
       float3 color_output = color;
       
       float3 signs = sign(color);
@@ -127,6 +120,4 @@ float3 ReinhardTonemap(float3 color, float peak_nits, float diffuse_nits, Reinha
 
       return color_output;
     };
-
 }
-

--- a/Shaders/Includes/Tonemap.hlsl
+++ b/Shaders/Includes/Tonemap.hlsl
@@ -94,7 +94,7 @@ float3 Tonemap_ACES(float3 color, float peakWhite, float paperWhite = 1.0)
 	return ACESTonemap(color, paperWhite, peakWhite, settings);
 }
 
-
+// From RenoDX, by ShortFuse
 float3 UpgradeToneMap(
     float3 color_untonemapped,
     float3 color_tonemapped,
@@ -103,9 +103,9 @@ float3 UpgradeToneMap(
     float auto_correction = 0.f) {
   float ratio = 1.f;
 
-  float y_untonemapped = GetLuminance(abs(color_untonemapped), CS_BT709);
-  float y_tonemapped = GetLuminance(abs(color_tonemapped), CS_BT709);
-  float y_tonemapped_graded = GetLuminance(abs(color_tonemapped_graded), CS_BT709);
+  float y_untonemapped = GetLuminance(color_untonemapped, CS_BT709);
+  float y_tonemapped = GetLuminance(color_tonemapped, CS_BT709);
+  float y_tonemapped_graded = GetLuminance(color_tonemapped_graded, CS_BT709);
 
   if (y_untonemapped < y_tonemapped) {
     // If substracting (user contrast or paperwhite) scale down instead
@@ -127,6 +127,5 @@ float3 UpgradeToneMap(
   color_scaled = RestoreHue(color_scaled, color_tonemapped_graded, 1.f, false, CS_BT709);
   return lerp(color_untonemapped, color_scaled, post_process_strength);
 }
-
 
 #endif // SRC_TONEMAP_HLSL

--- a/Shaders/Includes/Tonemap.hlsl
+++ b/Shaders/Includes/Tonemap.hlsl
@@ -4,6 +4,7 @@
 #include "Common.hlsl"
 #include "ACES.hlsl"
 #include "DICE.hlsl"
+#include "ColorGradingLUT.hlsl"
 
 static const float HableShoulderScale = 4.0;
 static const float HableLinearScale = 1.0;
@@ -92,5 +93,40 @@ float3 Tonemap_ACES(float3 color, float peakWhite, float paperWhite = 1.0)
 	ACESSettings settings = DefaultACESSettings();
 	return ACESTonemap(color, paperWhite, peakWhite, settings);
 }
+
+
+float3 UpgradeToneMap(
+    float3 color_untonemapped,
+    float3 color_tonemapped,
+    float3 color_tonemapped_graded,
+    float post_process_strength = 1.f,
+    float auto_correction = 0.f) {
+  float ratio = 1.f;
+
+  float y_untonemapped = GetLuminance(abs(color_untonemapped), CS_BT709);
+  float y_tonemapped = GetLuminance(abs(color_tonemapped), CS_BT709);
+  float y_tonemapped_graded = GetLuminance(abs(color_tonemapped_graded), CS_BT709);
+
+  if (y_untonemapped < y_tonemapped) {
+    // If substracting (user contrast or paperwhite) scale down instead
+    // Should only apply on mismatched HDR
+    ratio = y_untonemapped / y_tonemapped;
+  } else {
+    float y_delta = y_untonemapped - y_tonemapped;
+    y_delta = max(0, y_delta);  // Cleans up NaN
+    const float y_new = y_tonemapped_graded + y_delta;
+
+    const bool y_valid = (y_tonemapped_graded > 0);  // Cleans up NaN and ignore black
+    ratio = y_valid ? (y_new / y_tonemapped_graded) : 0;
+  }
+  float auto_correct_ratio = lerp(1.f, ratio, saturate(y_untonemapped));
+  ratio = lerp(ratio, auto_correct_ratio, auto_correction);
+
+  float3 color_scaled = color_tonemapped_graded * ratio;
+  // Match hue
+  color_scaled = RestoreHue(color_scaled, color_tonemapped_graded, 1.f, false, CS_BT709);
+  return lerp(color_untonemapped, color_scaled, post_process_strength);
+}
+
 
 #endif // SRC_TONEMAP_HLSL


### PR DESCRIPTION
Added Reinhard Tonemapper & UpgradeToneMap function. This is a simple port from renodx renodrt.hlsl, without color grading functions (Contrast, Exposure, Highlights etc). 

The hue correction in UpgradeToneMap is done by the RestoreHue function in ColorGradingLUT.

Tested in Final Fantasy XV. 