### PR TITLE
Initial commit for Final Fantasy XV

### DIFF
--- a/Luma.sln
+++ b/Luma.sln
@@ -41,6 +41,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Thumper", "Source\Games\Thu
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Burnout Paradise", "Source\Games\Burnout Paradise\Burnout Paradise.vcxproj", "{5671B4DE-DD84-4FCC-890F-D5B7F5437E42}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Final Fantasy XV", "Source\Games\Final Fantasy XV\FFXV.vcxproj", "{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Development-Debug|Win32 = Development-Debug|Win32
@@ -289,6 +291,22 @@ Global
 		{5671B4DE-DD84-4FCC-890F-D5B7F5437E42}.Test-Release|Win32.ActiveCfg = Test-Release|Win32
 		{5671B4DE-DD84-4FCC-890F-D5B7F5437E42}.Test-Release|Win32.Build.0 = Test-Release|Win32
 		{5671B4DE-DD84-4FCC-890F-D5B7F5437E42}.Test-Release|x64.ActiveCfg = Test-Release|Win32
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Debug|Win32.ActiveCfg = Development-Debug|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Debug|Win32.Build.0 = Development-Debug|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Debug|x64.ActiveCfg = Development-Debug|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Debug|x64.Build.0 = Development-Debug|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Release|Win32.ActiveCfg = Development-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Release|Win32.Build.0 = Development-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Release|x64.ActiveCfg = Development-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Development-Release|x64.Build.0 = Development-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Publishing-Release|Win32.ActiveCfg = Publishing-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Publishing-Release|Win32.Build.0 = Publishing-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Publishing-Release|x64.ActiveCfg = Publishing-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Publishing-Release|x64.Build.0 = Publishing-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Test-Release|Win32.ActiveCfg = Test-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Test-Release|Win32.Build.0 = Test-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Test-Release|x64.ActiveCfg = Test-Release|x64
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}.Test-Release|x64.Build.0 = Test-Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -310,6 +328,7 @@ Global
 		{08143144-3ABB-D7B3-815C-7B798924E8E6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{3C99EF50-7B5C-475C-9E13-F451F0D7A3A1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{5671B4DE-DD84-4FCC-890F-D5B7F5437E42} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B799422-BA66-3174-B21F-B9FA07C4B2E3}

--- a/Shaders/Final Fantasy XV/common.hlsl
+++ b/Shaders/Final Fantasy XV/common.hlsl
@@ -1,0 +1,151 @@
+#include "../Includes/Color.hlsl"
+#include "../Includes/ColorGradingLUT.hlsl"
+#include "../Includes/Oklab.hlsl"
+#include "../Includes/Reinhard.hlsl"
+#include "../Includes/Tonemap.hlsl"
+
+
+float3 CorrectHuePolar(float3 incorrectOkLCH, float3 correctOkLCH, float strength) {
+  // skip adjustment for achromatic colors
+  const float chromaThreshold = 1e-5;
+  float iChroma = incorrectOkLCH.y;
+  float cChroma = correctOkLCH.y;
+
+  if (iChroma < chromaThreshold || cChroma < chromaThreshold) {
+    return incorrectOkLCH;
+  }
+
+  // hues in radians
+  float iHue = incorrectOkLCH.z;
+  float cHue = correctOkLCH.z;
+
+  // calculate shortest angular difference
+  float diff = cHue - iHue;
+  if (diff > PI) diff -= PI_X2;
+  else if (diff < -PI) diff += PI_X2;
+
+  // apply strength-based correction
+  float newHue = iHue + strength * diff;
+
+  float3 adjustedOkLCH = float3(
+      incorrectOkLCH.x,
+      incorrectOkLCH.y,
+      newHue
+  );
+
+  return adjustedOkLCH;
+}
+
+
+#define CUSTOM_TONEMAP_UPGRADE_HUECORR 1.0f
+#define CUSTOM_TONEMAP_UPGRADE_STRENGTH 0.4f
+
+
+float UpgradeToneMapRatio(float color_hdr, float color_sdr, float post_process_color) {
+  if (color_hdr < color_sdr) {
+    // If substracting (user contrast or paperwhite) scale down instead
+    // Should only apply on mismatched HDR
+    return color_hdr / color_sdr;
+  } else {
+    float delta = color_hdr - color_sdr;
+    delta = max(0, delta);  // Cleans up NaN
+    const float new_value = post_process_color + delta;
+
+    const bool valid = (post_process_color > 0);  // Cleans up NaN and ignore black
+    return valid ? (new_value / post_process_color) : 0;
+  }
+}
+
+
+float3 UpgradeToneMapPerChannel(float3 color_hdr, float3 color_sdr, float3 post_process_color, float post_process_strength) {
+  // float ratio = 1.f;
+
+  float3 bt2020_hdr = max(0, BT709_To_BT2020(color_hdr));
+  float3 bt2020_sdr = max(0, BT709_To_BT2020(color_sdr));
+  float3 bt2020_post_process = max(0, BT709_To_BT2020(post_process_color));
+
+  float3 ratio = float3(
+      UpgradeToneMapRatio(bt2020_hdr.r, bt2020_sdr.r, bt2020_post_process.r),
+      UpgradeToneMapRatio(bt2020_hdr.g, bt2020_sdr.g, bt2020_post_process.g),
+      UpgradeToneMapRatio(bt2020_hdr.b, bt2020_sdr.b, bt2020_post_process.b));
+
+  float3 color_scaled = max(0, bt2020_post_process * ratio);
+  color_scaled = BT2020_To_BT709(color_scaled);
+  float peak_correction = saturate(1.f - GetLuminance(bt2020_post_process, CS_BT2020));
+  color_scaled = RestoreHue(color_scaled, post_process_color, peak_correction);
+  return lerp(color_hdr, color_scaled, post_process_strength);
+}
+
+
+
+float3 CustomUpgradeToneMapPerChannel(float3 untonemapped, float3 graded) {
+  float hueCorrection = 1.f - CUSTOM_TONEMAP_UPGRADE_HUECORR;
+  float satStrength = 1.f - CUSTOM_TONEMAP_UPGRADE_STRENGTH;
+
+  ReinhardSettings settings = DefaultReinhardSettings();
+  settings.by_luminance = true;
+
+  float3 upgradedPerCh = UpgradeToneMapPerChannel(
+      untonemapped,
+
+      // use the neutral Reinhard as the neutral SDR
+      ReinhardTonemap(untonemapped, 100.f, 100.f, settings),
+      graded,
+      1.f);
+
+  float3 upgradedPerCh_okLCH = linear_srgb_to_oklch(upgradedPerCh);
+  float3 graded_okLCH = linear_srgb_to_oklch(graded);
+
+  // heavy hue correction with graded hue
+  upgradedPerCh_okLCH = CorrectHuePolar(upgradedPerCh_okLCH, graded_okLCH, saturate(pow(graded_okLCH.y, hueCorrection)));
+
+  // desaturate highlights based on graded chrominance
+  upgradedPerCh_okLCH.y = lerp(graded_okLCH.y, upgradedPerCh_okLCH.y, saturate(pow(graded_okLCH.y, satStrength)));
+
+  upgradedPerCh = oklch_to_linear_srgb(upgradedPerCh_okLCH);
+
+  upgradedPerCh = max(-10000000000000000000000000000000000000.f, upgradedPerCh);  // bandaid for NaNs
+
+  return upgradedPerCh;
+}
+
+
+float3 NeutralSDR(float3 color)    {
+
+    ReinhardSettings settings = DefaultReinhardSettings();
+    settings.by_luminance = true;
+    return ReinhardTonemap(color, 100.f, 100.f, settings);
+}
+
+float3 ToneMapReinhard(float3 color, bool per_channel = true)    {
+
+    ReinhardSettings settings = DefaultReinhardSettings();
+    settings.by_luminance = !per_channel;
+    return ReinhardTonemap(color, LumaSettings.PeakWhiteNits, LumaSettings.GamePaperWhiteNits, settings);
+}
+
+
+
+float3 GammaCorrection(float3 color, float gamma=2.4)   {
+
+    float3 colorSign = sign(color);
+
+    return colorSign * gamma_to_linear(linear_to_sRGB_gamma(color, GCT_NONE), GCT_NONE, gamma);
+
+}
+
+
+
+float3 RestoreHighlightSaturation(float3 untonemapped)	{
+
+	float l = GetLuminance(untonemapped, CS_BT709);
+
+	DICESettings settings = DefaultDICESettings();
+	settings.Type = DICE_TYPE_BY_LUMINANCE_RGB;
+	settings.ShoulderStart = 0.f;
+	float3 displayMappedColor = DICETonemap(untonemapped, 1.0f, settings);
+
+	float3 output = lerp(untonemapped, displayMappedColor, saturate(l));
+
+	return output;
+}

--- a/Shaders/Final Fantasy XV/postprocessing_0xDD4C5B74.ps_5_0.hlsl
+++ b/Shaders/Final Fantasy XV/postprocessing_0xDD4C5B74.ps_5_0.hlsl
@@ -1,0 +1,73 @@
+// ---- Created with 3Dmigoto v1.3.16 on Sat Aug 02 01:21:35 2025
+#include "../Includes/Color.hlsl"
+#include "../Includes/Common.hlsl"
+#include "Common.hlsl"
+
+cbuffer _Globals : register(b0)
+{
+  float gamma : packoffset(c0);
+  float pqScale : packoffset(c0.y);
+}
+
+SamplerState samplerSrc0_s : register(s0);
+Texture2D<float4> samplerSrc0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = samplerSrc0Texture.Sample(samplerSrc0_s, v1.xy).xyzw;
+  // r0.xyz = max(float3(0,0,0), r0.xyz);
+  o0.w = r0.w;
+  // r1.xyz = float3(0.0549999997,0.0549999997,0.0549999997) + r0.xyz;
+  // r1.xyz = float3(0.947867334,0.947867334,0.947867334) * r1.xyz;
+  // r1.xyz = log2(r1.xyz);
+  // r1.xyz = float3(2.4000001,2.4000001,2.4000001) * r1.xyz;
+  // r1.xyz = exp2(r1.xyz);
+  // r2.xyz = cmp(float3(0.0392800011,0.0392800011,0.0392800011) >= r0.xyz);
+  // r0.xyz = float3(0.0773993805,0.0773993805,0.0773993805) * r0.xyz;
+  // r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+  r0.xyz = gamma_sRGB_to_linear(r0.xyz, GCT_POSITIVE);
+
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = gamma * r0.xyz;
+  // r0.xyz = exp2(r0.xyz);
+
+  // gamma correction instead of custom gamma
+  r0.xyz = GammaCorrection(r0.xyz, 2.4);
+  
+  // color expansion
+  r0.w = 0.587700009 * r0.y;
+  r0.w = r0.x * 1.66050005 + -r0.w;
+  r1.x = -r0.z * 0.072800003 + r0.w;
+  r0.w = 0.100599997 * r0.y;
+  r0.w = r0.x * -0.0182000007 + -r0.w;
+  r1.z = r0.z * 1.11870003 + r0.w;
+  r0.x = dot(r0.xy, float2(-0.124600001,1.13300002));
+  r1.y = -r0.z * 0.0083999997 + r0.x;
+
+  r1.rgb = BT709_To_BT2020(r1.rgb);
+  r1.rgb = max(0.f, r1.rgb);
+  r1.rgb = BT2020_To_BT709(r1.rgb);
+
+  // r1.rgb = max(r1.rgb, 0.f)
+
+  // o0.xyz = pqScale * r1.xyz;
+
+  // scale with game nits
+
+  o0.rgb = r1.rgb * 203.f / 80.f;
+  // o0.rgb = r1.rgb;
+
+  return;
+}

--- a/Shaders/Final Fantasy XV/tonemap2_0x18EF8C72.ps_5_0.hlsl
+++ b/Shaders/Final Fantasy XV/tonemap2_0x18EF8C72.ps_5_0.hlsl
@@ -1,0 +1,318 @@
+// ---- Created with 3Dmigoto v1.3.16 on Sat Aug 02 01:21:12 2025
+#include "../Includes/Common.hlsl"
+#include "../Includes/Color.hlsl"
+#include "../Includes/Tonemap.hlsl"
+#include "./common.hlsl"
+
+cbuffer COLOR_FILTER_PARMS : register(b0)
+{
+  float WhiteX : packoffset(c0);
+  float WhiteY : packoffset(c0.y);
+  float WhiteZ : packoffset(c0.z);
+  float HighRange : packoffset(c0.w);
+  float TenPowLogHighRangePlusContrastMinusOne : packoffset(c1);
+  float TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse : packoffset(c1.y);
+  float ZeroSlopeByTenPowDispositionPlusOne : packoffset(c1.z);
+  float Param_n37 : packoffset(c1.w);
+  float Param_n46 : packoffset(c2);
+  float Param_n49 : packoffset(c2.y);
+  float rotM : packoffset(c2.z);
+  float rotY : packoffset(c2.w);
+  float rotG : packoffset(c3);
+  float rotB : packoffset(c3.y);
+  float sAllsMExp2 : packoffset(c3.z);
+  float sAllsYExp2 : packoffset(c3.w);
+  float sAllsGExp2 : packoffset(c4);
+  float sAllsBExp2 : packoffset(c4.y);
+  float scAllscM : packoffset(c4.z);
+  float scAllscY : packoffset(c4.w);
+  float scAllscG : packoffset(c5);
+  float scAllscB : packoffset(c5.y);
+  float sM0Final : packoffset(c5.z);
+  float sM1Final : packoffset(c5.w);
+  float sM2Final : packoffset(c6);
+  float sM3Final : packoffset(c6.y);
+  float sM4Final : packoffset(c6.z);
+  float sY0Final : packoffset(c6.w);
+  float sY1Final : packoffset(c7);
+  float sY2Final : packoffset(c7.y);
+  float sY3Final : packoffset(c7.z);
+  float sY4Final : packoffset(c7.w);
+  float sG0Final : packoffset(c8);
+  float sG1Final : packoffset(c8.y);
+  float sG2Final : packoffset(c8.z);
+  float sG3Final : packoffset(c8.w);
+  float sG4Final : packoffset(c9);
+  float sB0Final : packoffset(c9.y);
+  float sB1Final : packoffset(c9.z);
+  float sB2Final : packoffset(c9.w);
+  float sB3Final : packoffset(c10);
+  float sB4Final : packoffset(c10.y);
+  bool CAT : packoffset(c10.z);
+  bool HDR : packoffset(c10.w);
+  bool Gamma : packoffset(c11);
+  bool Dither : packoffset(c11.y);
+  bool EnabledToneCurve : packoffset(c11.z);
+  bool EnabledHue : packoffset(c11.w);
+  bool EnabledSaturationALL : packoffset(c12);
+  bool EnabledSaturation : packoffset(c12.y);
+  bool EnabledSaturationClamp : packoffset(c12.z);
+  bool EnabledSaturationByKido : packoffset(c12.w);
+  bool EnabledTemporalAACheckerboard : packoffset(c13);
+  float HDRGamutRatio : packoffset(c13.y);
+  float ToneCurveInterpolation : packoffset(c13.z);
+}
+
+SamplerState g_sSampler_s : register(s0);
+Texture2D<float4> g_tTex : register(t0);
+
+
+float3 toneMapLogContrast(float3 color)  {
+  float4 r0, r1;
+  r0.rgb = color;
+
+  r1.x = dot(r0.xyz, float3(0.542472005,0.439283997,0.0182429999));
+  r1.y = dot(r0.xyz, float3(0.0426700003,0.941115022,0.0162140001));
+  r1.z = dot(r0.xyz, float3(0.0173160005, 0.0949679986, 0.887715995));
+  r0.xyz = float3(WhiteX, WhiteY, WhiteZ) * r1.xyz;
+  r1.x = dot(r0.xyz, float3(0.720840991,0.267010987,0.0121480003));
+  r1.y = dot(r0.xyz, float3(0.0496839993,0.943306983,0.00700900005));
+  r1.z = dot(r0.xyz, float3(0.00642100023,0.0243079998,0.969271004));
+  r0.xyz = r1.xyz * float3(39.8107185,39.8107185,39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  r0.xyz = float3(0.693147182,0.693147182,0.693147182) * r0.xyz;
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = Param_n37 * r0.xyz;
+  r0.xyz = exp2(r0.xyz);
+  // r0.xyz = renodx::math::SignPow(r0.xyz, Param_n37);
+  
+  r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1,1,1);
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = Param_n46 * r0.xyz;
+  r0.xyz = r0.xyz * float3(0.693147182,0.693147182,0.693147182) + -Param_n49;
+  r0.xyz = max(float3(0, 0, 0), r0.xyz);
+  r0.xyz = EnabledToneCurve ? r0.xyz : r1.xyz;
+
+  return r0.xyz;
+
+}
+
+
+float3 colorGrade(float3 ungraded) {
+  float4 r0, r1, r2, r3, r4, r5;
+  r0.rgb = ungraded;
+
+  r1.x = dot(r0.xyz, float3(1.41498101, -0.400139987, -0.0148409996));
+  r1.y = dot(r0.xyz, float3(-0.0744709969, 1.081357, -0.00688599981));
+  r1.z = dot(r0.xyz, float3(-0.00750700012, -0.0244679991, 1.03197396));
+  r0.x = dot(r1.xyz, float3(0.343300015, 0.593299985, 0.0634000003));
+  r2.y = dot(r1.xyz, float3(0.40959999, -0.453200012, 0.0436000004));
+  r2.z = dot(r1.xyz, float3(0.286799997, 0.211300001, -0.498100013));
+  r2.xw = -r2.yz;
+  r1.xyzw = max(float4(0, 0, 0, 0), r2.yzxw);
+  // r1.zw = sAllsGExp2 * r1.zw;
+  r1.zw = float2(sAllsGExp2, sAllsBExp2) * r1.zw;
+  // r0.yz = r1.xy * sAllsMExp2 + -r1.zw;
+  r0.yz = r1.xy * float2(sAllsMExp2, sAllsYExp2) + -r1.zw;
+  r2.x = r0.x;
+  r0.xyz = EnabledSaturation ? r0.xyz : r2.xyz;
+  r1.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  // r2.xy = scAllscM;
+  r2.xy = float2(scAllscM, scAllscM); 
+  r2.zw = float2(scAllscG, scAllscB);
+  r3.xyzw = r2.xyzw + r1.xyzw;
+  r1.xyzw = r1.xyzw / r3.xyzw;
+  r1.zw = r1.zw * r2.zw;
+  r1.yz = r1.xy * r2.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+
+  // float peak = 1.0f;
+  float peak = LumaSettings.PeakWhiteNits / LumaSettings.GamePaperWhiteNits;
+  r1.xyzw = max(float4(0, 0.0199999996, 0.180000007, 0.5), r0.xxxx);
+  r1.xyzw = min(float4(0.0199999996, 0.180000007, 0.5, peak), r1.xyzw);
+  r1.xyzw = float4(-0, -0.0199999996, -0.180000007, -0.5) + r1.xyzw;
+  r2.x = sM2Final * r1.y;
+  r2.y = sY2Final * r1.y;
+  r2.z = sG2Final * r1.y;
+  r2.w = sB2Final * r1.y;
+  r3.x = sM3Final * r1.z;
+  r3.y = sY3Final * r1.z;
+  r3.z = sG3Final * r1.z;
+  r3.w = sB3Final * r1.z;
+  r4.x = sM4Final * r1.w;
+  r4.y = sY4Final * r1.w;
+  r4.z = sG4Final * r1.w;
+  r4.w = sB4Final * r1.w;
+  r5.x = r1.x * sM1Final + sM0Final;
+  r5.y = r1.x * sY1Final + sY0Final;
+  r5.z = r1.x * sG1Final + sG0Final;
+  r5.w = r1.x * sB1Final + sB0Final;
+  r1.xyzw = r5.xyzw + r2.xyzw;
+  r1.xyzw = r1.xyzw + r3.xyzw;
+  r1.xyzw = r1.xyzw + r4.xyzw;
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  r2.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+  r2.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  r1.zw = r2.zw * r1.zw;
+  r1.yz = r2.xy * r1.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationByKido ? r1.xyz : r0.xyz;
+  
+  r1.x = dot(r0.xyz, float3(1, 1.42680001, 0.252200007));
+  r1.y = dot(r0.xyz, float3(1, -0.87379998, 0.0509000011));
+  r1.z = dot(r0.xyz, float3(1, 0.450800002, -1.84089994));
+  r0.x = dot(r1.xyz, float3(1.91424894, -0.891185999, -0.0230620001));
+  r0.y = dot(r1.xyz, float3(-0.0863080025, 1.10471201, -0.0184039995));
+  r0.z = dot(r1.xyz, float3(-0.0281070005, -0.100798003, 1.12890506));
+
+  if (HDR != 0)  {
+    // push colors a bit towards BT2020?
+    r1.xyz = float3(0.329299986, 0.919499993, 0.0879999995) * r0.yyy;
+    r1.xyz = r0.xxx * float3(0.627399981, 0.0691, 0.0164000001) + r1.xyz;
+    r1.xyz = r0.zzz * float3(0.0432999991, 0.0114000002, 0.895600021) + r1.xyz;
+    r2.xyz = -r1.xyz + r0.xyz;
+    r0.xyz = HDRGamutRatio * r2.xyz + r1.xyz;
+  }
+
+  return r0.rgb;
+}
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = g_tTex.SampleLevel(g_sSampler_s, v1.xy, 0).xyzw;
+  // r1.x = dot(r0.xyz, float3(0.542472005,0.439283997,0.0182429999));
+  // r1.y = dot(r0.xyz, float3(0.0426700003,0.941115022,0.0162140001));
+  // r1.z = dot(r0.xyz, float3(0.0173160005,0.0949679986,0.887715995));
+  // r0.xyz = WhiteX * r1.xyz;
+  // r1.x = dot(r0.xyz, float3(0.720840991,0.267010987,0.0121480003));
+  // r1.y = dot(r0.xyz, float3(0.0496839993,0.943306983,0.00700900005));
+  // r1.z = dot(r0.xyz, float3(0.00642100023,0.0243079998,0.969271004));
+  // r0.xyz = r1.xyz * float3(39.8107185,39.8107185,39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  // r0.xyz = float3(0.693147182,0.693147182,0.693147182) * r0.xyz;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = Param_n37 * r0.xyz;
+  // r0.xyz = exp2(r0.xyz);
+  // r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1,1,1);
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = Param_n46 * r0.xyz;
+  // r0.xyz = r0.xyz * float3(0.693147182,0.693147182,0.693147182) + -Param_n49;
+  // r0.xyz = max(float3(0,0,0), r0.xyz);
+  // r0.xyz = Gamma ? r0.xyz : r1.xyz;
+
+  float3 untonemapped = r0.xyz;
+
+  r0.xyz = toneMapLogContrast(r0.xyz);
+
+  // r1.x = dot(r0.xyz, float3(1.41498101,-0.400139987,-0.0148409996));
+  // r1.y = dot(r0.xyz, float3(-0.0744709969,1.081357,-0.00688599981));
+  // r1.z = dot(r0.xyz, float3(-0.00750700012,-0.0244679991,1.03197396));
+  // r0.x = dot(r1.xyz, float3(0.343300015,0.593299985,0.0634000003));
+  // r2.y = dot(r1.xyz, float3(0.40959999,-0.453200012,0.0436000004));
+  // r2.z = dot(r1.xyz, float3(0.286799997,0.211300001,-0.498100013));
+  // r2.xw = -r2.yz;
+  // r1.xyzw = max(float4(0,0,0,0), r2.yzxw);
+  // r1.zw = sAllsGExp2 * r1.zw;
+  // r0.yz = r1.xy * sAllsMExp2 + -r1.zw;
+  // r2.x = r0.x;
+  // r0.xyz = EnabledSaturationALL ? r0.xyz : r2.xyz;
+  // r1.xyzw = float4(1,1,-1,-1) * r0.yzyz;
+  // r1.xyzw = max(float4(0,0,0,0), r1.xyzw);
+  // r2.xy = scAllscM;
+  // r2.zw = scAllscG;
+  // r3.xyzw = r2.xyzw + r1.xyzw;
+  // r1.xyzw = r1.xyzw / r3.xyzw;
+  // r1.zw = r1.zw * r2.zw;
+  // r1.yz = r1.xy * r2.xy + -r1.zw;
+  // r1.x = r0.x;
+  // r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+  // r1.xyzw = max(float4(0,0.0199999996,0.180000007,0.5), r0.xxxx);
+  // r1.xyzw = min(float4(0.0199999996,0.180000007,0.5,1), r1.xyzw);
+  // r1.xyzw = float4(-0,-0.0199999996,-0.180000007,-0.5) + r1.xyzw;
+  // r2.x = sM2Final * r1.y;
+  // r2.y = sY2Final * r1.y;
+  // r2.z = sG2Final * r1.y;
+  // r2.w = sB2Final * r1.y;
+  // r3.x = sM3Final * r1.z;
+  // r3.y = sY3Final * r1.z;
+  // r3.z = sG3Final * r1.z;
+  // r3.w = sB3Final * r1.z;
+  // r4.x = sM4Final * r1.w;
+  // r4.y = sY4Final * r1.w;
+  // r4.z = sG4Final * r1.w;
+  // r4.w = sB4Final * r1.w;
+  // r5.x = r1.x * sM1Final + sM0Final;
+  // r5.y = r1.x * sY1Final + sY0Final;
+  // r5.z = r1.x * sG1Final + sG0Final;
+  // r5.w = r1.x * sB1Final + sB0Final;
+  // r1.xyzw = r5.xyzw + r2.xyzw;
+  // r1.xyzw = r1.xyzw + r3.xyzw;
+  // r1.xyzw = r1.xyzw + r4.xyzw;
+  // r1.xyzw = max(float4(0,0,0,0), r1.xyzw);
+  // r2.xyzw = float4(1,1,-1,-1) * r0.yzyz;
+  // r2.xyzw = max(float4(0,0,0,0), r2.xyzw);
+  // r1.zw = r2.zw * r1.zw;
+  // r1.yz = r2.xy * r1.xy + -r1.zw;
+  // r1.x = r0.x;
+  // r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+  // r1.x = dot(r0.xyz, float3(1,1.42680001,0.252200007));
+  // r1.y = dot(r0.xyz, float3(1,-0.87379998,0.0509000011));
+  // r1.z = dot(r0.xyz, float3(1,0.450800002,-1.84089994));
+  // r0.x = dot(r1.xyz, float3(1.91424894,-0.891185999,-0.0230620001));
+  // r0.y = dot(r1.xyz, float3(-0.0863080025,1.10471201,-0.0184039995));
+  // r0.z = dot(r1.xyz, float3(-0.0281070005,-0.100798003,1.12890506));
+  // if (HDR != 0) {
+  //   r1.xyz = float3(0.329299986,0.919499993,0.0879999995) * r0.yyy;
+  //   r1.xyz = r0.xxx * float3(0.627399981,0.0691,0.0164000001) + r1.xyz;
+  //   r1.xyz = r0.zzz * float3(0.0432999991,0.0114000002,0.895600021) + r1.xyz;
+  //   r2.xyz = -r1.xyz + r0.xyz;
+  //   r0.xyz = EnabledTemporalAACheckerboard * r2.xyz + r1.xyz;
+  // }
+
+  float3 ungraded_sdr = r0.rgb;
+  float3 neutral_sdr = NeutralSDR(untonemapped);
+  float3 ungraded_untonemapped = UpgradeToneMap(untonemapped, neutral_sdr, ungraded_sdr);
+  float3 ungraded_hdr = ToneMapReinhard(ungraded_untonemapped);
+
+  float3 graded_hdr = colorGrade(ungraded_hdr);
+  float3 graded_sdr = colorGrade(ungraded_sdr);
+
+  graded_sdr = max(graded_sdr, 0.f);
+
+  graded_hdr = RestoreHue(graded_hdr, graded_sdr, 1.0f, false, CS_BT709);
+
+  r0.rgb = graded_hdr * LumaSettings.GamePaperWhiteNits / LumaSettings.UIPaperWhiteNits;
+
+
+  // r0.xyz = max(float3(0,0,0), r0.xyz);
+  // r1.xyz = cmp(float3(0.00313080009,0.00313080009,0.00313080009) >= r0.xyz);
+  // r2.xyz = float3(12.9200001,12.9200001,12.9200001) * r0.xyz;
+  // r3.xyz = log2(r0.xyz);
+  // r3.xyz = float3(0.416666657,0.416666657,0.416666657) * r3.xyz;
+  // r3.xyz = exp2(r3.xyz);
+  // r3.xyz = r3.xyz * float3(1.05499995,1.05499995,1.05499995) + float3(-0.0549999997,-0.0549999997,-0.0549999997);
+  // r1.xyz = r1.xyz ? r2.xyz : r3.xyz;
+  // o0.xyz = Gamma ? r1.xyz : r0.xyz;
+
+  o0.xyz = Gamma ? linear_to_sRGB_gamma(r0.rgb, GCT_MIRROR) : r0.xyz;
+
+  o0.w = r0.w;
+  return;
+}

--- a/Shaders/Final Fantasy XV/tonemap_0x75DFE4B0.ps_5_0.hlsl
+++ b/Shaders/Final Fantasy XV/tonemap_0x75DFE4B0.ps_5_0.hlsl
@@ -1,0 +1,371 @@
+// ---- Created with 3Dmigoto v1.3.16 on Sat Aug 02 01:21:22 2025
+#include "../Includes/Common.hlsl"
+#include "../Includes/Color.hlsl"
+#include "../Includes/Tonemap.hlsl"
+#include "./common.hlsl"
+
+// LumaSettings
+
+cbuffer COLOR_FILTER_PARMS : register(b0)
+{
+  float WhiteX : packoffset(c0);
+  float WhiteY : packoffset(c0.y);
+  float WhiteZ : packoffset(c0.z);
+  float HighRange : packoffset(c0.w);
+  float TenPowLogHighRangePlusContrastMinusOne : packoffset(c1);
+  float TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse : packoffset(c1.y);
+  float ZeroSlopeByTenPowDispositionPlusOne : packoffset(c1.z);
+  float Param_n37 : packoffset(c1.w);
+  float Param_n46 : packoffset(c2);
+  float Param_n49 : packoffset(c2.y);
+  float rotM : packoffset(c2.z);
+  float rotY : packoffset(c2.w);
+  float rotG : packoffset(c3);
+  float rotB : packoffset(c3.y);
+  float sAllsMExp2 : packoffset(c3.z);
+  float sAllsYExp2 : packoffset(c3.w);
+  float sAllsGExp2 : packoffset(c4);
+  float sAllsBExp2 : packoffset(c4.y);
+  float scAllscM : packoffset(c4.z);
+  float scAllscY : packoffset(c4.w);
+  float scAllscG : packoffset(c5);
+  float scAllscB : packoffset(c5.y);
+  float sM0Final : packoffset(c5.z);
+  float sM1Final : packoffset(c5.w);
+  float sM2Final : packoffset(c6);
+  float sM3Final : packoffset(c6.y);
+  float sM4Final : packoffset(c6.z);
+  float sY0Final : packoffset(c6.w);
+  float sY1Final : packoffset(c7);
+  float sY2Final : packoffset(c7.y);
+  float sY3Final : packoffset(c7.z);
+  float sY4Final : packoffset(c7.w);
+  float sG0Final : packoffset(c8);
+  float sG1Final : packoffset(c8.y);
+  float sG2Final : packoffset(c8.z);
+  float sG3Final : packoffset(c8.w);
+  float sG4Final : packoffset(c9);
+  float sB0Final : packoffset(c9.y);
+  float sB1Final : packoffset(c9.z);
+  float sB2Final : packoffset(c9.w);
+  float sB3Final : packoffset(c10);
+  float sB4Final : packoffset(c10.y);
+  bool CAT : packoffset(c10.z);
+  bool HDR : packoffset(c10.w);
+  bool Gamma : packoffset(c11);
+  bool Dither : packoffset(c11.y);
+  bool EnabledToneCurve : packoffset(c11.z);
+  bool EnabledHue : packoffset(c11.w);
+  bool EnabledSaturationALL : packoffset(c12);
+  bool EnabledSaturation : packoffset(c12.y);
+  bool EnabledSaturationClamp : packoffset(c12.z);
+  bool EnabledSaturationByKido : packoffset(c12.w);
+  bool EnabledTemporalAACheckerboard : packoffset(c13);
+  float HDRGamutRatio : packoffset(c13.y);
+  float ToneCurveInterpolation : packoffset(c13.z);
+}
+
+SamplerState g_sSampler_s : register(s0);
+Texture2D<float4> g_tTex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+float3 toneMapLogContrast(float3 color)  {
+  float4 r0, r1;
+  r0.rgb = color;
+
+  r1.x = dot(r0.xyz, float3(0.542472005, 0.439283997, 0.0182429999));
+  r1.y = dot(r0.xyz, float3(0.0426700003, 0.941115022, 0.0162140001));
+  r1.z = dot(r0.xyz, float3(0.0173160005, 0.0949679986, 0.887715995));
+  r0.xyz = float3(WhiteX, WhiteY, WhiteZ) * r1.xyz;
+
+  r1.x = dot(r0.xyz, float3(0.720840991, 0.267010987, 0.0121480003));
+  r1.y = dot(r0.xyz, float3(0.0496839993, 0.943306983, 0.00700900005));
+  r1.z = dot(r0.xyz, float3(0.00642100023, 0.0243079998, 0.969271004));
+  r0.xyz = r1.xyz * float3(39.8107185, 39.8107185, 39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+
+  // ln(color) * constant
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  r0.xyz = float3(0.693147182, 0.693147182, 0.693147182) * r0.xyz;
+
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = Param_n37 * r0.xyz;
+  r0.xyz = exp2(r0.xyz);
+
+  r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1, 1, 1);
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = Param_n46 * r0.xyz;
+  r0.xyz = r0.xyz * float3(0.693147182, 0.693147182, 0.693147182) + -Param_n49;
+  r0.xyz = max(float3(0, 0, 0), r0.xyz);
+  r0.xyz = EnabledToneCurve ? r0.xyz : r1.xyz;
+
+  return r0.rgb;
+}
+
+
+float3 colorGrade(float3 color) {
+  float4 r0, r1, r2, r3, r4, r5;
+  float4 signs;
+  r0.rgb = color;
+
+
+  r1.x = dot(r0.xyz, float3(1.41498101, -0.400139987, -0.0148409996));
+  r1.y = dot(r0.xyz, float3(-0.0744709969, 1.081357, -0.00688599981));
+  r1.z = dot(r0.xyz, float3(-0.00750700012, -0.0244679991, 1.03197396));
+
+  r0.x = dot(r1.xyz, float3(0.343300015, 0.593299985, 0.0634000003)); // luminance
+  r2.x = dot(r1.xyz, float3(0.40959999, -0.453200012, 0.0436000004)); // magenta (red + blue) vs green
+  r2.y = dot(r1.xyz, float3(0.286799997, 0.211300001, -0.498100013)); // yellow (red + green) vs blue
+  r2.zw = -r2.xy;
+
+  r1.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  
+  // r1.x = magenta
+  // r1.y = yellow
+  // r1.z = green
+  // r1.w = blue
+
+  r1.zw = float2(rotG, rotB) * r1.zw;  // scale green and blue
+  r1.xy = r1.xy * float2(rotM, rotY) + -r1.zw; // scale magenta/yellow and blend back
+  r1.z = -r1.y; // r1.z = blue vs yellow
+  r1.yz = r2.xy + r1.zx; 
+  // magenta vs green - blue vs yellow
+  // yellow vs blue + magenta vs green
+  r1.xw = -r1.yz;
+
+  r2.xyzw = max(float4(0, 0, 0, 0), r1.yzxw);
+  r2.zw *= float2(sAllsGExp2, sAllsBExp2);
+  r0.yz = r2.xy * float2(sAllsMExp2, sAllsYExp2) + -r2.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturation ? r0.xyz : r1.xyz;
+
+  r1.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  r2.xy = float2(scAllscM, scAllscM);
+  r2.zw = float2(scAllscG, scAllscB);
+  r3.xyzw = r2.xyzw + r1.xyzw;
+  r1.xyzw = r1.xyzw / r3.xyzw;
+  r1.zw = r1.zw * r2.zw;
+  r1.yz = r1.xy * r2.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+
+  // spline design
+  float peak = LumaSettings.PeakWhiteNits / LumaSettings.GamePaperWhiteNits;
+  // if (RENODX_TONE_MAP_TYPE > 1.f)
+  //   peak = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
+  r1.xyzw = max(float4(0, 0.0199999996, 0.180000007, 0.5), r0.xxxx);
+  r1.xyzw = min(float4(0.0199999996, 0.180000007, 0.5, peak), r1.xyzw);
+
+  // four bins
+  // [0, 0.02]
+  // [0.02, 0.18]
+  // [0.18, 0.5]
+  // [0.5, 1]
+  r1.xyzw = float4(-0, -0.0199999996, -0.180000007, -0.5) + r1.xyzw;
+
+  // scale the last band for HDR. From 1.0 we might use PQ-scale instead of linear to avoid oversaturation
+  // float lum = r0.x;
+  // float pq = PQEncode(lum * RENODX_DIFFUSE_WHITE_NITS, 10000.f);
+  // float pq_one = PQEncode(1.0f * RENODX_DIFFUSE_WHITE_NITS, 10000.f);
+  // float pq_peak = PQEncode(RENODX_PEAK_WHITE_NITS, 10000.f);
+  // r1.w = 1.0f + (pq - pq_one) / (pq_peak - pq_one) ;
+    // weight4 = saturate((lum - 0.5f) / 0.5f);  // original behavior
+  // scale them back to zero
+
+  r2.x = sM2Final * r1.y;
+  r2.y = sY2Final * r1.y;
+  r2.z = sG2Final * r1.y;
+  r2.w = sB2Final * r1.y;
+  r3.x = sM3Final * r1.z;
+  r3.y = sY3Final * r1.z;
+  r3.z = sG3Final * r1.z;
+  r3.w = sB3Final * r1.z;
+  r4.x = sM4Final * r1.w;
+  r4.y = sY4Final * r1.w;
+  r4.z = sG4Final * r1.w;
+  r4.w = sB4Final * r1.w;
+  r5.x = r1.x * sM1Final + sM0Final;
+  r5.y = r1.x * sY1Final + sY0Final;
+  r5.z = r1.x * sG1Final + sG0Final;
+  r5.w = r1.x * sB1Final + sB0Final;
+  r1.xyzw = r5.xyzw + r2.xyzw;
+  r1.xyzw = r1.xyzw + r3.xyzw;
+  r1.xyzw = r1.xyzw + r4.xyzw;
+
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  r2.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+  r2.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  r1.zw = r2.zw * r1.zw;
+  r1.yz = r2.xy * r1.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationByKido ? r1.xyz : r0.xyz;
+
+  r1.x = dot(r0.xyz, float3(1, 1.42680001, 0.252200007));
+  r1.y = dot(r0.xyz, float3(1, -0.87379998, 0.0509000011));
+  r1.z = dot(r0.xyz, float3(1, 0.450800002, -1.84089994));
+
+  r0.x = dot(r1.xyz, float3(1.91424894, -0.891185999, -0.0230620001)); // Luminace 
+  r0.y = dot(r1.xyz, float3(-0.0863080025, 1.10471201, -0.0184039995)); // A
+  r0.z = dot(r1.xyz, float3(-0.0281070005, -0.100798003, 1.12890506));  // B
+
+  if (HDR != 0) {
+      // push colors a bit towards BT2020?
+      r1.xyz = float3(0.329299986, 0.919499993, 0.0879999995) * r0.yyy;
+      r1.xyz = r0.xxx * float3(0.627399981, 0.0691, 0.0164000001) + r1.xyz;
+      r1.xyz = r0.zzz * float3(0.0432999991, 0.0114000002, 0.895600021) + r1.xyz;
+      r2.xyz = -r1.xyz + r0.xyz;
+      r0.xyz = HDRGamutRatio * r2.xyz + r1.xyz;
+    }
+
+  r0.rgb = BT709_To_BT2020(r0.rgb);
+  r0.rgb = max(0.f, r0.rgb);
+  r0.rgb = BT2020_To_BT709(r0.rgb);
+
+  return r0.rgb;
+}
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = g_tTex.SampleLevel(g_sSampler_s, v1.xy, 0).xyzw;
+  // r1.x = dot(r0.xyz, float3(0.542472005,0.439283997,0.0182429999));
+  // r1.y = dot(r0.xyz, float3(0.0426700003,0.941115022,0.0162140001));
+  // r1.z = dot(r0.xyz, float3(0.0173160005,0.0949679986,0.887715995));
+  // r0.xyz = WhiteX * r1.xyz;
+  // r1.x = dot(r0.xyz, float3(0.720840991,0.267010987,0.0121480003));
+  // r1.y = dot(r0.xyz, float3(0.0496839993,0.943306983,0.00700900005));
+  // r1.z = dot(r0.xyz, float3(0.00642100023,0.0243079998,0.969271004));
+  // r0.xyz = r1.xyz * float3(39.8107185,39.8107185,39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  // r0.xyz = float3(0.693147182,0.693147182,0.693147182) * r0.xyz;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = Param_n37 * r0.xyz;
+  // r0.xyz = exp2(r0.xyz);
+  // r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1,1,1);
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = Param_n46 * r0.xyz;
+  // r0.xyz = r0.xyz * float3(0.693147182,0.693147182,0.693147182) + -Param_n49;
+  // r0.xyz = max(float3(0,0,0), r0.xyz);
+  // r0.xyz = Gamma ? r0.xyz : r1.xyz;
+  float3 untonemapped = r0.xyz;
+
+  r0.xyz = toneMapLogContrast(r0.xyz);
+
+  // r1.x = dot(r0.xyz, float3(1.41498101,-0.400139987,-0.0148409996));
+  // r1.y = dot(r0.xyz, float3(-0.0744709969,1.081357,-0.00688599981));
+  // r1.z = dot(r0.xyz, float3(-0.00750700012,-0.0244679991,1.03197396));
+  // r0.x = dot(r1.xyz, float3(0.343300015,0.593299985,0.0634000003));
+  // r2.x = dot(r1.xyz, float3(0.40959999,-0.453200012,0.0436000004));
+  // r2.y = dot(r1.xyz, float3(0.286799997,0.211300001,-0.498100013));
+  // r2.zw = -r2.xy;
+  // r1.xyzw = max(float4(0,0,0,0), r2.xyzw);
+  // r1.zw = rotG * r1.zw;
+  // r1.xy = r1.xy * rotM + -r1.zw;
+  // r1.z = -r1.y;
+  // r1.yz = r2.xy + r1.zx;
+  // r1.xw = -r1.yz;
+  // r2.xyzw = max(float4(0,0,0,0), r1.yzxw);
+  // r2.zw = sAllsGExp2 * r2.zw;
+  // r0.yz = r2.xy * sAllsMExp2 + -r2.zw;
+  // r1.x = r0.x;
+  // r0.xyz = EnabledSaturationALL ? r0.xyz : r1.xyz;
+  // r1.xyzw = float4(1,1,-1,-1) * r0.yzyz;
+  // r1.xyzw = max(float4(0,0,0,0), r1.xyzw);
+  // r2.xy = scAllscM;
+  // r2.zw = scAllscG;
+  // r3.xyzw = r2.xyzw + r1.xyzw;
+  // r1.xyzw = r1.xyzw / r3.xyzw;
+  // r1.zw = r1.zw * r2.zw;
+  // r1.yz = r1.xy * r2.xy + -r1.zw;
+  // r1.x = r0.x;
+  // r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+  // r1.xyzw = max(float4(0,0.0199999996,0.180000007,0.5), r0.xxxx);
+  // r1.xyzw = min(float4(0.0199999996,0.180000007,0.5,1), r1.xyzw);
+  // r1.xyzw = float4(-0,-0.0199999996,-0.180000007,-0.5) + r1.xyzw;
+  // r2.x = sM2Final * r1.y;
+  // r2.y = sY2Final * r1.y;
+  // r2.z = sG2Final * r1.y;
+  // r2.w = sB2Final * r1.y;
+  // r3.x = sM3Final * r1.z;
+  // r3.y = sY3Final * r1.z;
+  // r3.z = sG3Final * r1.z;
+  // r3.w = sB3Final * r1.z;
+  // r4.x = sM4Final * r1.w;
+  // r4.y = sY4Final * r1.w;
+  // r4.z = sG4Final * r1.w;
+  // r4.w = sB4Final * r1.w;
+  // r5.x = r1.x * sM1Final + sM0Final;
+  // r5.y = r1.x * sY1Final + sY0Final;
+  // r5.z = r1.x * sG1Final + sG0Final;
+  // r5.w = r1.x * sB1Final + sB0Final;
+  // r1.xyzw = r5.xyzw + r2.xyzw;
+  // r1.xyzw = r1.xyzw + r3.xyzw;
+  // r1.xyzw = r1.xyzw + r4.xyzw;
+  // r1.xyzw = max(float4(0,0,0,0), r1.xyzw);
+  // r2.xyzw = float4(1,1,-1,-1) * r0.yzyz;
+  // r2.xyzw = max(float4(0,0,0,0), r2.xyzw);
+  // r1.zw = r2.zw * r1.zw;
+  // r1.yz = r2.xy * r1.xy + -r1.zw;
+  // r1.x = r0.x;
+  // r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+  // r1.x = dot(r0.xyz, float3(1,1.42680001,0.252200007));
+  // r1.y = dot(r0.xyz, float3(1,-0.87379998,0.0509000011));
+  // r1.z = dot(r0.xyz, float3(1,0.450800002,-1.84089994));
+  // r0.x = dot(r1.xyz, float3(1.91424894,-0.891185999,-0.0230620001));
+  // r0.y = dot(r1.xyz, float3(-0.0863080025,1.10471201,-0.0184039995));
+  // r0.z = dot(r1.xyz, float3(-0.0281070005,-0.100798003,1.12890506));
+  // if (HDR != 0) {
+  //   r1.xyz = float3(0.329299986,0.919499993,0.0879999995) * r0.yyy;
+  //   r1.xyz = r0.xxx * float3(0.627399981,0.0691,0.0164000001) + r1.xyz;
+  //   r1.xyz = r0.zzz * float3(0.0432999991,0.0114000002,0.895600021) + r1.xyz;
+  //   r2.xyz = -r1.xyz + r0.xyz;
+  //   r0.xyz = EnabledTemporalAACheckerboard * r2.xyz + r1.xyz;
+  // }
+  // TODO: tonemapping
+
+  float3 ungraded_sdr = r0.rgb;
+
+  float3 neutral_sdr = NeutralSDR(untonemapped);
+  float3 ungraded_untonemapped = UpgradeToneMap(untonemapped, neutral_sdr, ungraded_sdr);
+
+  // float3 ungraded_hdr = ToneMapReinhard(ungraded_untonemapped, false);
+  DICESettings settings = DefaultDICESettings();
+  settings.Type = DICE_TYPE_BY_LUMINANCE_PQ;
+	// return DICETonemap(color * paperWhite, peakWhite, settings);
+  // float3 ungraded_hdr = Tonemap_DICE(ungraded_untonemapped, LumaSettings.PeakWhiteNits / LumaSettings.GamePaperWhiteNits);
+  float3 ungraded_hdr = DICETonemap(ungraded_untonemapped, LumaSettings.PeakWhiteNits / LumaSettings.GamePaperWhiteNits, settings);
+
+  float3 graded_hdr = colorGrade(ungraded_hdr);
+  float3 graded_sdr = colorGrade(ungraded_sdr);
+  graded_sdr = max(graded_sdr, 0.f);
+
+  graded_hdr = RestoreHue(graded_hdr, graded_sdr, 1.0f, false, CS_BT709);
+
+  r0.rgb = graded_hdr * LumaSettings.GamePaperWhiteNits / LumaSettings.UIPaperWhiteNits;
+
+  // r0.xyz = max(float3(0,0,0), r0.xyz);
+  // r1.xyz = cmp(float3(0.00313080009,0.00313080009,0.00313080009) >= r0.xyz);
+  // r2.xyz = float3(12.9200001,12.9200001,12.9200001) * r0.xyz;
+  // r3.xyz = log2(r0.xyz);
+  // r3.xyz = float3(0.416666657,0.416666657,0.416666657) * r3.xyz;
+  // r3.xyz = exp2(r3.xyz);
+  // r3.xyz = r3.xyz * float3(1.05499995,1.05499995,1.05499995) + float3(-0.0549999997,-0.0549999997,-0.0549999997);
+  // r1.xyz = r1.xyz ? r2.xyz : r3.xyz;
+  o0.xyz = Gamma ? linear_to_sRGB_gamma(r0.rgb, GCT_POSITIVE) : r0.xyz;
+  o0.w = r0.w;
+  return;
+}

--- a/Source/Games/Final Fantasy XV/FFXV.vcxproj
+++ b/Source/Games/Final Fantasy XV/FFXV.vcxproj
@@ -1,0 +1,300 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Development-Debug|x64">
+      <Configuration>Development-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Release|x64">
+      <Configuration>Development-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Publishing-Release|x64">
+      <Configuration>Publishing-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Test-Release|x64">
+      <Configuration>Test-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8EF11F8D-FD8B-45E1-888E-CEEA5FFB316E}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Platform>x64</Platform>
+    <ProjectName>Final Fantasy XV</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgTriplet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">true</GenerateManifest>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>false</VcpkgEnableManifest>
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'" />
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'" Label="Vcpkg" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;..\..\External\NGX;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_DEBUG;_WINDOWS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>nvsdk_ngx_d_dbg.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\External\NGX\libs</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_FFXV_BIN_PATH%" || exit /B 0</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;..\..\External\NGX;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>nvsdk_ngx_d.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\External\NGX\libs</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_FFXV_BIN_PATH%" || exit /B 0</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;..\..\External\NGX;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;TEST=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>nvsdk_ngx_d.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\External\NGX\libs</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_FFXV_BIN_PATH%" || exit /B 0</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;..\..\External\NGX;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>nvsdk_ngx_d.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\External\NGX\libs</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_FFXV_BIN_PATH_PATH%" || exit /B 0</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="includes\cbuffers.h" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Games/Final Fantasy XV/FFXV.vcxproj
+++ b/Source/Games/Final Fantasy XV/FFXV.vcxproj
@@ -287,11 +287,10 @@
       </LinkLibraryDependencies>
     </ProjectReference>
     <PostBuildEvent>
-      <Command>xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_FFXV_BIN_PATH_PATH%" || exit /B 0</Command>
+      <Command>xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_FFXV_BIN_PATH%" || exit /B 0</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="includes\cbuffers.h" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Source/Games/Final Fantasy XV/FFXV.vcxproj.filters
+++ b/Source/Games/Final Fantasy XV/FFXV.vcxproj.filters
@@ -3,7 +3,4 @@
   <ItemGroup>
     <ClCompile Include="main.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="includes\cbuffers.h" />
-  </ItemGroup>
 </Project>

--- a/Source/Games/Final Fantasy XV/FFXV.vcxproj.filters
+++ b/Source/Games/Final Fantasy XV/FFXV.vcxproj.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="includes\cbuffers.h" />
+  </ItemGroup>
+</Project>

--- a/Source/Games/Final Fantasy XV/main.cpp
+++ b/Source/Games/Final Fantasy XV/main.cpp
@@ -1,0 +1,374 @@
+// ### Rename this ###
+#define GAME_TEMPLATE 1
+#define GAME_FINALFANTASYXV 1
+
+
+#define UPGRADE_SAMPLERS 0
+#define GEOMETRY_SHADER_SUPPORT 0
+#define ALLOW_SHADERS_DUMPING 0
+#define ENABLE_NGX 1
+
+#include "..\..\Core\core.hpp"
+#include "..\..\Core\includes\math.h"
+#include "..\..\Core\includes\matrix.h"
+#include "..\..\Core\dlss\DLSS.cpp"
+namespace
+{
+    float2 projection_jitters = { 0, 0 };
+	//const uint32_t shader_hash_mvec_pixel = std::stoul("FFFFFFF3", nullptr, 16);
+    ShaderHashesList shader_hashes_tonemap;
+    ShaderHashesList shader_hashes_TAA;
+}
+
+struct GameDeviceDataFFXV final : public GameDeviceData
+{
+#if ENABLE_NGX
+    // DLSS SR
+    com_ptr<ID3D11Resource> dlss_motion_vectors;
+    com_ptr<ID3D11Resource> dlss_source_color;
+    com_ptr<ID3D11Resource> depth_buffer;
+    com_ptr<ID3D11RenderTargetView> dlss_motion_vectors_rtv;
+#endif // ENABLE_NGX
+    std::atomic<bool> has_drawn_upscaling = false;
+    //com_ptr<ID3D11PixelShader> motion_vectors_ps;
+};
+
+class FinalFantasyXV final : public Game // ### Rename this to your game's name ###
+{
+    static GameDeviceDataFFXV& GetGameDeviceData(DeviceData& device_data)
+    {
+        return *static_cast<GameDeviceDataFFXV*>(device_data.game);
+    }
+public:
+   void OnInit(bool async) override
+   {
+       GetShaderDefineData(POST_PROCESS_SPACE_TYPE_HASH).SetDefaultValue('1');
+       GetShaderDefineData(EARLY_DISPLAY_ENCODING_HASH).SetDefaultValue('0');
+       GetShaderDefineData(VANILLA_ENCODING_TYPE_HASH).SetDefaultValue('0');
+       GetShaderDefineData(GAMMA_CORRECTION_TYPE_HASH).SetDefaultValue('0');
+       GetShaderDefineData(UI_DRAW_TYPE_HASH).SetDefaultValue('0');
+      luma_settings_cbuffer_index = 13;
+      luma_data_cbuffer_index = 12; // #w## Update this (find the right value) ###
+   }
+
+   bool OnDrawCustom(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, CommandListData& cmd_list_data, DeviceData& device_data, reshade::api::shader_stage stages, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass, bool& updated_cbuffers) override
+   {
+	   auto& game_device_data = GetGameDeviceData(device_data);
+
+	   const bool had_drawn_upscaling = game_device_data.has_drawn_upscaling;
+	   if (!game_device_data.has_drawn_upscaling && device_data.dlss_sr && !device_data.dlss_sr_suppressed && original_shader_hashes.Contains(shader_hashes_TAA))
+	   {	
+		   
+		   game_device_data.has_drawn_upscaling = true;
+		   // 1 depth [3]
+		   // 2 current color source () = [0]
+		   // 3 previous color source (previous frame) = [1]
+		   // 4 motion vectors [6]
+		   com_ptr<ID3D11ShaderResourceView> ps_shader_resources[16];
+		   native_device_context->PSGetShaderResources(0, ARRAYSIZE(ps_shader_resources), reinterpret_cast<ID3D11ShaderResourceView**>(ps_shader_resources));
+
+		   com_ptr<ID3D11RenderTargetView> render_target_views[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];
+		   com_ptr<ID3D11DepthStencilView> depth_stencil_view;
+		   native_device_context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, &render_target_views[0], &depth_stencil_view);
+		   const bool dlss_inputs_valid = ps_shader_resources[0].get() != nullptr && ps_shader_resources[5].get() != nullptr && ps_shader_resources[6].get() != nullptr && render_target_views[0] != nullptr;
+		   ASSERT_ONCE(dlss_inputs_valid);
+
+           if (dlss_inputs_valid) {
+
+               com_ptr<ID3D11Resource> output_colorTemp;
+               render_target_views[0]->GetResource(&output_colorTemp);
+               com_ptr<ID3D11Texture2D> output_color;
+               HRESULT hr = output_colorTemp->QueryInterface(&output_color);
+               ASSERT_ONCE(SUCCEEDED(hr));
+               D3D11_TEXTURE2D_DESC output_texture_desc;
+               output_color->GetDesc(&output_texture_desc);
+
+               //ASSERT_ONCE(std::lrintf(device_data.output_resolution.x) == output_texture_desc.Width && std::lrintf(device_data.output_resolution.y) == output_texture_desc.Height);
+               std::array<uint32_t, 2> dlss_render_resolution = FindClosestIntegerResolutionForAspectRatio((double)output_texture_desc.Width * (double)device_data.dlss_render_resolution_scale, (double)output_texture_desc.Height * (double)device_data.dlss_render_resolution_scale, (double)output_texture_desc.Width / (double)output_texture_desc.Height);
+               bool dlss_hdr = true;
+   //            
+               // Test DLSS
+               com_ptr<ID3D11VertexShader> vs;
+               com_ptr<ID3D11PixelShader> ps;
+               native_device_context->VSGetShader(&vs, nullptr, 0);
+               native_device_context->PSGetShader(&ps, nullptr, 0);
+               // end Test Dlss
+
+               NGX::DLSS::UpdateSettings(device_data.dlss_sr_handle, native_device_context, output_texture_desc.Width, output_texture_desc.Height, dlss_render_resolution[0], dlss_render_resolution[1], dlss_hdr, false); //TODO: figure out dsr later
+               
+               // Test DLSS
+               com_ptr<ID3D11ShaderResourceView> ps_shader_resources_post[ARRAYSIZE(ps_shader_resources)];
+               native_device_context->PSGetShaderResources(0, ARRAYSIZE(ps_shader_resources_post), reinterpret_cast<ID3D11ShaderResourceView**>(ps_shader_resources_post));
+               for (uint32_t i = 0; i < ARRAYSIZE(ps_shader_resources); i++)
+               {
+                   ASSERT_ONCE(ps_shader_resources[i] == ps_shader_resources_post[i]);
+               }
+
+               com_ptr<ID3D11RenderTargetView> render_target_view_post;
+               com_ptr<ID3D11DepthStencilView> depth_stencil_view_post;
+               native_device_context->OMGetRenderTargets(1, &render_target_view_post, &depth_stencil_view_post);
+               ASSERT_ONCE(render_target_views[0] == render_target_view_post && depth_stencil_view == depth_stencil_view_post);
+
+               com_ptr<ID3D11VertexShader> vs_post;
+               com_ptr<ID3D11PixelShader> ps_post;
+               native_device_context->VSGetShader(&vs_post, nullptr, 0);
+               native_device_context->PSGetShader(&ps_post, nullptr, 0);
+               ASSERT_ONCE(vs == vs_post && ps == ps_post);
+               vs = nullptr;
+               ps = nullptr;
+               vs_post = nullptr;
+               ps_post = nullptr;
+
+               // end Test Dlss
+
+               bool skip_dlss = output_texture_desc.Width < 32 || output_texture_desc.Height < 32; // DLSS desn't support output below 32x32
+               bool dlss_output_changed = false;
+               constexpr bool dlss_use_native_uav = true;
+
+               //reshade::log::message(reshade::log::level::info, ("DLSS initialization successful"));
+
+               bool dlss_output_supports_uav = dlss_use_native_uav && (output_texture_desc.BindFlags & D3D11_BIND_UNORDERED_ACCESS) != 0;
+               if (!dlss_output_supports_uav) {
+
+                   output_texture_desc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
+
+                   if (device_data.dlss_output_color.get())
+                   {
+                       D3D11_TEXTURE2D_DESC dlss_output_texture_desc;
+                       device_data.dlss_output_color->GetDesc(&dlss_output_texture_desc);
+                       dlss_output_changed = dlss_output_texture_desc.Width != output_texture_desc.Width || dlss_output_texture_desc.Height != output_texture_desc.Height || dlss_output_texture_desc.Format != output_texture_desc.Format;
+                   }
+                   if (!device_data.dlss_output_color.get() || dlss_output_changed)
+                   {
+                       device_data.dlss_output_color = nullptr; // Make sure we discard the previous one
+                       hr = native_device->CreateTexture2D(&output_texture_desc, nullptr, &device_data.dlss_output_color);
+                       ASSERT_ONCE(SUCCEEDED(hr));
+                   }
+                   if (!device_data.dlss_output_color.get())
+                   {
+                       skip_dlss = true;
+                   }
+               }
+               else
+               {
+                   device_data.dlss_output_color = output_color;
+               }
+
+               if (!skip_dlss)
+               {
+                   game_device_data.dlss_source_color = nullptr;
+                   ps_shader_resources[0]->GetResource(&game_device_data.dlss_source_color);
+                   game_device_data.depth_buffer = nullptr;
+                   ps_shader_resources[3]->GetResource(&game_device_data.depth_buffer);
+                   game_device_data.dlss_motion_vectors = nullptr;
+                   ps_shader_resources[6]->GetResource(&game_device_data.dlss_motion_vectors);
+
+                   reshade::log::message(reshade::log::level::info, ("Loading DLSS inputs successfully"));
+
+                   // Extract jitter from constant buffer 0
+                   {
+                       ID3D11Buffer* cb0_buffer = nullptr;
+                       native_device_context->PSGetConstantBuffers(0, 1, &cb0_buffer); // slot 0 = b0
+
+                       if (cb0_buffer)
+                       {
+                           D3D11_BUFFER_DESC cb0_desc = {};
+                           cb0_buffer->GetDesc(&cb0_desc);
+
+                           ID3D11Buffer* staging_cb0 = cb0_buffer;
+                           com_ptr<ID3D11Buffer> staging_cb0_buf;
+                           if (cb0_desc.Usage != D3D11_USAGE_STAGING || !(cb0_desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ))
+                           {
+                               cb0_desc.Usage = D3D11_USAGE_STAGING;
+                               cb0_desc.BindFlags = 0;
+                               cb0_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+                               cb0_desc.MiscFlags = 0;
+                               cb0_desc.StructureByteStride = 0;
+                               HRESULT hr_staging = native_device->CreateBuffer(&cb0_desc, nullptr, &staging_cb0_buf);
+                               if (SUCCEEDED(hr_staging))
+                               {
+                                   native_device_context->CopyResource(staging_cb0_buf.get(), cb0_buffer);
+                                   staging_cb0 = staging_cb0_buf.get();
+                                   D3D11_MAPPED_SUBRESOURCE mapped_cb0 = {};
+                                   if (SUCCEEDED(native_device_context->Map(staging_cb0, 0, D3D11_MAP_READ, 0, &mapped_cb0)))
+                                   {
+                                       // cb0 is float4[140], so each element is 16 bytes
+                                       const float* cb0_floats = reinterpret_cast<const float*>(mapped_cb0.pData);
+                                       //float4 g_screenSize : packoffset(c0);
+                                       //float4 g_frameBits : packoffset(c1);
+                                       //float4 g_uvJitterOffset : packoffset(c2);
+                                       float jitter_x = cb0_floats[8];
+                                       float jitter_y = cb0_floats[9];
+                                       if (jitter_x != 0 || jitter_y != 0)
+                                       {
+                                           projection_jitters.x = jitter_x;
+                                           projection_jitters.y = jitter_y;
+                                       }
+                                       native_device_context->Unmap(staging_cb0, 0);
+                                       staging_cb0->Release();
+                                       cb0_buffer->Release();
+                                   }
+                               }
+                               else
+                               {
+                                   cb0_buffer->Release();
+                               }
+                           }
+                       }
+                   }
+                   reshade::log::message(reshade::log::level::info, ("Loading DLSS  successfully"));
+                   reshade::log::message(
+                       reshade::log::level::info,
+                       ("Jitter X: " + std::to_string(projection_jitters.x) +
+                           ", Jitter Y: " + std::to_string(projection_jitters.y)).c_str()
+                   );
+
+                   bool reset_dlss = false;
+                   uint32_t render_width_dlss = std::lrintf(device_data.render_resolution.x);
+                   uint32_t render_height_dlss = std::lrintf(device_data.render_resolution.y);
+                   float dlss_pre_exposure = 0.f;
+                   bool dlss_succeeded = NGX::DLSS::Draw(device_data.dlss_sr_handle, native_device_context, device_data.dlss_output_color.get(), game_device_data.dlss_source_color.get(), game_device_data.dlss_motion_vectors.get(), game_device_data.depth_buffer.get(), nullptr, dlss_pre_exposure, projection_jitters.x, projection_jitters.y, reset_dlss, render_width_dlss, render_height_dlss);
+
+                   reshade::log::message(
+                       reshade::log::level::info,
+                       (std::string("DLSS succeeded: ") + (dlss_succeeded ? "true" : "false")).c_str()
+                   );
+
+                   if (dlss_succeeded)
+                   {
+                       device_data.has_drawn_dlss_sr = true;
+                   }
+
+                   game_device_data.dlss_motion_vectors_rtv = nullptr;
+                   game_device_data.dlss_motion_vectors = nullptr;
+                   game_device_data.dlss_source_color = nullptr;
+                   game_device_data.depth_buffer = nullptr;
+
+                   ID3D11RenderTargetView* const* rtvs_const = (ID3D11RenderTargetView**)std::addressof(render_target_views[0]);
+                   native_device_context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, rtvs_const, depth_stencil_view.get());
+
+                   if (device_data.has_drawn_dlss_sr)
+                   {
+                       if (!dlss_output_supports_uav)
+                       {
+                           native_device_context->CopyResource(output_color.get(), device_data.dlss_output_color.get()); // DX11 doesn't need barriers
+                       }
+                       else
+                       {
+                           device_data.dlss_output_color = nullptr;
+                       }
+
+                       reshade::log::message(
+                           reshade::log::level::info,
+                           "Skipping the TAA draw call ..."
+                       );
+
+                       return true;
+                   }
+                   else
+                   {
+                       //ASSERT_ONCE(false);
+                       //cb_luma_frame_settings.DLSS = 0;
+                       //device_data.cb_luma_frame_settings_dirty = true;
+                       //device_data.dlss_sr_suppressed = true;
+                       device_data.force_reset_dlss_sr = true;
+                   }
+
+               }
+               if (dlss_output_supports_uav)
+               {
+                   device_data.dlss_output_color = nullptr;
+               }
+
+
+           }
+		   
+
+	   }
+	   return false; // Don't cancel the original draw call
+
+   }
+
+   void OnCreateDevice(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+       device_data.game = new GameDeviceDataFFXV;
+   }
+
+   void OnPresent(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+       auto& game_device_data = GetGameDeviceData(device_data);
+
+       game_device_data.has_drawn_upscaling = false;
+   }
+
+
+   void PrintImGuiAbout() override
+   {
+      ImGui::Text("FFXV Luma mod - about and credits section", ""); // ### Rename this ###
+   }
+
+   void CreateShaderObjects(DeviceData& device_data, const std::optional<std::set<std::string>>& shader_names_filter) override
+   {
+       auto& game_device_data = GetGameDeviceData(device_data);
+       //CreateShaderObject(device_data.native_device, shader_hash_mvec_pixel, game_device_data.motion_vectors_ps, shader_hashes_filter);
+   }
+   
+};
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+   {
+      Globals::SetGlobals(PROJECT_NAME, "Final Fantasy XV Luma Edition");
+      Globals::VERSION = 1;
+
+      shader_hashes_tonemap.pixel_shaders.emplace(std::stoul("75DFE4B0", nullptr, 16)); // Main game tonemapping
+      shader_hashes_tonemap.pixel_shaders.emplace(std::stoul("18EF8C72", nullptr, 16)); // Title screen tonemapping
+      shader_hashes_tonemap.pixel_shaders.emplace(std::stoul("DD4C5B74", nullptr, 16)); // Post-processing / swapchain
+
+      // TODO: intercept this
+      shader_hashes_TAA.pixel_shaders.emplace(std::stoul("0DF0A97D", nullptr, 16));
+
+      enable_swapchain_upgrade = true; // We don't need swapchain upgrade for this game
+      swapchain_upgrade_type = 1;  // 1 = scrgb
+      
+      enable_texture_format_upgrades = true;
+
+      std::vector<ShaderDefineData> game_shader_defines_data = {
+         {"TONEMAP_TYPE", '1', false, false, "0 - Vanilla SDR\n1 - Luma HDR (Vanilla+)\n2 - Raw HDR (Untonemapped)\nThe HDR tonemapper works for SDR too\nThis games uses a filmic tonemapper, which slightly crushes blacks"},
+      };
+
+      shader_defines_data.append_range(game_shader_defines_data);
+      assert(shader_defines_data.size() < MAX_SHADER_DEFINES);
+      
+      // ### Check which of these are needed and remove the rest ###
+      texture_upgrade_formats = {
+            reshade::api::format::r8g8b8a8_unorm,
+            //reshade::api::format::r8g8b8a8_unorm_srgb,
+            //reshade::api::format::r8g8b8a8_typeless,
+            //reshade::api::format::r8g8b8x8_unorm,
+            //reshade::api::format::r8g8b8x8_unorm_srgb,
+            reshade::api::format::b8g8r8a8_unorm,
+            //reshade::api::format::b8g8r8a8_unorm_srgb,
+            //reshade::api::format::b8g8r8a8_typeless,
+            //reshade::api::format::b8g8r8x8_unorm,
+            //reshade::api::format::b8g8r8x8_unorm_srgb,
+            //reshade::api::format::b8g8r8x8_typeless,
+
+            reshade::api::format::r11g11b10_float,
+            reshade::api::format::r10g10b10a2_typeless,
+            reshade::api::format::r10g10b10a2_unorm,
+            //reshade::api::format::r16g16_float,
+            //reshade::api::format::r16g16_unorm,
+            //reshade::api::format::r32_g8_typeless
+      };
+      // ### Check these if textures are not upgraded ###
+      texture_format_upgrades_2d_size_filters = 0 | (uint32_t)TextureFormatUpgrades2DSizeFilters::SwapchainResolution | (uint32_t)TextureFormatUpgrades2DSizeFilters::SwapchainAspectRatio;
+
+      game = new FinalFantasyXV();
+   }
+
+   CoreMain(hModule, ul_reason_for_call, lpReserved);
+
+   return TRUE;
+}

--- a/Source/Games/Final Fantasy XV/main.cpp
+++ b/Source/Games/Final Fantasy XV/main.cpp
@@ -1,7 +1,4 @@
-// ### Rename this ###
-#define GAME_TEMPLATE 1
 #define GAME_FINALFANTASYXV 1
-
 
 #define UPGRADE_SAMPLERS 0
 #define GEOMETRY_SHADER_SUPPORT 0
@@ -12,6 +9,7 @@
 #include "..\..\Core\includes\math.h"
 #include "..\..\Core\includes\matrix.h"
 #include "..\..\Core\dlss\DLSS.cpp"
+
 namespace
 {
     float2 projection_jitters = { 0, 0 };
@@ -301,7 +299,6 @@ public:
        game_device_data.has_drawn_upscaling = false;
    }
 
-
    void PrintImGuiAbout() override
    {
       ImGui::Text("FFXV Luma mod - about and credits section", ""); // ### Rename this ###
@@ -312,7 +309,6 @@ public:
        auto& game_device_data = GetGameDeviceData(device_data);
        //CreateShaderObject(device_data.native_device, shader_hash_mvec_pixel, game_device_data.motion_vectors_ps, shader_hashes_filter);
    }
-   
 };
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)


### PR DESCRIPTION
HDR fix:
- The game tonemaps to about 2.0 (400 nits with 203 paper white) and then scales up brightness and contrast, this is replaced by a DICE tonemapper, the game's saturation grading is also extended to values > 1.0.
- the contrast (1.3 gamma) is replaced by Gamma Correction (currently hardcoded to 2.4)

Initial setup for DLSS/DLAA. The draw call using the TAA shader's g_jitterTex, g_depthTex and g_velocityTex is successful but the image quality is poor. 