### PR TITLE
Borderlands 2 + The Pre-Sequel: Add Luma HDR + SMAA mod

### DIFF
--- a/Luma.sln
+++ b/Luma.sln
@@ -77,6 +77,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NieR Automata", "Source\Gam
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Vanquish", "Source\Games\Vanquish\Vanquish.vcxproj", "{51BFC834-EC5F-4F25-90DC-A2001E88B491}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Borderlands 2 and The Pre-Sequel", "Source\Games\Borderlands 2 and The Pre-Sequel\Borderlands 2 and The Pre-Sequel.vcxproj", "{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Project Diva Mega Mix", "Source\Games\Project Diva Mega Mix\Project Diva Mega Mix.vcxproj", "{E9C6A0CB-74CC-4202-855B-FA91EBA2104B}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Call of Duty Black Ops 3", "Source\Games\Call of Duty Black Ops 3\Call of Duty Black Ops 3.vcxproj", "{ADAE0E50-F63A-4FA5-BC6A-E1D974CC2D2C}"
@@ -574,6 +576,18 @@ Global
 		{51BFC834-EC5F-4F25-90DC-A2001E88B491}.Test-Release|Win32.ActiveCfg = Test-Release|Win32
 		{51BFC834-EC5F-4F25-90DC-A2001E88B491}.Test-Release|Win32.Build.0 = Test-Release|Win32
 		{51BFC834-EC5F-4F25-90DC-A2001E88B491}.Test-Release|x64.ActiveCfg = Test-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Development-Debug|Win32.ActiveCfg = Development-Debug|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Development-Debug|Win32.Build.0 = Development-Debug|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Development-Debug|x64.ActiveCfg = Development-Debug|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Development-Release|Win32.ActiveCfg = Development-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Development-Release|Win32.Build.0 = Development-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Development-Release|x64.ActiveCfg = Development-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Publishing-Release|Win32.ActiveCfg = Publishing-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Publishing-Release|Win32.Build.0 = Publishing-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Publishing-Release|x64.ActiveCfg = Publishing-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Test-Release|Win32.ActiveCfg = Test-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Test-Release|Win32.Build.0 = Test-Release|Win32
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402}.Test-Release|x64.ActiveCfg = Test-Release|Win32
 		{E9C6A0CB-74CC-4202-855B-FA91EBA2104B}.Development-Debug|Win32.ActiveCfg = Development-Debug|x64
 		{E9C6A0CB-74CC-4202-855B-FA91EBA2104B}.Development-Debug|x64.ActiveCfg = Development-Debug|x64
 		{E9C6A0CB-74CC-4202-855B-FA91EBA2104B}.Development-Debug|x64.Build.0 = Development-Debug|x64
@@ -853,6 +867,7 @@ Global
 		{597555CF-7003-4B06-8409-C3A0AC818E59} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{457A69B6-422F-4E49-9EC0-111BF35941E1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{51BFC834-EC5F-4F25-90DC-A2001E88B491} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{56B56CAD-A792-42A8-B7CD-7CFE9FF7D402} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{E9C6A0CB-74CC-4202-855B-FA91EBA2104B} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{ADAE0E50-F63A-4FA5-BC6A-E1D974CC2D2C} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{36D63B53-C40A-479C-94F9-FC93CBB49FEB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Includes/Common.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Includes/Common.hlsl
@@ -1,0 +1,6 @@
+// Borderlands 2 / The Pre-Sequel — game-local Common: defines LumaGameSettings before the shared Settings.hlsl cbuffer.
+
+// Define the game custom cbuffer structs.
+#include "GameCBuffers.hlsl"
+// Shared global common (pulls in the shared Settings.hlsl -> LumaSettings cbuffer with our GameSettings).
+#include "../../Includes/Common.hlsl"

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Includes/GameCBuffers.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Includes/GameCBuffers.hlsl
@@ -1,0 +1,37 @@
+#ifndef LUMA_GAME_CB_STRUCTS
+#define LUMA_GAME_CB_STRUCTS
+
+#ifdef __cplusplus
+// This include is needed to allow reading shader types from c++.
+#include "../../../Source/Core/includes/shader_types.h"
+#endif
+
+// Mirrors c++ name spaces.
+namespace CB
+{
+// User-facing grade controls, drawn in DrawImGuiSettings (main.cpp) and read in Tonemap_0xD00AA2A7.ps_5_0.hlsl.
+// Exposure/BloomIntensity/VignetteIntensity apply on both SDR and HDR (they live in the shared scene mix /
+// vignette block); Saturation/HighlightDechroma/Contrast apply only on the HDR display path. All default to a
+// vanilla no-op. SMAA metrics are passed via a dedicated CB at b1, not here.
+struct LumaGameSettings
+{
+   float Exposure;          // 1 = vanilla. Scene exposure multiplier, scene-referred / pre-grade.
+   float Saturation;        // 1 = vanilla. Oklab saturation multiplier on the final HDR color.
+   float HighlightDechroma; // 0 = off (only the mandatory DICE/gamut desat applies); higher = bright sources fade to white sooner.
+   float BloomIntensity;    // 1 = vanilla. Scales the game's bloom contribution in the scene mix.
+   float Contrast;          // 1 = vanilla. Slope contrast around 18% mid-gray on the final HDR color.
+   float VignetteIntensity; // 1 = vanilla. Scales the game's vignette darkening (0 = no vignette).
+   float LumaBloomEnable;   // 0/1. 1 = composite Luma HDR pyramidal bloom (t5 BL2 / t8 TPS, additive); 0 = vanilla game bloom (t1).
+   float DOFRadius;         // Luma Gaussian DoF strength (half-res blur extent, full-res px @ 4K).
+   float DOFType;           // DoF path: 0 = vanilla game DoF, 2 = Luma separable Gaussian (t7 pre-blurred).
+   float Dithering;         // 0/1 toggle. Animated triangular dither at output (HDR only) to break gradient banding.
+};
+
+// Game specific cbuffer (instance/pass) data.
+struct LumaGameData
+{
+   float Dummy; // hlsl doesn't support empty structs
+};
+} // namespace CB
+
+#endif // LUMA_GAME_CB_STRUCTS

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_DepthExtract.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_DepthExtract.hlsl
@@ -1,0 +1,24 @@
+// Borderlands 2 / The Pre-Sequel — extract a normalized depth for SMAA predication.
+//
+// Both games (dgVoodoo DX9->11) expose NO separate depth buffer, but the fp16 scene-color buffer carries linear
+// view-space Z in its ALPHA channel (UE3 pattern): geometry = NEGATIVE z (right-handed view space, |z| grows
+// with distance), sky/invalid = a >= 0 (a large +sentinel). We read that, decode depth = -a, and perceptually
+// compress it into [0,1] so silhouette deltas comfortably exceed SMAA's predication threshold (~0.01) at all
+// distances. Output is single-channel (R) because SMAA predication Gathers the R channel (SMAA.hlsl).
+
+Texture2D<float4> scene : register(t0); // fp16 scene color; .a = view-space Z (negative for geometry)
+RWTexture2D<float> uav : register(u0);  // R16_FLOAT normalized predication depth
+
+cbuffer PredCB : register(b0)
+{
+   float4 P; // P.x = compress constant k (world units); larger k = more spread pushed to the far field
+}
+
+[numthreads(8, 8, 1)] void main(uint3 id : SV_DispatchThreadID) {
+   float a = scene.Load(int3(id.xy, 0)).a;
+   // Geometry: a < 0 -> linear depth = -a. Sky / invalid (a >= 0, e.g. the +65472 far sentinel) -> treat as
+   // very far so foreground silhouettes against sky register a large predication delta.
+   float depth = (a < 0.0) ? -a : 1e9;
+   float k = max(P.x, 1.0);
+   uav[id.xy] = depth / (depth + k); // near -> 0, far -> 1, monotonic; deltas are largest at silhouettes
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_DoFGaussian.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_DoFGaussian.hlsl
@@ -1,0 +1,39 @@
+// Separable Gaussian blur for the "Luma Gaussian" DoF mode (the only Luma DoF path; grain-free).
+// Dispatched twice on the half-res prefiltered scene: horizontal then vertical. Each pixel is
+// a dense, normalized 1D Gaussian along the axis -> no sparse taps, no jitter -> no graininess by
+// construction. The tonemap then blends this blurred half-res buffer with the sharp scene by the game's
+// per-pixel focus weight (the GPU Gems 3 Ch.28 single-radius-blur-blended-by-CoC model, which is also how
+// the game's own vanilla DoF works). HDR is preserved (linear fp16 source) so bright defocused areas glow.
+
+cbuffer cb_dof_blur : register(b0)
+{
+   float2 BlurAxisInvSize; // per-tap UV step along the blur axis: (1/halfW, 0) for H, (0, 1/halfH) for V
+   float BlurSigma;        // gaussian sigma in half-res pixels (derived from the DoF Radius slider)
+   float _dof_blur_pad;
+}
+
+Texture2D<float4> t0 : register(t0);         // half-res source (prefilter output for H, H output for V)
+SamplerState s0 : register(s0);              // linear-clamp
+RWTexture2D<float4> out_blur : register(u0); // half-res blurred output
+
+[numthreads(8, 8, 1)] void dof_blur_cs(uint3 id : SV_DispatchThreadID) {
+   uint w, h;
+   t0.GetDimensions(w, h);
+   if (id.x >= w || id.y >= h)
+      return;
+
+   const float2 uv = (float2(id.xy) + 0.5) / float2(w, h);
+   const float sigma = max(BlurSigma, 0.5);
+   const int radius = (int)clamp(ceil(2.0 * sigma), 1.0, 32.0); // up to 65 taps/axis
+   const float inv2s2 = rcp(2.0 * sigma * sigma);
+
+   float3 sum = 0.0;
+   float wsum = 0.0;
+   [loop] for (int i = -radius; i <= radius; i++)
+   {
+      float wt = exp(-(float)(i * i) * inv2s2);
+      sum += t0.SampleLevel(s0, uv + (float)i * BlurAxisInvSize, 0).rgb * wt;
+      wsum += wt;
+   }
+   out_blur[id.xy] = float4(sum * rcp(max(wsum, 1e-6)), 1.0);
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_DoFPrefilter.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_DoFPrefilter.hlsl
@@ -1,0 +1,31 @@
+#include "../Includes/Color.hlsl"
+
+// Half-res, firefly-tamed prefilter that feeds the separable "Luma Gaussian" DoF blur (Luma_BL2TPS_DoFGaussian).
+// Point-tap blurring the full-res scene turns high-frequency detail into discrete sample dots (grain/sparkle).
+// Fix (downsampled-gather DoF): blur a half-res buffer where each texel is the Karis-weighted average of a 4x4
+// full-res footprint (overlapping -> gap-free downsample; Karis stops one bright pixel dominating) -> taps = areas.
+
+Texture2D<float4> t0 : register(t0);                // full-res scene color (fp16)
+RWTexture2D<float4> out_prefiltered : register(u0); // half-res Karis-tamed scene
+
+float karis_w(float3 c)
+{
+   return rcp(1.0 + GetLuminance(c)); // same firefly weight as Shaders/Global/Luma_KarisAverage.hlsl
+}
+
+[numthreads(8, 8, 1)] void dof_prefilter_cs(uint3 dtid : SV_DispatchThreadID) {
+   const int2 base = int2(dtid.xy) * 2; // half-res texel -> full-res block origin
+   float3 sum = 0.0;
+   float wsum = 0.0;
+   // 4x4 full-res footprint (offsets -1..2) centered on the 2x2 block -> overlaps neighbouring half-res
+   // texels so the downsampled result is gap-free for the Gaussian blur.
+   [unroll] for (int dy = -1; dy <= 2; dy++)
+       [unroll] for (int dx = -1; dx <= 2; dx++)
+   {
+      float3 c = t0.Load(int3(base + int2(dx, dy), 0)).rgb;
+      float w = karis_w(c);
+      sum += c * w;
+      wsum += w;
+   }
+   out_prefiltered[dtid.xy] = float4(sum * rcp(max(wsum, 1e-6)), 1.0);
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_Sharpen.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Luma_BL2TPS_Sharpen.hlsl
@@ -1,0 +1,21 @@
+// RCAS sharpening for the SMAA output.
+// Runs after the SMAA neighborhood-blend pass, on the linear scRGB color (DrawSMAA blends the linear copy),
+// before the result is copied back into the fp16 scRGB swapchain. paperWhite=1.0; the sharpness slider is the
+// tuning knob. RCAS_LIMIT bounds the lobe so HDR highlights don't over-sharpen.
+
+#include "../Includes/RCAS.hlsl"
+
+cbuffer SharpenCB : register(b0)
+{
+   float4 SharpenParams; // (width, height, sharpness[0..1], unused)
+}
+
+Texture2D<float4> tex0 : register(t0);    // SMAA output (linear scRGB)
+Texture2D<float2> dummyMV : register(t1); // unused (dynamicSharpening = false)
+
+float4 sharpen_ps(float4 pos : SV_Position) : SV_Target
+{
+   int2 p = int2(pos.xy);
+   int2 maxPixel = int2((int)SharpenParams.x - 1, (int)SharpenParams.y - 1);
+   return RCAS(p, int2(0, 0), maxPixel, SharpenParams.z, tex0, dummyMV, 1.0, false, (float4)0, false);
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Luma_Bloom_impl.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Luma_Bloom_impl.hlsl
@@ -1,0 +1,16 @@
+// Borderlands 2 / The Pre-Sequel — Luma HDR pyramidal bloom (provides the Bloom * entry points DrawBloom calls,
+// auto-registered by core when ENABLE_BLOOM=1). Replaces the game's single-level quarter-res UNORM-clamped bloom
+// with a multi-mip fp16 bloom computed from the linear HDR scene (energy-correct: bright HDR sources glow
+// proportionally instead of flattening at the 1.0 clamp).
+//
+// Threshold = soft-knee quadratic (Bloom.hlsl default LUMA_BLOOM_THRESHOLD_FUNCTION). Source is linear scene
+// referred to paper white (1.0), so threshold 1.0 blooms above-paper-white highlights; soft knee 0.5 fades the
+// transition in (web best-practice — avoids hard popping on cel-shade ink edges). Karis firefly weighting is
+// applied separately (DrawKarisAverage) before this, since BL2 has no TAA to hide sparkle.
+
+#include "../Includes/Color.hlsl" // GetLuminance, gamma helpers used by Bloom.hlsl
+
+#define LUMA_BLOOM_THRESHOLD 1.0
+#define LUMA_BLOOM_SOFT_KNEE 0.5
+
+#include "../Includes/Bloom.hlsl"

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Luma_SMAA_impl.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Luma_SMAA_impl.hlsl
@@ -1,0 +1,102 @@
+// SMAA implementation for Borderlands 2 / The Pre-Sequel.
+// Reference: https://github.com/iryoku/smaa
+// ULTRA preset + color edge detection. Runs POST-tonemap on the tonemap's LDR output (main.cpp drives it via the
+// post-draw callback: it runs the tonemap, then SMAA on its LDR result) — NOT on the game's pre-tonemap FXAA pass.
+// This keeps SMAA from perturbing the depth-of-field (composited inside the tonemap; the native FXAA is left
+// running untouched to feed DoF as vanilla). The LDR buffer is GAMMA (the BL2 tonemap outputs gamma,
+// POST_PROCESS_SPACE_TYPE=0), so edge detection + neighborhood blending both work in gamma and the PS appends NO
+// HDR/tonemap tail (the core Display Composition still does paper-white + scRGB downstream). Predication uses the
+// scene-color .a depth captured at the tonemap; null-predication + scale 1.0 is the no-depth fallback.
+
+#include "../Includes/Common.hlsl"
+
+// (1/W, 1/H, W, H) at output resolution — filled by the mod (see main.cpp RunPostTonemapSMAA).
+cbuffer SmaaMetricsCB : register(b1)
+{
+   float4 SmaaRtMetrics;
+   // x = predication threshold scale: 2.0 when predication is active (scene-color .a depth bound) -> frame-wide
+   // threshold 0.10 on flats; 1.0 with a null predication texture (fallback) -> plain ULTRA threshold 0.05. yzw unused.
+   float4 SmaaPredication;
+}
+
+#define SMAA_RT_METRICS SmaaRtMetrics
+#define SMAA_PRESET_ULTRA
+#define SMAA_PREDICATION       1
+#define SMAA_PREDICATION_SCALE SmaaPredication.x
+// Predication tuned to ReShade-community best-practice + BL2's clean view-Z depth signal:
+//  - flat threshold  = SCALE * SMAA_THRESHOLD            = 2.0 * 0.05      = 0.10 (recommended; rejects busy
+//    cel-shade texture color-noise so SMAA doesn't over-AA flat detail)
+//  - silhouette thr  = SCALE * SMAA_THRESHOLD * (1-STR)  = 2.0 * 0.05 *0.5 = 0.05 (= plain ULTRA base; predication
+//    only relaxes geometric edges back to normal sensitivity, never below -> no over-aggression)
+//  - PREDICATION_THRESHOLD lowered (depth-delta gate) since our normalized depth is clean (FPR ~0.1% on flats).
+#define SMAA_PREDICATION_STRENGTH  0.5
+#define SMAA_PREDICATION_THRESHOLD 0.005
+#define SMAA_CUSTOM_SL
+SamplerState LinearSampler : register(s0);
+SamplerState PointSampler : register(s1);
+#define SMAATexture2D(tex)                            Texture2D tex
+#define SMAATexturePass2D(tex)                        tex
+#define SMAASampleLevelZero(tex, coord)               tex.SampleLevel(LinearSampler, coord, 0)
+#define SMAASampleLevelZeroPoint(tex, coord)          tex.SampleLevel(PointSampler, coord, 0)
+#define SMAASampleLevelZeroOffset(tex, coord, offset) tex.SampleLevel(LinearSampler, coord, 0, offset)
+#define SMAASample(tex, coord)                        tex.Sample(LinearSampler, coord)
+#define SMAASamplePoint(tex, coord)                   tex.Sample(PointSampler, coord)
+#define SMAASampleOffset(tex, coord, offset)          tex.Sample(LinearSampler, coord, offset)
+#define SMAA_FLATTEN                                  [flatten]
+#define SMAA_BRANCH                                   [branch]
+#define SMAATexture2DMS2(tex)                         Texture2DMS<float4, 2> tex
+#define SMAALoad(tex, pos, sample)                    tex.Load(pos, sample)
+#define SMAAGather(tex, coord)                        tex.Gather(LinearSampler, coord, 0)
+#include "../Includes/SMAA.hlsl"
+
+Texture2D tex0 : register(t0);
+Texture2D tex1 : register(t1);
+Texture2D tex2 : register(t2);
+
+void fullscreen_triangle(uint id, out float4 position, out float2 texcoord)
+{
+   texcoord = float2((id << 1) & 2, id & 2);
+   position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}
+
+// SMAAEdgeDetection
+void smaa_edge_detection_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float4 offset[3] : TEXCOORD1)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAAEdgeDetectionVS(texcoord, offset);
+}
+
+float2 smaa_edge_detection_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float4 offset[3] : TEXCOORD1) : SV_Target
+{
+   // tex0 = colorTexGamma (gamma-encoded scene color)
+   // tex1 = predicationTex (scene .a depth; null fallback -> reads 0, scale 1.0 = plain ULTRA threshold)
+   return SMAAColorEdgeDetectionPS(texcoord, offset, tex0, tex1);
+}
+
+// SMAABlendingWeightCalculation
+void smaa_blending_weight_calculation_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float2 pixcoord : TEXCOORD1, out float4 offset[3] : TEXCOORD2)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAABlendingWeightCalculationVS(texcoord, pixcoord, offset);
+}
+
+float4 smaa_blending_weight_calculation_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float2 pixcoord : TEXCOORD1, float4 offset[3] : TEXCOORD2) : SV_Target
+{
+   // tex0 = edgesTex, tex1 = areaTex, tex2 = searchTex
+   return SMAABlendingWeightCalculationPS(texcoord, pixcoord, offset, tex0, tex1, tex2, 0);
+}
+
+// SMAANeighborhoodBlending
+void smaa_neighborhood_blending_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float4 offset : TEXCOORD1)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAANeighborhoodBlendingVS(texcoord, offset);
+}
+
+float4 smaa_neighborhood_blending_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float4 offset : TEXCOORD1) : SV_Target
+{
+   // tex0 = colorTex (gamma copy), tex1 = blendTex. Blend in gamma (the buffer's space): keeps the bright HDR sky
+   // compressed so 1px-thin dark features survive the average (linear blend erodes them). No HDR tail / re-encode:
+   // output stays in the gamma LDR buffer's space, mid-pipeline before the composition.
+   return SMAANeighborhoodBlendingPS(texcoord, offset, tex0, tex1);
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Tonemap_0xD00AA2A7.ps_5_0.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Tonemap_0xD00AA2A7.ps_5_0.hlsl
@@ -1,0 +1,320 @@
+// clang-format off
+// ORDER MATTERS — do NOT let clang-format sort these. The game-local Common.hlsl MUST come first: it defines
+// LumaGameSettings (via GameCBuffers.hlsl) BEFORE the shared Settings.hlsl (pulled in by Color.hlsl below)
+// declares the LumaSettings cbuffer. If sorted after Color.hlsl, GameSettings becomes the empty fallback struct
+// and every LumaSettings.GameSettings.* reference fails to compile (invalid subscript).
+#include "Includes/Common.hlsl"             // game-local: LumaGameSettings (grade sliders) — keep FIRST
+#include "../Includes/Color.hlsl"           // BT709_To_BT2020 / BT2020_To_BT709
+#include "../Includes/ColorGradingLUT.hlsl" // SimpleGamutClip
+#include "../Includes/DICE.hlsl"
+#include "../Includes/Reinhard.hlsl" // Reinhard::ReinhardScalable (max-channel compressor)
+// clang-format on
+
+// Borderlands 2 uber post-process / tonemap (UE3, via dgVoodoo D3D9->11 -> ps_5_0).
+// Vanilla body (DOF + screen-blend bloom + vignette + ImageAdjustments + 16-slice ColorGradingLUT) transcribed
+// VERBATIM (register-level) from the readable DX9 BL2 tonemap (tonemap_0x54ED86A0.ps_3_0),
+// constants remapped DX9 cN -> cb4[N+8] (verified vs the live 0xD00AA2A7 disasm).
+//
+// HDR output uses the "apply SDR LUT in HDR" method: max-channel-compress the raw scene into [0,1] BEFORE the
+// grade+LUT (so neither the per-channel saturate nor the LUT clip -> highlight hue/chroma preserved), then expand
+// back with the exact inverse (sdr / tm) and DICE-map to the display peak. SDR mode keeps tm=1 -> the grade runs on
+// the raw scene exactly like vanilla. Compression MUST be max-channel: it scales all 3 channels by one factor (hue
+// intact) AND pins the brightest channel <=1 (nothing escapes the LUT). by-luminance would leave a saturated
+// channel >1 and the LUT would clip it; per-channel shifts hue outright.
+// NOTE: the per-channel ImageAdjustments curve below MUST keep the original's exact swizzles (r0.zzxy / r3.z,w,xy) — a
+// "cleaner" rewrite swaps channels and casts the whole image green.
+
+// ---- Per-game texture/sampler slot map: Borderlands 2 vs The Pre-Sequel ------------------------------
+// dgVoodoo maps each DX9 sampler sN 1:1 onto DX11 tN. BL2 and TPS run the same UE3 uber-post tonemap, but TPS
+// inserts a LightShaftTexture at slot 1, shifting bloom/vignette/LUT/DOF DOWN one slot (verified against
+// the two DX9 tonemaps: BL2 tonemap_0x54ED86A0 has LUT@s3/DOF@s4; TPS tps_tonemap_0xF8997849 has
+// lightshaft@s1, LUT@s4, DOF@s5). The grade math is identical, so the body below is SHARED verbatim — only
+// which register each named texture binds to changes, plus TPS's extra light-shaft composite term. The TPS
+// file (Tonemap_0xFCFE623E.ps_5_0.hlsl) #defines these macros then #includes this file; with them undefined
+// (BL2) every mapping is the identity = the original BL2 bindings, so BL2 is byte-for-byte unchanged.
+#ifndef TM_T_BLOOM
+#define TM_T_BLOOM     t1 // FilterColor1Texture (screen-blend bloom)
+#define TM_T_VIGNETTE  t2 // VignetteTexture
+#define TM_T_LUT       t3 // ColorGradingLUT (256x16, 16-slice)
+#define TM_T_DOF       t4 // LowResPostProcessBuffer (half-res DOF)
+#define TM_T_LUMABLOOM t5 // injected Luma HDR bloom (free slot on BL2)
+#define TM_S_BLOOM     s1
+#define TM_S_VIGNETTE  s2
+#define TM_S_LUT       s3
+#define TM_S_DOF       s4
+#endif
+
+Texture2D<float4> t0 : register(t0); // SceneColorTexture (fp16 HDR scene)
+#if TM_HAS_LIGHTSHAFT
+Texture2D<float4> t_lightshaft : register(TM_T_LIGHTSHAFT); // LightShaftTexture (TPS god rays) — slot 1
+#endif
+Texture2D<float4> t1 : register(TM_T_BLOOM);     // FilterColor1Texture (bloom)        BL2 t1 / TPS t2
+Texture2D<float4> t2 : register(TM_T_VIGNETTE);  // VignetteTexture                    BL2 t2 / TPS t3
+Texture2D<float4> t3 : register(TM_T_LUT);       // ColorGradingLUT (256x16, 16-slice) BL2 t3 / TPS t4
+Texture2D<float4> t4 : register(TM_T_DOF);       // LowResPostProcessBuffer (half-res DOF) BL2 t4 / TPS t5
+Texture2D<float4> t5 : register(TM_T_LUMABLOOM); // Luma HDR pyramidal bloom, bound by the mod when LumaBloomEnable (BL2 t5 / TPS t8 — TPS t5 is the native DOF)
+Texture2D<float4> t7 : register(t7);             // Half-res pre-blurred scene for the Luma Gaussian DoF, bound when it is active (free on both BL2/TPS)
+
+SamplerState s0_s : register(s0);
+SamplerState s1_s : register(TM_S_BLOOM);    // BL2 s1 / TPS s2
+SamplerState s2_s : register(TM_S_VIGNETTE); // BL2 s2 / TPS s3
+SamplerState s3_s : register(TM_S_LUT);      // BL2 s3 / TPS s4
+SamplerState s4_s : register(TM_S_DOF);      // BL2 s4 / TPS s5
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+#define BloomTintAndScreenBlendThreshold cb4[16] // c8
+#define ImageAdjustments2                cb4[17] // c9
+#define ImageAdjustments3                cb4[18] // c10
+#define HalfResMaskRect                  cb4[19] // c11
+#define DOFKernelSize                    cb4[20] // c12
+#define VignetteSettings                 cb4[21] // c13
+#define VignetteColor                    cb4[22] // c14
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0, // DOF radial/kernel coords (.zw)
+    float4 v6 : TEXCOORD1, // scene UV (.xy), half-res DOF UV (.zw)
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   float4 o;
+   float4 r0, r1, r2, r3;
+
+   // --- DOF: vanilla half-res Gaussian composite, OR Luma separable HDR Gaussian ---
+   // The game's depth/object DoF decision is baked into t4.a (the in-focus weight: 1 = sharp focused
+   // subject, 0.25 = max-blurred background; devkit clone confirmed it tracks the focused subject's
+   // silhouette). The Luma path KEEPS that decision — when the game turns DoF off, t4.a -> ~1 -> the blend
+   // weight -> 0 -> no blur, so cutscenes/scripted focus stay game-driven — but replaces the half-res
+   // Gaussian with a denser separable Gaussian of the prefiltered scene (t7), preserving HDR so bright
+   // defocused areas glow. DOFKernelSize.z/.w + v5.zw drive only the vanilla fallback below.
+   float2 sceneUV = v6.xy;
+   float2 dofUV = clamp(v6.zw, HalfResMaskRect.xy, HalfResMaskRect.zw);
+   float4 sceneTap = t0.SampleLevel(s0_s, sceneUV, 0);
+   float centerInFocus = t4.SampleLevel(s4_s, dofUV, 0).a; // 1 = sharp .. 0.25 = max blur
+
+   // Replicate the game's EXACT per-pixel DoF blend weight (radial DOF-kernel falloff, VERBATIM from the
+   // vanilla branch below, + the t4.a in-focus weight), then blend the blurred scene by it. The game blends
+   // only a fraction of its blurred buffer (sharpness >> t4.a alone), so matching this weight is what keeps
+   // the effect at vanilla strength instead of fully replacing the background. Without it it over-blurs.
+   float dofRadial = (v5.z * 2.0 - 1.0) * DOFKernelSize.z;
+   float radialSharp = 1.0 - saturate(dofRadial * dofRadial);
+   float blurWeight = 1.0 - saturate(radialSharp + centerInFocus); // 0 = sharp .. 1 = full vanilla blur
+
+   float dofType = LumaSettings.GameSettings.DOFType; // 0 = vanilla game Gaussian, 2 = Luma separable Gaussian
+   float3 hdr_color;
+   if (dofType < 0.5)
+   {
+      // --- vanilla DOF composite (verbatim) ---
+      r0.y = DOFKernelSize.w + v5.w;
+      r0.x = v5.z;
+      r0.xy = r0.xy * 2 + -1;
+      r0.xy = r0.xy * DOFKernelSize.z;
+      r0.x = saturate(dot(r0.x, r0.x) + 0);
+      r0.x = -r0.x + 1;
+      r0.yz = max(v6.xzww, HalfResMaskRect.xxyw).yz;
+      r1.xy = min(HalfResMaskRect.zw, r0.yz);
+      r1 = t4.Sample(s4_s, r1.xy);
+      r0.x = saturate(r0.x + r1.w);
+      r2 = float4(1, 1, 0, 0) * v6.xyxx;
+      r2 = t0.SampleLevel(s0_s, r2.xy, 0);
+      hdr_color = lerp(r1.xyz * 4, r2.rgb, r0.x);
+   }
+   else if (blurWeight <= 0.02)
+   {
+      hdr_color = sceneTap.rgb; // in-focus (both Luma modes) -> no blur; covers most of the screen (cheap)
+   }
+   else
+   {
+      // Luma separable Gaussian: t7 holds the pre-blurred half-res scene (dense H+V Gaussian on the prefilter),
+      // so this is a single smooth tap — no sparse gather, no jitter -> grain-free. Blend at the game's DoF
+      // strength (blurWeight). HDR is preserved, so bright defocused areas glow.
+      hdr_color = lerp(sceneTap.rgb, t7.SampleLevel(s0_s, sceneUV, 0).rgb, blurWeight);
+   }
+
+   // --- bloom ---
+   if (LumaSettings.GameSettings.LumaBloomEnable > 0.5)
+   {
+      // Luma HDR pyramidal bloom (t5, generated by the mod from the linear fp16 scene). Additive in linear so
+      // bright HDR sources glow proportionally (the game's bloom is UNORM-clamped + quarter-res single-level).
+      // v6.xy = the screen UV used for the scene sample above; s1_s is a linear sampler.
+      float3 lumaBloom = t5.SampleLevel(s1_s, v6.xy, 0).rgb;
+      hdr_color += lumaBloom * LumaSettings.GameSettings.BloomIntensity;
+   }
+   else
+   {
+      // Vanilla bloom (screen-blend gated by luminance, t1). BloomIntensity scales it (1 = vanilla).
+      r0.w = dot(hdr_color, float3(0.300000012, 0.589999974, 0.109999999));
+      r0.w = r0.w * -3;
+      r0.w = exp2(r0.w);
+      r0.w = saturate(r0.w * BloomTintAndScreenBlendThreshold.w);
+      r1 = t1.Sample(s1_s, v5.zw);
+      r1.xyz = r1.xyz * BloomTintAndScreenBlendThreshold.xyz;
+      r1.xyz = r1.xyz * 4;
+      hdr_color += r1.xyz * r0.w * LumaSettings.GameSettings.BloomIntensity;
+   }
+
+#if TM_HAS_LIGHTSHAFT
+   // Light shafts / god rays (TPS only). Vanilla TPS composites a separate low-res light-shaft buffer here,
+   // between bloom and the tonemap: an inverse-luminance gate (only adds into darker pixels), additive *4
+   // color, and a per-pixel attenuation in .a that scales the existing scene down where shafts occlude.
+   // Transcribed verbatim from the DX9 TPS tonemap (tps_tonemap_0xF8997849). BL2 has no such pass.
+   {
+      float lsGate = saturate(exp2(dot(hdr_color, float3(0.300000012, 0.589999974, 0.109999999)) * -3.0));
+      float4 ls = t_lightshaft.Sample(s0_s, v5.zw);
+      hdr_color = hdr_color * ls.w + (ls.xyz * 4.0) * lsGate;
+   }
+#endif
+
+   // User Exposure (scene-referred, pre-grade; 1 = vanilla). Applies to both SDR and HDR — the grade below tracks it.
+   hdr_color *= LumaSettings.GameSettings.Exposure;
+
+   // --- max-channel compress BEFORE grade+LUT (HDR only) ---
+   // tm = per-pixel uniform scale (<=1) that maps the brightest channel into [0,1] via a midgray-pinned Reinhard.
+   // One scale for all 3 channels => hue/chroma intact; brightest channel pinned <=1 => the saturate(line ~129) and
+   // the 16-slice LUT never clip. SDR mode leaves tm=1 so the grade runs on the raw scene exactly like vanilla.
+   float tm = 1.0;
+   if (LumaSettings.DisplayMode == 1)
+   {
+      float mx = max(hdr_color.r, max(hdr_color.g, hdr_color.b));
+      float mx_c = Reinhard::ReinhardScalable(mx, 1.0, 0.0, MidGray, MidGray);
+      tm = (mx > 1e-6) ? (mx_c / mx) : 1.0;
+   }
+   r0.xyz = hdr_color * tm;
+
+   // --- vignette (verbatim) ---
+   float3 vignette_color = r0.rgb;
+   r1.xyz = r0.xyz * VignetteColor.xyz;
+   r2.xyz = r0.xyz * -VignetteColor.xyz + r0.xyz;
+   r1.xyz = v6.y * r2.xyz + r1.xyz;
+   r2.xyz = r0.xyz * r1.xyz;
+   r1.xyz = r0.xyz * -r1.xyz + r0.xyz;
+   r3.xy = v6.xy + v6.xy;
+   r3 = t2.Sample(s2_s, r3.xy);
+   r0.w = saturate(r3.x + VignetteSettings.y);
+   r1.xyz = r0.w * r1.xyz + r2.xyz;
+   r2.y = 0.00999999978;
+   r0.w = r2.y + -VignetteSettings.x;
+   r0.xyz = (r0.w >= 0) ? r0.xyz : r1.xyz;
+   // User Vignette Intensity: lerp between the pre-vignette color and the vignetted result (1 = vanilla, 0 = none).
+   r0.xyz = lerp(vignette_color, r0.xyz, LumaSettings.GameSettings.VignetteIntensity);
+
+   // --- ImageAdjustments per-channel curve (verbatim; keep swizzles exactly) ---
+   r1 = r0.zzxy + -ImageAdjustments2.z;
+   r1 = saturate(r1 * 10000);
+   r2.xyz = r0.xyz + ImageAdjustments2.x;
+   r3.z = 1 / abs(r2.x);
+   r3.w = 1 / abs(r2.y);
+   r3.xy = 1 / abs(r2.z);
+   r2 = r0.zzxy * r3;
+   r0.xyz = r0.xyz * ImageAdjustments2.w;
+   r3.x = log2(r0.x);
+   r3.y = log2(r0.y);
+   r3.z = log2(r0.z);
+   r0.xyz = r3.xyz * 0.454545468;
+   r3.z = exp2(r0.x);
+   r3.w = exp2(r0.y);
+   r3.xy = exp2(r0.z);
+   r0 = r2.yyzw * ImageAdjustments2.y + -r3.yyzw;
+   r0 = r1 * r0 + r3;
+   r1 = r2 * ImageAdjustments2.y + -r0.yyzw;
+   r0 = saturate(ImageAdjustments3.x * r1 + r0);
+
+   // --- 16-slice ColorGradingLUT (verbatim trilinear; keep swizzles exactly) ---
+   // (Tetrahedral interpolation was measured against this on the live LUT: maxΔ 0.5/255, 0% visibly different — the
+   // LUT is near-linear between grid points so it gives no gain at +cost. Reverted to vanilla trilinear.)
+   r1.xyw = (r0.xwzz * float4(14.9998999, 0.9375, 0.9375, 0.05859375)).xyw;
+   r0.x = frac(r1.x);
+   r0.x = -r0.x + r1.x;
+   r1.x = r0.x * 0.0625 + r1.w;
+   r0.x = r0.y * 15 + -r0.x;
+   r1 = r1.xyxy + float4(0.001953125, 0.03125, 0.064453125, 0.03125);
+   r2 = t3.Sample(s3_s, r1.zw);
+   r1 = t3.Sample(s3_s, r1.xy);
+   r0.yzw = (-r1.xxyz + r2.xxyz).yzw;
+   o.xyz = r0.x * r0.yzw + r1.xyz;
+
+   // ====================== Luma HDR output (max-channel inverse) ======================
+   // o.rgb = the graded look the LUT produced. In HDR it is the grade of the COMPRESSED scene (hdr_color*tm);
+   // dividing by tm is the exact inverse -> recovers real HDR range with true hue+chroma (two bright pixels that
+   // both saturate the LUT are re-separated by /tm). In SDR tm was 1, so o.rgb is the vanilla grade of the raw scene.
+   float3 graded_sdr_gamma = o.rgb;
+   float3 sdr_lin = gamma_to_linear(graded_sdr_gamma, GCT_MIRROR);
+
+   const float paperWhite = LumaSettings.GamePaperWhiteNits / sRGB_WhiteLevelNits;
+   const float peakWhite = LumaSettings.PeakWhiteNits / sRGB_WhiteLevelNits;
+
+   float3 postProcessedColor;
+
+   if (LumaSettings.DisplayMode == 1) // HDR
+   {
+      float3 recovered = sdr_lin / max(tm, 1e-6); // exact inverse of the pre-grade compression -> HDR range (linear BT.709)
+
+      // Display rolloff to the user's peak/paper-white nits. DICE by-luminance preserves hue; the
+      // *_CORRECT_CHANNELS_BEYOND_PEAK_WHITE type additionally gamut-maps any single channel that rides past peak
+      // (e.g. saturated blues) back under it (fleet default).
+      // DICE takes/returns linear BT.709 and processes internally in BT.2020 (its defaults), so feed BT.709
+      // directly: do NOT round-trip primaries by hand. (With type 1 the manual 709<->2020 cancelled because the
+      // luminance compress is a pure scalar; the corrected type's per-channel gamut map breaks that cancellation.)
+      DICESettings settings = DefaultDICESettings(DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE);
+      float3 hdr = DICETonemap(recovered * paperWhite, peakWhite, settings) / paperWhite;
+
+      // --- User HDR grade (HDR display path only; defaults are vanilla no-ops) ---
+      // Highlight desaturation: bright sources fade toward white as luminance approaches peak (eye/sensor
+      // saturation). exponent in [1,0.05] keeps mid-tones colored; only luminance->peak whitens.
+      const float highlightDechroma = LumaSettings.GameSettings.HighlightDechroma;
+      if (highlightDechroma > 0.0)
+      {
+         float dcExp = lerp(1.0, 0.05, highlightDechroma);
+         float dcWeight = saturate(pow(saturate(GetLuminance(hdr) / peakWhite), dcExp));
+         hdr = Saturation(hdr, 1.0 - dcWeight);
+      }
+      hdr = Saturation(hdr, LumaSettings.GameSettings.Saturation); // user Saturation (Oklab; 1 = vanilla)
+      // user Contrast: slope around 18% mid-gray (linear, 1.0 = paper white). Excursions caught by the NaN/clamp tail.
+      const float midGray = 0.18;
+      hdr = (hdr - midGray) * LumaSettings.GameSettings.Contrast + midGray;
+
+      postProcessedColor = hdr;
+   }
+   else // SDR (still presented through the scRGB swapchain) — sdr_lin is the vanilla grade (tm was 1)
+   {
+      postProcessedColor = sdr_lin;
+   }
+
+#if UI_DRAW_TYPE >= 2
+   // Pre-scale so the gamma-SDR HUD drawn on top (not pre-scaled) lands at UIPaperWhite after the composition
+   // rescales the buffer by it; the scene then lands at GamePaperWhite. Gives the HUD its own paper white.
+   postProcessedColor *= LumaSettings.GamePaperWhiteNits / max(LumaSettings.UIPaperWhiteNits, 1.0);
+#endif
+
+   // Sanitize (inverse divide + DICE + gamma encode can emit NaN/negatives -> garbage on the swapchain).
+   postProcessedColor = (postProcessedColor == postProcessedColor) ? postProcessedColor : 0.0; // NaN -> 0
+   postProcessedColor = max(0.0, postProcessedColor);
+
+   postProcessedColor = linear_to_gamma(postProcessedColor, GCT_MIRROR);
+
+   // Sub-perceptual animated triangular dither (9-bit, gamma space) vs gradient banding from the HDR expansion +
+   // 10-bit PQ encode. HDR only, runtime toggle (GameSettings.Dithering), FrameIndex animates it. Runs before
+   // SMAA but ~1/511 noise is below SMAA's 0.05 edge threshold -> no spawned edges / RCAS amplification.
+   if (LumaSettings.DisplayMode == 1 && LumaSettings.GameSettings.Dithering > 0.5)
+      ApplyDithering(postProcessedColor, v6.xy, true, 1.0, DITHERING_BIT_DEPTH, LumaSettings.FrameIndex, true);
+
+   o0.rgb = postProcessedColor;
+   o0.a = 0; // vanilla wrote o.w = 0
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Tonemap_0xFCFE623E.ps_5_0.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Tonemap_0xFCFE623E.ps_5_0.hlsl
@@ -1,0 +1,24 @@
+// Borderlands: The Pre-Sequel — tonemap / HDR injection point (dgVoodoo->DX11 hash 0xFCFE623E).
+// TPS runs the SAME UE3/Gearbox uber-post tonemap as Borderlands 2, but its native shader
+// (tps_tonemap_0xF8997849) inserts a LightShaftTexture at sampler slot 1, which shifts bloom/vignette/LUT/DOF
+// DOWN one slot vs BL2 (the DX9 BL2 tonemap_0x54ED86A0 has LUT@s3/DOF@s4; TPS has lightshaft@s1, LUT@s4,
+// DOF@s5). dgVoodoo maps DX9 sN 1:1 onto DX11 tN, so the same shift lands in the DX11 register space Luma
+// sees. Reusing the BL2 bindings verbatim made the grade sample the Vignette texture as the LUT (grayscale /
+// black-and-white) and the LUT as the DOF buffer (broken DoF) — hence the dedicated slot map below.
+//
+// The grade MATH is identical between the two games, so we set the slot-map + light-shaft macros here and
+// pull in the shared BL2 body (one source of truth; matched/replaced by the 0x<HASH> in this filename).
+// Injected Luma bloom moves to t8 because TPS's native DOF occupies t5; the Gaussian DoF prefilter (t7)
+// stays put — free on TPS. The mod binds Luma bloom at t8 when it detects this tonemap hash.
+#define TM_HAS_LIGHTSHAFT 1
+#define TM_T_LIGHTSHAFT   t1 // LightShaftTexture (god rays) — TPS-only, inserted at slot 1
+#define TM_T_BLOOM        t2 // FilterColor1Texture (screen-blend bloom)
+#define TM_T_VIGNETTE     t3 // VignetteTexture
+#define TM_T_LUT          t4 // ColorGradingLUT (256x16, 16-slice)
+#define TM_T_DOF          t5 // LowResPostProcessBuffer (half-res DOF)
+#define TM_T_LUMABLOOM    t8 // injected Luma HDR bloom (t5 is the native DOF on TPS — bind higher to avoid the clash)
+#define TM_S_BLOOM        s2
+#define TM_S_VIGNETTE     s3
+#define TM_S_LUT          s4
+#define TM_S_DOF          s5
+#include "Tonemap_0xD00AA2A7.ps_5_0.hlsl"

--- a/Shaders/Borderlands 2 and The Pre-Sequel/UIEmissive_0xC84956AA.ps_5_0.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/UIEmissive_0xC84956AA.ps_5_0.hlsl
@@ -1,0 +1,95 @@
+// Borderlands 2 / The Pre-Sequel — Scaleform emissive HUD sprite (e.g. the autosave/saving icon).
+//
+// This HUD shader allows an emissive overshoot: o0 = min(color, 4) * vertexColor.w + vertexColor.xyz, so its
+// output can exceed 1.0 (the autosave icon pulses with a >1 glow). Vanilla rendered to an 8-bit UNORM backbuffer
+// which clamped that to white for free; Luma upgrades the LDR to fp16, so the overshoot SURVIVES. It draws POST-
+// tonemap (after DICE), so it bypasses the HDR display rolloff and the composition's paper-white scale pushes the
+// unclamped value past peak -> the icon blows to ~10000 nits, ignoring the user's Peak setting.
+//
+// Fix: re-add the vanilla 8-bit clamp dgVoodoo dropped (saturate the output) so the icon lands at UI paper white
+// like the rest of the HUD. Body transcribed VERBATIM from the live dgVoodoo->ps_5_0 disasm of 0xC84956AA; the
+// cb3 and/or pairs are dgVoodoo's texture-format bit emulation (mask+set), kept exactly via asint.
+
+Texture2D<float4> t0 : register(t0);
+Texture2D<float4> t1 : register(t1);
+Texture2D<float4> t2 : register(t2);
+Texture2D<float4> t3 : register(t3);
+
+SamplerState s0_s : register(s0);
+SamplerState s1_s : register(s1);
+SamplerState s2_s : register(s2);
+SamplerState s3_s : register(s3);
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+#define cmp -
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0,
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   float4 r0, r1, r2, r3;
+
+   r0.xy = v5.xy + cb4[18].xy;
+   r0.xyzw = t3.Sample(s3_s, r0.xy).xyzw;
+   r0.xyzw = asfloat((asuint(r0.xyzw) & asuint(cb3[50].xyzw)) | asuint(cb3[51].xyzw));
+   r0.yz = v5.xy + cb4[17].xy;
+   r1.xyzw = t3.Sample(s3_s, r0.yz).xyzw;
+   r1.xyzw = asfloat((asuint(r1.xyzw) & asuint(cb3[50].xyzw)) | asuint(cb3[51].xyzw));
+   r2.xyzw = t2.Sample(s2_s, r0.yz).xyzw;
+   r2.xyzw = asfloat((asuint(r2.xyzw) & asuint(cb3[48].xyzw)) | asuint(cb3[49].xyzw));
+   r0.yzw = float3(1, 1, 1) + -r2.xyz;
+   r0.x = r1.x * r0.x;
+   r0.x = 10 * r0.x;
+   r3.x = log2(abs(r0.x));
+   r3.x = cb4[19].z * r3.x;
+   r3.y = cmp(r3.x != r3.x);
+   r3.x = r3.y ? 0 : r3.x;
+   r1.x = exp2(r3.x);
+   r0.x = -9.99999997e-007 + abs(r0.x);
+   r2.xyzw = t0.Sample(s0_s, v5.xy).xyzw;
+   r2.xyzw = asfloat((asuint(r2.xyzw) & asuint(cb3[44].xyzw)) | asuint(cb3[45].xyzw));
+   r1.yzw = float3(1, 1.39999998, 3) * r2.yzx;
+   r1.x = r1.x * r1.w;
+   r1.x = cb4[19].w * r1.x;
+   r3.w = cmp(r0.x >= 0);
+   o0.w = r3.w ? r1.x : 0;
+   r2.xyzw = t1.Sample(s1_s, v5.xy).xyzw;
+   r2.xyzw = asfloat((asuint(r2.xyzw) & asuint(cb3[46].xyzw)) | asuint(cb3[47].xyzw));
+   r1.yz = r2.yz * r1.yz;
+   r1.x = 0;
+   r1.xyz = float3(6, 6, 6) * r1.xyz;
+   r2.xyzw = t2.Sample(s2_s, v5.xy).xyzw;
+   r2.xyzw = asfloat((asuint(r2.xyzw) & asuint(cb3[48].xyzw)) | asuint(cb3[49].xyzw));
+   r0.x = 1 + -r2.y;
+   r0.xyz = r0.xxx * r0.yzw;
+   r2.xyz = r0.xyz * float3(0, 10, 12) + -r1.xyz;
+   r0.xyz = r0.xyz * r2.xyz + r1.xyz;
+   r0.xyz = cb4[16].xyz + r0.xyz;
+   r1.xyz = min(float3(4, 4, 4), r0.xyz);
+   o0.xyz = r1.xyz * v12.www + v12.xyz;
+
+   // Vanilla relied on the 8-bit UNORM backbuffer to clamp this emissive HUD output; the fp16 LDR doesn't, so the
+   // autosave icon's >1 glow escapes to peak nits. Re-add the clamp -> icon caps at UI paper white like other HUD.
+   o0 = saturate(o0);
+   return;
+}

--- a/Shaders/Borderlands 2 and The Pre-Sequel/Video_0xE41621CF.ps_5_0.hlsl
+++ b/Shaders/Borderlands 2 and The Pre-Sequel/Video_0xE41621CF.ps_5_0.hlsl
@@ -1,0 +1,89 @@
+// Borderlands 2 — Bink intro/cutscene video (YUV->RGB) pass. SDR clamp + light AutoHDR for HDR.
+//
+// BL2's pre-rendered movies (2K/Gearbox/Unreal boot logos, story FMVs) decode to 3 YUV planes (Y=t0, U=t1,
+// V=t2) and a fullscreen quad converts them to RGB straight onto the swapchain — bypassing the scene tonemap
+// (0xD00AA2A7). On Luma's fp16 scRGB swapchain that SDR output would sit flat at paper white. So: restore the
+// vanilla clamp, then apply a LIGHT PumboAutoHDR so movies gain a little highlight pop in HDR.
+//
+// Body transcribed VERBATIM from the live dgVoodoo->ps_5_0 disasm of 0xE41621CF (maps the DX9 video shader
+// 0x33244F80: tor/tog/tob/consts c0..c3 -> cb4[8..11], same cb4[N+8] mapping as the tonemap). The cb3 and/or
+// pairs are dgVoodoo's texture-format bit emulation (mask+set), kept exactly via asuint/asfloat.
+// NOTE: dgVoodoo dropped the SM3 `saturate(o)` (the vanilla 8-bit UNORM backbuffer clamped for free); the fp16
+// swapchain does not, so we re-add it before the AutoHDR (kills YUV overshoot + negatives).
+
+#include "../Includes/Common.hlsl"
+
+// Light AutoHDR on videos (0 = off -> flat SDR at paper white). Peak kept low on purpose (Bink is low-bitrate;
+// pushing peak amplifies block/compression artifacts in highlights). PumboAutoHDR self-noops in SDR (peak==paper).
+#ifndef ENABLE_VIDEO_AUTO_HDR
+#define ENABLE_VIDEO_AUTO_HDR 1
+#endif
+#ifndef VIDEO_AUTO_HDR_PEAK_NITS
+#define VIDEO_AUTO_HDR_PEAK_NITS 250.0
+#endif
+
+Texture2D<float4> t0 : register(t0); // Y plane
+Texture2D<float4> t1 : register(t1); // U plane
+Texture2D<float4> t2 : register(t2); // V plane
+
+SamplerState s0_s : register(s0);
+SamplerState s1_s : register(s1);
+SamplerState s2_s : register(s2);
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0, // movie UV (only .xy used)
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   float4 r0, r1;
+
+   // --- YUV plane fetch + dgVoodoo format-emulation mask (verbatim) ---
+   r0 = t0.Sample(s0_s, v5.xy);
+   r0 = asfloat((asuint(r0) & asuint(cb3[44])) | asuint(cb3[45]));
+   r1 = t1.Sample(s1_s, v5.xy);
+   r1 = asfloat((asuint(r1) & asuint(cb3[46])) | asuint(cb3[47]));
+   r0.y = r1.x;
+   r1 = t2.Sample(s2_s, v5.xy);
+   r1 = asfloat((asuint(r1) & asuint(cb3[48])) | asuint(cb3[49]));
+   r0.z = r1.x;
+   r0.w = cb4[11].x;
+
+   // --- YUV -> RGB matrix (verbatim: c0/c1/c2 = tor/tog/tob -> cb4[8..10], consts -> cb4[11]) ---
+   o0.x = dot(cb4[8], r0);
+   o0.y = dot(cb4[9], r0);
+   o0.z = dot(cb4[10], r0);
+   o0.w = cb4[11].w; // vanilla alpha
+
+   // --- restore vanilla 8-bit clamp, then light AutoHDR ---
+   o0.rgb = saturate(o0.rgb);
+   float3 lin = gamma_to_linear(o0.rgb);
+#if ENABLE_VIDEO_AUTO_HDR
+   lin = PumboAutoHDR(lin, VIDEO_AUTO_HDR_PEAK_NITS, LumaSettings.GamePaperWhiteNits);
+#endif
+#if UI_DRAW_TYPE >= 2
+   // Match the tonemap's linear pre-scale: land movies at the same brightness as in-game after the
+   // composition's UIPaperWhite rescale (when UIPaperWhite != GamePaperWhite).
+   lin *= LumaSettings.GamePaperWhiteNits / max(LumaSettings.UIPaperWhiteNits, 1.0);
+#endif
+   o0.rgb = linear_to_gamma(lin); // re-encode for the gamma post buffer the composition expects
+}

--- a/Source/Games/Borderlands 2 and The Pre-Sequel/Borderlands 2 and The Pre-Sequel.vcxproj
+++ b/Source/Games/Borderlands 2 and The Pre-Sequel/Borderlands 2 and The Pre-Sequel.vcxproj
@@ -1,0 +1,317 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Development-Debug|Win32">
+      <Configuration>Development-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Release|Win32">
+      <Configuration>Development-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Publishing-Release|Win32">
+      <Configuration>Publishing-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Test-Release|Win32">
+      <Configuration>Test-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{56b56cad-a792-42a8-b7cd-7cfe9ff7d402}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Platform>x64</Platform>
+    <ProjectName>Borderlands 2 and The Pre-Sequel</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgTriplet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">true</GenerateManifest>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>false</VcpkgEnableManifest>
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'" Label="Vcpkg" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_DEBUG;_WINDOWS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_BORDERLANDS2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_BORDERLANDS2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;TEST=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_BORDERLANDS2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_BORDERLANDS2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_BORDERLANDS_PRESEQUEL_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Games/Borderlands 2 and The Pre-Sequel/Borderlands 2 and The Pre-Sequel.vcxproj.filters
+++ b/Source/Games/Borderlands 2 and The Pre-Sequel/Borderlands 2 and The Pre-Sequel.vcxproj.filters
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+  </ItemGroup>
+</Project>

--- a/Source/Games/Borderlands 2 and The Pre-Sequel/main.cpp
+++ b/Source/Games/Borderlands 2 and The Pre-Sequel/main.cpp
@@ -1,0 +1,1013 @@
+// Borderlands 2 + The Pre-Sequel — Luma HDR + SMAA mod (Unreal Engine 3, native DX9 -> D3D11 via dgVoodoo2).
+//
+// DX9 game, DX11-only Luma -> dgVoodoo2 translates SM3.0 to ps_5_0, so CSO hashes differ from the native DX9 ones
+// (re-dumped via devkit). Launch the game exe DIRECTLY: the XNA Launcher.exe also loads d3d9 and would capture
+// ReShade instead of the game. One shared addon serves both games (tonemap hash = discriminator).
+//
+// Pipeline (devkit-verified, see NOTES.md):
+// - TONEMAP PS 0xD00AA2A7 (BL2) / 0xFCFE623E (TPS): scene fp16 + bloom + vignette + LUT + DOF -> 8-bit LDR.
+//   Replaced to recover HDR (DICE + paper-white); UI composites AFTER, on the LDR.
+// - FXAA PS 0x0D3001F6 (only when in-game AA on) -> replaced with SMAA ULTRA + optional RCAS.
+//
+// All SDR/gamma space. One HDR mod owns the swapchain -> only ONE Luma .addon, dgVoodoo & ReShade both 32-bit
+// (other ReShade addons that also hook the swapchain crash via dgVoodoo -> keep disabled in normal use).
+
+// Don't pop the DEVELOPMENT auto-debugger MessageBox on DLL attach: under a borderless/fullscreen game it's
+// invisible and blocks the loader (ReShade times out the addon load -> error 1114).
+#define DISABLE_AUTO_DEBUGGER 1
+
+#define ENABLE_NGX 0 // no DLSS/DLAA: UE3 has no usable motion vectors, and NGX is x64-only (game is 32-bit)
+#define ENABLE_FIDELITY_SK 0
+#define GEOMETRY_SHADER_SUPPORT 0
+#define ENABLE_SMAA 1  // replaces the FXAA resolve PS with SMAA ULTRA (+RCAS); core auto-registers the 6 "SMAA ..." passes from Luma_SMAA_impl
+#define ENABLE_BLOOM 1 // core auto-registers the Bloom VS/Prefilter/Downsample/Upsample passes -> Luma_Bloom_impl
+// SMAA runs POST-tonemap (on the LDR output) via the post-draw callback, so it can't perturb the game's DoF
+// (composited INSIDE the tonemap). Needs original_draw_dispatch_func non-null.
+#define ENABLE_POST_DRAW_DISPATCH_CALLBACK 1
+
+#include "..\..\Core\core.hpp"
+#include <shellapi.h> // ShellExecuteA for About links (system("start ...") hangs the render thread in exclusive fullscreen)
+
+// FXAA resolve PS (only present when AA is enabled in the game's video settings) — replaced with SMAA. RE in NOTES.
+static constexpr uint32_t kFXAAResolveHash = 0x0D3001F6;
+static constexpr uint32_t kTonemapHash = 0xD00AA2A7;    // BL2: writes the LDR buffer the HUD then draws onto
+static constexpr uint32_t kTonemapHashTPS = 0xFCFE623E; // The Pre-Sequel: same engine, different tonemap CSO (one addon serves both)
+
+// Luma-injected SRV slots on the tonemap. These MUST match the shader register macros in
+// Tonemap_0xD00AA2A7.ps_5_0.hlsl (BL2) + Tonemap_0xFCFE623E.ps_5_0.hlsl (TPS) — there is no compile-time link,
+// so keep them in sync if a slot is ever re-RE'd:
+//   bloom -> TM_T_LUMABLOOM : BL2 t5 / TPS t8 (TPS t5 is the native DOF)
+//   DoF   -> register(t7)   : t7 on both (free on BL2 & TPS)
+static constexpr uint32_t kLumaBloomSlotBL2 = 5;
+static constexpr uint32_t kLumaBloomSlotTPS = 8;
+static constexpr uint32_t kLumaDoFSlot = 7;
+
+// User settings (persisted via ReShade config under the project name; loaded in LoadConfigs).
+static bool g_smaa_enable = true;
+static float g_rcas_sharpness = 0.f;                                   // RCAS sharpen on SMAA output (0 = off)
+static bool g_hide_ui = false;                                         // hide the game's HUD (for clean screenshots)
+static bool g_smaa_predication = true;                                 // SMAA depth predication (depth from scene-color .a)
+static float g_smaa_pred_k = 1000.f;                                   // predication depth compress (world units): D=z/(z+k); k=1000 measured optimum (~100% far-silhouette recall, ~0% flat false-fire @4K; plateau past 1000)
+static bool g_luma_bloom_enable = true;                                // replace the game's clamped bloom with Luma HDR pyramidal bloom (live toggle)
+static int g_bloom_nmips = 6;                                          // bloom pyramid mip count
+static float g_bloom_sigmas[6] = {1.5f, 2.0f, 2.0f, 2.0f, 1.0f, 1.0f}; // per-mip Gaussian sigma (tapered, wider middle for a soft natural halo)
+static int g_dof_type = 2;                                             // DoF path (live): 0 = vanilla game DoF, 2 = Luma separable Gaussian (default, UI checkbox)
+static float g_dof_radius = 9.f;                                       // DoF strength (full-res px @ 4K Gaussian blur extent). Default, users tune
+
+struct Borderlands2GameDeviceData final : public GameDeviceData
+{
+
+   // SMAA metrics CB (b1) = (1/w,1/h,w,h) + (predication scale,0,0,0); scale 2.0 when predication on, else 1.0.
+   ComPtr<ID3D11Buffer> cb_smaa_metrics;
+   uint32_t smaa_metrics_w = 0, smaa_metrics_h = 0;
+
+   uint32_t smaa_core_w = 0, smaa_core_h = 0;
+
+   // SMAA scratch. tex_input = SRV snapshot of the LDR (it's already gamma, fed to both DrawSMAA color args directly).
+   ComPtr<ID3D11Texture2D> tex_input;
+   ComPtr<ID3D11ShaderResourceView> srv_input;
+   uint32_t smaa_temps_w = 0, smaa_temps_h = 0;
+
+   // SMAA output temp (SRV+RTV). Copied back into the LDR (or via RCAS first).
+   ComPtr<ID3D11Texture2D> tex_smaa_out;
+   ComPtr<ID3D11RenderTargetView> tex_smaa_out_rtv;
+   ComPtr<ID3D11ShaderResourceView> tex_smaa_out_srv;
+   uint32_t smaa_out_w = 0, smaa_out_h = 0;
+
+   // RCAS sharpen CB (b0) = (w,h,sharpness,0) + output temp (fp16, RTV).
+   ComPtr<ID3D11Buffer> cb_sharpen;
+   uint32_t sharpen_w = 0, sharpen_h = 0;
+   float sharpen_amount = -1.f;
+   ComPtr<ID3D11Texture2D> tex_rcas_out;
+   ComPtr<ID3D11RenderTargetView> tex_rcas_out_rtv;
+   uint32_t rcas_out_w = 0, rcas_out_h = 0;
+
+   // Resource the tonemap (0xD00AA2A7) renders to; on BL2 the HUD draws onto it afterwards. Used by Hide UI.
+   uint64_t ldr_buffer_handle = 0;
+   // Set when the tonemap runs, cleared every Present: scopes Hide UI's alpha-blend skip to the post-tonemap
+   // span of THIS frame (so next frame's pre-tonemap transparents aren't dropped). See the Hide HUD block.
+   bool tonemap_fired_this_frame = false;
+
+   // SMAA depth predication. Scene-color SRV (depth packed in .a) captured at the tonemap, + a normalized
+   // single-channel (R16F) predication depth produced by the BL2TPS Depth Extract CS.
+   ComPtr<ID3D11ShaderResourceView> srv_scene_depth;
+   ComPtr<ID3D11Texture2D> tex_pred;
+   ComPtr<ID3D11UnorderedAccessView> uav_pred;
+   ComPtr<ID3D11ShaderResourceView> srv_pred;
+   uint32_t pred_w = 0, pred_h = 0;
+   ComPtr<ID3D11Buffer> cb_pred;
+   float pred_k = -1.f;
+   float smaa_metrics_pred_scale = -1.f; // recreate the metrics CB when predication turns on/off
+
+   // Luma HDR pyramidal bloom output (linear fp16), generated at the tonemap from the scene SRV, bound to PS t5 (BL2) / t8 (TPS).
+   ComPtr<ID3D11ShaderResourceView> srv_luma_bloom;
+
+   // Half-res Karis-prefiltered scene for the Gaussian DoF blur (area-averaged source -> no under-sampling
+   // grain on sharp/bright detail). Cached per render resolution, bound at tonemap PS t7.
+   ComPtr<ID3D11Texture2D> tex_dof_prefilter; // RGBA16F
+   ComPtr<ID3D11ShaderResourceView> srv_dof_prefilter;
+   ComPtr<ID3D11UnorderedAccessView> uav_dof_prefilter;
+   uint32_t dof_pf_w = 0, dof_pf_h = 0;
+
+   // "Luma Gaussian" DoF: separable blur of the half-res prefilter (H -> blur_h, V -> blur_out). blur_out is
+   // bound at tonemap PS t7 in Gaussian mode. Cached per render resolution; CBs recreated when the radius changes.
+   ComPtr<ID3D11Texture2D> tex_dof_blur_h, tex_dof_blur_out; // RGBA16F, half render resolution
+   ComPtr<ID3D11ShaderResourceView> srv_dof_blur_h, srv_dof_blur_out;
+   ComPtr<ID3D11UnorderedAccessView> uav_dof_blur_h, uav_dof_blur_out;
+   ComPtr<ID3D11Buffer> cb_dof_blur_h, cb_dof_blur_v; // cb_dof_blur (b0): axis-step + sigma, per pass
+   float dof_blur_radius = -1.f;                      // recreate the CBs when the DoF Radius slider changes
+};
+
+class Borderlands2 final : public Game
+{
+   static Borderlands2GameDeviceData& GetGameDeviceData(DeviceData& device_data)
+   {
+      return *static_cast<Borderlands2GameDeviceData*>(device_data.game);
+   }
+
+   static bool CreateImmutableCB(ID3D11Device* device, const void* data, UINT size, ComPtr<ID3D11Buffer>& out)
+   {
+      out.reset();
+      D3D11_BUFFER_DESC bd = {};
+      bd.ByteWidth = size;
+      bd.Usage = D3D11_USAGE_IMMUTABLE;
+      bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+      D3D11_SUBRESOURCE_DATA sd = {};
+      sd.pSysMem = data;
+      return SUCCEEDED(device->CreateBuffer(&bd, &sd, out.put()));
+   }
+
+   // Default-pool 2D texture. Format defaults to fp16 (bloom/scene callers); pass the live LDR 8-bit format for
+   // SMAA color temps, since CopyResource requires identical formats.
+   static bool CreateDefaultTex(ID3D11Device* device, uint32_t w, uint32_t h, UINT bind_flags, ComPtr<ID3D11Texture2D>& out, DXGI_FORMAT format = DXGI_FORMAT_R16G16B16A16_FLOAT)
+   {
+      out.reset();
+      D3D11_TEXTURE2D_DESC td = {};
+      td.Width = w;
+      td.Height = h;
+      td.MipLevels = 1;
+      td.ArraySize = 1;
+      td.Format = format;
+      td.SampleDesc.Count = 1;
+      td.Usage = D3D11_USAGE_DEFAULT;
+      td.BindFlags = bind_flags;
+      return SUCCEEDED(device->CreateTexture2D(&td, nullptr, out.put()));
+   }
+
+#if ENABLE_SMAA
+   // Post-tonemap SMAA on the LDR (gamma space). Runs AFTER the tonemap so it can't perturb the DoF (composited
+   // inside the tonemap; vanilla == SMAA-off, devkit-verified). Snapshot LDR -> SRV (already gamma; fed to both
+   // DrawSMAA color args, no color-prep) -> DrawSMAA -> optional RCAS -> copy back into the LDR. No-op if not ready.
+   void RunPostTonemapSMAA(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, DeviceData& device_data, Borderlands2GameDeviceData& gd, ID3D11Resource* ldr_res)
+   {
+      uint4 cinfo{};
+      DXGI_FORMAT cfmt = DXGI_FORMAT_UNKNOWN;
+      GetResourceInfo(ldr_res, cinfo, cfmt);
+      uint32_t w = cinfo.x, h = cinfo.y;
+      if (w == 0 || h == 0 || (uint32_t)cfmt == (uint32_t)DXGI_FORMAT_UNKNOWN)
+      {
+         return;
+      }
+
+      // Shader-readiness gate (async loader / dev live-reload): skip SMAA this frame if anything is missing.
+      const bool smaa_ready =
+         device_data.native_pixel_shaders[CompileTimeStringHash("SMAA Edge Detection PS")].get() != nullptr &&
+         device_data.native_pixel_shaders[CompileTimeStringHash("SMAA Blending Weight Calculation PS")].get() != nullptr &&
+         device_data.native_pixel_shaders[CompileTimeStringHash("SMAA Neighborhood Blending PS")].get() != nullptr &&
+         device_data.native_vertex_shaders[CompileTimeStringHash("SMAA Edge Detection VS")].get() != nullptr &&
+         device_data.native_vertex_shaders[CompileTimeStringHash("SMAA Blending Weight Calculation VS")].get() != nullptr &&
+         device_data.native_vertex_shaders[CompileTimeStringHash("SMAA Neighborhood Blending VS")].get() != nullptr;
+      if (!smaa_ready)
+      {
+         return;
+      }
+
+      // Drop DrawSMAA's core-managed intermediates on resolution change so they recreate at the new size.
+      if (gd.smaa_core_w != w || gd.smaa_core_h != h)
+      {
+         auto& mr = device_data.managed_resources;
+         mr.depth_stencil_views[CompileTimeStringHash("smaa_dsv")].reset();
+         mr.render_target_views[CompileTimeStringHash("smaa_edge_detection")].reset();
+         mr.render_target_views[CompileTimeStringHash("smaa_blending_weight_calculation")].reset();
+         gd.smaa_core_w = w;
+         gd.smaa_core_h = h;
+      }
+
+      // SMAA depth predication: normalized-depth from the captured scene-color SRV (.a). Plain ULTRA fallback when
+      // any input is missing (never scale 2.0 with a null texture).
+      const bool pred_cs_ready = device_data.native_compute_shaders[CompileTimeStringHash("BL2TPS Depth Extract CS")].get() != nullptr;
+      bool pred_ok = g_smaa_predication && gd.srv_scene_depth && pred_cs_ready;
+      if (pred_ok)
+      {
+         if (!gd.cb_pred || gd.pred_k != g_smaa_pred_k)
+         {
+            const float p[4] = {g_smaa_pred_k, 0.f, 0.f, 0.f};
+            if (CreateImmutableCB(native_device, p, sizeof(p), gd.cb_pred))
+               gd.pred_k = g_smaa_pred_k;
+         }
+         if (!gd.tex_pred || gd.pred_w != w || gd.pred_h != h)
+         {
+            gd.uav_pred.reset();
+            gd.srv_pred.reset();
+            gd.tex_pred.reset();
+            if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS, gd.tex_pred, DXGI_FORMAT_R16_FLOAT))
+            {
+               native_device->CreateUnorderedAccessView(gd.tex_pred.get(), nullptr, gd.uav_pred.put());
+               native_device->CreateShaderResourceView(gd.tex_pred.get(), nullptr, gd.srv_pred.put());
+               gd.pred_w = w;
+               gd.pred_h = h;
+            }
+         }
+         pred_ok = gd.cb_pred && gd.uav_pred && gd.srv_pred;
+      }
+
+      // Metrics CB: predication scale 2.0 when active, else 1.0. Recreate on resolution or predication flip.
+      const float pred_scale = pred_ok ? 2.0f : 1.0f;
+      if (!gd.cb_smaa_metrics || gd.smaa_metrics_w != w || gd.smaa_metrics_h != h || gd.smaa_metrics_pred_scale != pred_scale)
+      {
+         const float metrics[8] = {1.f / (float)w, 1.f / (float)h, (float)w, (float)h, pred_scale, 0.f, 0.f, 0.f};
+         if (CreateImmutableCB(native_device, metrics, sizeof(metrics), gd.cb_smaa_metrics))
+         {
+            gd.smaa_metrics_w = w;
+            gd.smaa_metrics_h = h;
+            gd.smaa_metrics_pred_scale = pred_scale;
+         }
+      }
+      if (!gd.cb_smaa_metrics)
+         return;
+
+      // SMAA output temp (LDR format, SRV+RTV).
+      if (!gd.tex_smaa_out || gd.smaa_out_w != w || gd.smaa_out_h != h)
+      {
+         gd.tex_smaa_out_rtv.reset();
+         gd.tex_smaa_out_srv.reset();
+         gd.tex_smaa_out.reset();
+         if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, gd.tex_smaa_out, cfmt))
+         {
+            native_device->CreateRenderTargetView(gd.tex_smaa_out.get(), nullptr, gd.tex_smaa_out_rtv.put());
+            native_device->CreateShaderResourceView(gd.tex_smaa_out.get(), nullptr, gd.tex_smaa_out_srv.put());
+            gd.smaa_out_w = w;
+            gd.smaa_out_h = h;
+         }
+      }
+      if (!gd.tex_smaa_out_rtv || !gd.tex_smaa_out_srv)
+         return;
+
+      // tex_input = SRV-readable temp for the LDR (already gamma -> feeds both DrawSMAA color args, no color-prep).
+      if (!gd.tex_input || gd.smaa_temps_w != w || gd.smaa_temps_h != h)
+      {
+         gd.srv_input.reset();
+         gd.tex_input.reset();
+         if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE, gd.tex_input, cfmt))
+         {
+            native_device->CreateShaderResourceView(gd.tex_input.get(), nullptr, gd.srv_input.put());
+            gd.smaa_temps_w = w;
+            gd.smaa_temps_h = h;
+         }
+      }
+      if (!gd.srv_input)
+         return;
+
+      // Snapshot the LDR color into an SRV-readable temp (LDR is both the SMAA input and the write-back target).
+      native_device_context->CopyResource(gd.tex_input.get(), ldr_res);
+
+      // Predication depth extract: scene-color .a -> normalized R16F (gd.tex_pred). Independent of the LDR snapshot.
+      if (pred_ok)
+      {
+         DrawStateStack<DrawStateStackType::Compute> pred_cs_state;
+         pred_cs_state.Cache(native_device_context, device_data.uav_max_count);
+
+         ID3D11ShaderResourceView* ps_srv = gd.srv_scene_depth.get();
+         ID3D11UnorderedAccessView* ps_uav = gd.uav_pred.get();
+         ID3D11Buffer* ps_cb = gd.cb_pred.get();
+         native_device_context->CSSetShaderResources(0, 1, &ps_srv);
+         native_device_context->CSSetUnorderedAccessViews(0, 1, &ps_uav, nullptr);
+         native_device_context->CSSetConstantBuffers(0, 1, &ps_cb);
+         native_device_context->CSSetShader(device_data.native_compute_shaders[CompileTimeStringHash("BL2TPS Depth Extract CS")].get(), nullptr, 0);
+         native_device_context->Dispatch((w + 7) / 8, (h + 7) / 8, 1);
+
+         pred_cs_state.Restore(native_device_context);
+      }
+
+      // SMAA (3 passes) -> tex_smaa_out. Metrics CB at VS+PS b1 (DrawSMAA restores VS/PS/SRVs/RTs, not cbuffers).
+      ComPtr<ID3D11Buffer> vs_cb1_orig, ps_cb1_orig;
+      native_device_context->VSGetConstantBuffers(1, 1, vs_cb1_orig.put());
+      native_device_context->PSGetConstantBuffers(1, 1, ps_cb1_orig.put());
+      ID3D11Buffer* mcb = gd.cb_smaa_metrics.get();
+      native_device_context->VSSetConstantBuffers(1, 1, &mcb);
+      native_device_context->PSSetConstantBuffers(1, 1, &mcb);
+
+      DrawSMAA(native_device, native_device_context, device_data,
+         gd.tex_smaa_out_rtv.get(), gd.srv_input.get(), gd.srv_input.get(),
+         pred_ok ? gd.srv_pred.get() : nullptr /*predication depth (scene .a)*/);
+
+      // Optional RCAS sharpen on the SMAA output, then copy into the LDR target.
+      const bool sharpen_ready =
+         device_data.native_vertex_shaders[CompileTimeStringHash("Copy VS")].get() != nullptr &&
+         device_data.native_pixel_shaders[CompileTimeStringHash("BL2TPS Sharpen PS")].get() != nullptr;
+      bool do_sharpen = g_rcas_sharpness > 0.f && sharpen_ready;
+      if (do_sharpen)
+      {
+         if (!gd.cb_sharpen || gd.sharpen_w != w || gd.sharpen_h != h || gd.sharpen_amount != g_rcas_sharpness)
+         {
+            const float sp[4] = {(float)w, (float)h, g_rcas_sharpness, 0.f};
+            if (CreateImmutableCB(native_device, sp, sizeof(sp), gd.cb_sharpen))
+            {
+               gd.sharpen_w = w;
+               gd.sharpen_h = h;
+               gd.sharpen_amount = g_rcas_sharpness;
+            }
+         }
+         if (!gd.tex_rcas_out || gd.rcas_out_w != w || gd.rcas_out_h != h)
+         {
+            gd.tex_rcas_out_rtv.reset();
+            gd.tex_rcas_out.reset();
+            if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, gd.tex_rcas_out, cfmt))
+            {
+               native_device->CreateRenderTargetView(gd.tex_rcas_out.get(), nullptr, gd.tex_rcas_out_rtv.put());
+               gd.rcas_out_w = w;
+               gd.rcas_out_h = h;
+            }
+         }
+         if (!gd.cb_sharpen || !gd.tex_rcas_out_rtv)
+            do_sharpen = false;
+      }
+
+      if (do_sharpen)
+      {
+         auto* sharpen_vs = device_data.native_vertex_shaders[CompileTimeStringHash("Copy VS")].get();
+         auto* sharpen_ps = device_data.native_pixel_shaders[CompileTimeStringHash("BL2TPS Sharpen PS")].get();
+         DrawStateStack<DrawStateStackType::FullGraphics> sharpen_state;
+         sharpen_state.Cache(native_device_context, device_data.uav_max_count);
+
+         ID3D11Buffer* scb = gd.cb_sharpen.get();
+         native_device_context->PSSetConstantBuffers(0, 1, &scb);
+         DrawCustomPixelShader(native_device_context, device_data.default_depth_stencil_state.get(), device_data.default_blend_state.get(), nullptr,
+            sharpen_vs, sharpen_ps, gd.tex_smaa_out_srv.get(), gd.tex_rcas_out_rtv.get(), w, h, false);
+
+         sharpen_state.Restore(native_device_context);
+         native_device_context->CopyResource(ldr_res, gd.tex_rcas_out.get());
+      }
+      else
+      {
+         native_device_context->CopyResource(ldr_res, gd.tex_smaa_out.get());
+      }
+
+      ID3D11Buffer* vcb = vs_cb1_orig.get();
+      ID3D11Buffer* pcb = ps_cb1_orig.get();
+      native_device_context->VSSetConstantBuffers(1, 1, &vcb);
+      native_device_context->PSSetConstantBuffers(1, 1, &pcb);
+   }
+#endif // ENABLE_SMAA
+
+public:
+   void OnInit(bool async) override
+   {
+      // UE3 is all SDR (UNORM) gamma space: post buffers stay GAMMA so the
+      // gamma-SDR HUD blends on top like vanilla. The tonemap pre-scales the scene by GamePaperWhite/UIPaperWhite
+      // (UI_DRAW_TYPE 2) so the HUD lands at its own UIPaperWhite; the composition decodes gamma + paper white + scRGB.
+      GetShaderDefineData(POST_PROCESS_SPACE_TYPE_HASH).SetDefaultValue('0');
+      GetShaderDefineData(EARLY_DISPLAY_ENCODING_HASH).SetDefaultValue('0');
+      GetShaderDefineData(VANILLA_ENCODING_TYPE_HASH).SetDefaultValue('1'); // Gamma 2.2 in and out
+      GetShaderDefineData(GAMMA_CORRECTION_TYPE_HASH).SetDefaultValue('1');
+      GetShaderDefineData(GAMUT_MAPPING_TYPE_HASH).SetDefaultValue('1'); // gamut-map wild colors in composition
+      GetShaderDefineData(UI_DRAW_TYPE_HASH).SetDefaultValue('2');       // HUD gets its own UIPaperWhite + gamma blend
+
+      // Manual Scene + UI Paper White sliders instead of the OS HDR reference level. Core gates the separate
+      // "UI Paper White" slider on UI_DRAW_TYPE >= 1 && !use_os_reference_white_level. UI default 203 nits (BT.2408).
+      use_os_reference_white_level = false;
+
+      // The 6 SMAA passes are auto-registered by core when ENABLE_SMAA. Our tonemap outputs GAMMA space and the LDR
+      // snapshot is fed directly to both DrawSMAA color args (no color-prep CS): edge-detect on the gamma copy +
+      // neighborhood-blend on the color copy, both the same gamma LDR here (keeps thin features, matches FXAA).
+      // RCAS sharpen PS (drawn via core "Copy VS" + DrawCustomPixelShader after SMAA).
+      native_shaders_definitions.emplace(CompileTimeStringHash("BL2TPS Sharpen PS"),
+         ShaderDefinition{"Luma_BL2TPS_Sharpen", reshade::api::pipeline_subobject_type::pixel_shader, nullptr, "sharpen_ps"});
+      // Depth-extract CS for SMAA predication: scene-color .a (linear view Z) -> normalized R16F predication depth.
+      native_shaders_definitions.emplace(CompileTimeStringHash("BL2TPS Depth Extract CS"),
+         ShaderDefinition("Luma_BL2TPS_DepthExtract", reshade::api::pipeline_subobject_type::compute_shader));
+
+      // Gaussian DoF prefilter: half-res Karis-tamed scene downsample that the separable blur runs on (an
+      // averaged-area source, not full-res point samples -> removes under-sampling grain/sparkle).
+      native_shaders_definitions.emplace(CompileTimeStringHash("BL2TPS DoF Prefilter CS"),
+         ShaderDefinition{"Luma_BL2TPS_DoFPrefilter", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "dof_prefilter_cs"});
+      // "Luma Gaussian" DoF: separable blur of the prefiltered half-res scene (dispatched H then V).
+      native_shaders_definitions.emplace(CompileTimeStringHash("BL2TPS DoF Gaussian Blur CS"),
+         ShaderDefinition{"Luma_BL2TPS_DoFGaussian", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "dof_blur_cs"});
+
+      // The game's post passes use cb0..cb5; b12/b13 are free for Luma (measured via devkit).
+      luma_settings_cbuffer_index = 13;
+      luma_data_cbuffer_index = 12;
+
+      // User HDR grade controls (read in Tonemap_0xD00AA2A7.ps_5_0.hlsl via LumaSettings.GameSettings). All
+      // default to a vanilla no-op. Exposure/Bloom/Vignette act on both SDR+HDR; Saturation/Dechroma/Contrast HDR-only.
+      default_luma_global_game_settings.Exposure = 1.f;          // scene multiplier (1x)
+      default_luma_global_game_settings.Saturation = 1.f;        // Oklab saturation
+      default_luma_global_game_settings.HighlightDechroma = 0.f; // off; only mandatory DICE/gamut desat applies
+      default_luma_global_game_settings.BloomIntensity = 1.f;    // Luma HDR bloom strength (additive)
+      default_luma_global_game_settings.Contrast = 1.f;          // slope around 18% mid-gray
+      default_luma_global_game_settings.VignetteIntensity = 1.f; // game vignette darkening scale
+      default_luma_global_game_settings.LumaBloomEnable = 1.f;   // 1 = Luma HDR pyramidal bloom, 0 = vanilla game bloom
+      default_luma_global_game_settings.DOFRadius = 9.f;         // DoF strength (px @ 4K); = vanilla DoF peak (sigma ~1.98 half-res px)
+      default_luma_global_game_settings.DOFType = 2.f;           // 0 = vanilla game DoF, 2 = Luma separable Gaussian (default)
+      default_luma_global_game_settings.Dithering = 1.f;         // animated triangular dither at output (HDR), anti-banding on
+      cb_luma_global_settings.GameSettings = default_luma_global_game_settings;
+   }
+
+   void OnCreateDevice(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+      device_data.game = new Borderlands2GameDeviceData;
+   }
+
+   void OnDestroyDeviceData(DeviceData& device_data) override
+   {
+      if (device_data.game)
+      {
+         auto& gd = GetGameDeviceData(device_data);
+         gd.cb_smaa_metrics.reset();
+         gd.srv_input.reset();
+         gd.tex_input.reset();
+         gd.tex_smaa_out.reset();
+         gd.tex_smaa_out_rtv.reset();
+         gd.tex_smaa_out_srv.reset();
+         gd.cb_sharpen.reset();
+         gd.tex_rcas_out.reset();
+         gd.tex_rcas_out_rtv.reset();
+         gd.srv_luma_bloom.reset();
+      }
+      delete device_data.game;
+      device_data.game = nullptr;
+   }
+
+   // DoF prefilter: downsample the scene to a half-res, Karis-firefly-tamed buffer (gd.srv_dof_prefilter)
+   // that the separable Gaussian blur runs on instead of full-res t0 -> each tap is an averaged area, killing the
+   // under-sampling grain on sharp/bright detail. Resources cached per render resolution.
+   void RunDoFPrefilter(ID3D11Device* device, ID3D11DeviceContext* ctx, DeviceData& device_data, Borderlands2GameDeviceData& gd, ID3D11ShaderResourceView* scene_srv)
+   {
+      if (!scene_srv)
+         return;
+
+      // Size from the bound scene resource (NOT output_resolution) so the half-res stays aligned to the t7 sample if
+      // the scene ever differs from the swapchain (UE3 ScreenPercentage < 100). Mirrors bloom/SMAA self-sizing.
+      ComPtr<ID3D11Resource> scene_res;
+      scene_srv->GetResource(scene_res.put());
+      ComPtr<ID3D11Texture2D> scene_tex;
+      if (!scene_res || FAILED(scene_res->QueryInterface(IID_PPV_ARGS(scene_tex.put()))))
+         return;
+      D3D11_TEXTURE2D_DESC sd = {};
+      scene_tex->GetDesc(&sd);
+      const uint32_t w = sd.Width, h = sd.Height;
+      if (w == 0 || h == 0)
+         return;
+
+      const uint32_t hw = (w + 1) / 2, hh = (h + 1) / 2; // half render resolution
+      if (gd.dof_pf_w != hw || gd.dof_pf_h != hh)
+      {
+         gd.tex_dof_prefilter.reset();
+         gd.srv_dof_prefilter.reset();
+         gd.uav_dof_prefilter.reset();
+         gd.dof_pf_w = 0;
+         gd.dof_pf_h = 0;
+
+         D3D11_TEXTURE2D_DESC d = {};
+         d.Width = hw;
+         d.Height = hh;
+         d.MipLevels = 1;
+         d.ArraySize = 1;
+         d.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+         d.SampleDesc.Count = 1;
+         d.Usage = D3D11_USAGE_DEFAULT;
+         d.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+         if (FAILED(device->CreateTexture2D(&d, nullptr, gd.tex_dof_prefilter.put())))
+            return;
+         device->CreateShaderResourceView(gd.tex_dof_prefilter.get(), nullptr, gd.srv_dof_prefilter.put());
+         device->CreateUnorderedAccessView(gd.tex_dof_prefilter.get(), nullptr, gd.uav_dof_prefilter.put());
+         gd.dof_pf_w = hw;
+         gd.dof_pf_h = hh;
+      }
+      if (!gd.srv_dof_prefilter || !gd.uav_dof_prefilter)
+         return;
+
+      ID3D11ComputeShader* cs_pf = device_data.native_compute_shaders[CompileTimeStringHash("BL2TPS DoF Prefilter CS")].get();
+      if (!cs_pf)
+         return;
+
+      DrawStateStack<DrawStateStackType::Compute> pf_state;
+      pf_state.Cache(ctx, device_data.uav_max_count);
+
+      ID3D11ShaderResourceView* srv_null[1] = {};
+      ID3D11UnorderedAccessView* uav_null[1] = {};
+      ID3D11ShaderResourceView* src = scene_srv;
+      ID3D11UnorderedAccessView* uav = gd.uav_dof_prefilter.get();
+      ctx->CSSetShader(cs_pf, nullptr, 0);
+      ctx->CSSetShaderResources(0, 1, &src);
+      ctx->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+      ctx->Dispatch((hw + 7) / 8, (hh + 7) / 8, 1);
+      ctx->CSSetShaderResources(0, 1, srv_null);
+      ctx->CSSetUnorderedAccessViews(0, 1, uav_null, nullptr);
+
+      pf_state.Restore(ctx);
+   }
+
+   // "Luma Gaussian" DoF: downsample (RunDoFPrefilter) then a separable Gaussian blur (H then V) of the half-res
+   // scene, leaving the blurred half-res in gd.srv_dof_blur_out for the tonemap to sample (one tap) and blend by
+   // the game's per-pixel focus weight. Dense blur -> grain-free.
+   void RunDoFGaussian(ID3D11Device* device, ID3D11DeviceContext* ctx, DeviceData& device_data, Borderlands2GameDeviceData& gd, ID3D11ShaderResourceView* scene_srv)
+   {
+      if (!scene_srv)
+         return;
+
+      // 1. Half-res Karis-tamed source (sizes itself from scene_srv; also sets gd.dof_pf_w/h + gd.srv_dof_prefilter).
+      RunDoFPrefilter(device, ctx, device_data, gd, scene_srv);
+      if (!gd.srv_dof_prefilter)
+         return;
+      const uint32_t hw = gd.dof_pf_w, hh = gd.dof_pf_h;
+      if (hw == 0 || hh == 0)
+         return;
+
+      // 2. (Re)create the half-res ping-pong blur targets on size change.
+      D3D11_TEXTURE2D_DESC cur = {};
+      if (gd.tex_dof_blur_out)
+         gd.tex_dof_blur_out->GetDesc(&cur);
+      const bool size_changed = (!gd.tex_dof_blur_out || cur.Width != hw || cur.Height != hh);
+      if (size_changed)
+      {
+         gd.tex_dof_blur_h.reset();
+         gd.srv_dof_blur_h.reset();
+         gd.uav_dof_blur_h.reset();
+         gd.tex_dof_blur_out.reset();
+         gd.srv_dof_blur_out.reset();
+         gd.uav_dof_blur_out.reset();
+         auto make = [&](ComPtr<ID3D11Texture2D>& t, ComPtr<ID3D11ShaderResourceView>& s, ComPtr<ID3D11UnorderedAccessView>& u) -> bool
+         {
+            D3D11_TEXTURE2D_DESC d = {};
+            d.Width = hw;
+            d.Height = hh;
+            d.MipLevels = 1;
+            d.ArraySize = 1;
+            d.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+            d.SampleDesc.Count = 1;
+            d.Usage = D3D11_USAGE_DEFAULT;
+            d.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+            if (FAILED(device->CreateTexture2D(&d, nullptr, t.put())))
+               return false;
+            device->CreateShaderResourceView(t.get(), nullptr, s.put());
+            device->CreateUnorderedAccessView(t.get(), nullptr, u.put());
+            return true;
+         };
+         if (!make(gd.tex_dof_blur_h, gd.srv_dof_blur_h, gd.uav_dof_blur_h))
+            return;
+         if (!make(gd.tex_dof_blur_out, gd.srv_dof_blur_out, gd.uav_dof_blur_out))
+            return;
+      }
+
+      // 3. (Re)create the per-axis CBs (axis-step + sigma) on size or radius change.
+      if (size_changed || !gd.cb_dof_blur_h || !gd.cb_dof_blur_v || gd.dof_blur_radius != g_dof_radius)
+      {
+         const float sigma = g_dof_radius * 0.22f; // half-res sigma; radius 9 = vanilla DoF peak (sigma ~1.98 half-res px @ 4K, R2 0.98)
+         const float ph[4] = {1.0f / (float)hw, 0.f, sigma, 0.f};
+         const float pv[4] = {0.f, 1.0f / (float)hh, sigma, 0.f};
+         gd.cb_dof_blur_h.reset();
+         gd.cb_dof_blur_v.reset();
+         if (!CreateImmutableCB(device, ph, sizeof(ph), gd.cb_dof_blur_h))
+            return;
+         if (!CreateImmutableCB(device, pv, sizeof(pv), gd.cb_dof_blur_v))
+            return;
+         gd.dof_blur_radius = g_dof_radius;
+      }
+
+      ID3D11ComputeShader* cs_blur = device_data.native_compute_shaders[CompileTimeStringHash("BL2TPS DoF Gaussian Blur CS")].get();
+      if (!cs_blur)
+         return;
+
+      DrawStateStack<DrawStateStackType::Compute> blur_state;
+      blur_state.Cache(ctx, device_data.uav_max_count);
+
+      ID3D11SamplerState* lin = device_data.sampler_state_linear.get();
+      ctx->CSSetSamplers(0, 1, &lin);
+      ctx->CSSetShader(cs_blur, nullptr, 0);
+      ID3D11ShaderResourceView* srv_null[1] = {};
+      ID3D11UnorderedAccessView* uav_null[1] = {};
+      const UINT gx = (hw + 7) / 8, gy = (hh + 7) / 8;
+
+      // H pass: prefilter -> blur_h
+      ID3D11Buffer* cbh = gd.cb_dof_blur_h.get();
+      ctx->CSSetConstantBuffers(0, 1, &cbh);
+      ID3D11ShaderResourceView* s_pf = gd.srv_dof_prefilter.get();
+      ID3D11UnorderedAccessView* u_h = gd.uav_dof_blur_h.get();
+      ctx->CSSetShaderResources(0, 1, &s_pf);
+      ctx->CSSetUnorderedAccessViews(0, 1, &u_h, nullptr);
+      ctx->Dispatch(gx, gy, 1);
+      ctx->CSSetShaderResources(0, 1, srv_null);
+      ctx->CSSetUnorderedAccessViews(0, 1, uav_null, nullptr);
+
+      // V pass: blur_h -> blur_out (bound at tonemap t7 in Gaussian mode)
+      ID3D11Buffer* cbv = gd.cb_dof_blur_v.get();
+      ctx->CSSetConstantBuffers(0, 1, &cbv);
+      ID3D11ShaderResourceView* s_h = gd.srv_dof_blur_h.get();
+      ID3D11UnorderedAccessView* u_o = gd.uav_dof_blur_out.get();
+      ctx->CSSetShaderResources(0, 1, &s_h);
+      ctx->CSSetUnorderedAccessViews(0, 1, &u_o, nullptr);
+      ctx->Dispatch(gx, gy, 1);
+      ctx->CSSetShaderResources(0, 1, srv_null);
+      ctx->CSSetUnorderedAccessViews(0, 1, uav_null, nullptr);
+
+      blur_state.Restore(ctx);
+   }
+
+   DrawOrDispatchOverrideType OnDrawOrDispatch(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, CommandListData& cmd_list_data, DeviceData& device_data, reshade::api::shader_stage stages, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass, bool& updated_cbuffers, std::function<void()>* original_draw_dispatch_func) override
+   {
+      auto& gd = GetGameDeviceData(device_data);
+      const bool is_immediate = native_device_context->GetType() == D3D11_DEVICE_CONTEXT_IMMEDIATE;
+
+      // Track the LDR buffer (the tonemap's render target). The HUD draws onto it afterwards; the Hide UI
+      // toggle uses this to recognize (and drop) those HUD draws.
+      if (is_immediate && (original_shader_hashes.Contains(kTonemapHash, reshade::api::shader_stage::pixel) || original_shader_hashes.Contains(kTonemapHashTPS, reshade::api::shader_stage::pixel)))
+      {
+         // The Pre-Sequel's tonemap inserts a LightShaftTexture at slot 1, shifting its native textures down one
+         // (LUT@t4, DOF@t5) vs BL2. The replaced tonemap shader (Tonemap_0xFCFE623E) compensates in its register
+         // map; the only C++ consequence is the injected Luma bloom must move off t5 (TPS's native DOF) to t8.
+         const bool is_tps = original_shader_hashes.Contains(kTonemapHashTPS, reshade::api::shader_stage::pixel);
+         gd.tonemap_fired_this_frame = true; // Hide UI scopes its post-tonemap alpha-blend skip to this span
+         ComPtr<ID3D11RenderTargetView> rtv;
+         native_device_context->OMGetRenderTargets(1, rtv.put(), nullptr);
+         if (rtv)
+         {
+            ComPtr<ID3D11Resource> res;
+            rtv->GetResource(res.put());
+            if (res)
+               gd.ldr_buffer_handle = (uint64_t)res.get();
+         }
+         // Capture the scene-color SRV (PS t0) for SMAA predication: its .a holds linear view-space depth. The
+         // tonemap reads (doesn't overwrite) this buffer, so .a is still valid when SMAA runs later this frame.
+         ComPtr<ID3D11ShaderResourceView> scene_srv;
+         native_device_context->PSGetShaderResources(0, 1, scene_srv.put());
+         if (scene_srv)
+            gd.srv_scene_depth = scene_srv;
+
+#if ENABLE_BLOOM
+         // Luma HDR pyramidal bloom from the fp16 scene (tonemap t0), bound at PS t5 (BL2) / t8 (TPS) for the
+         // replaced tonemap to composite. Karis (firefly cut) then multi-mip pyramid, in a full-graphics state
+         // stack so DrawBloom restores the tonemap's RT/PS/SRVs. Tonemap ignores native bloom t1 here -> no double.
+         if (g_luma_bloom_enable && scene_srv)
+         {
+            DrawStateStack<DrawStateStackType::FullGraphics> bloom_state;
+            bloom_state.Cache(native_device_context, device_data.uav_max_count);
+
+            ComPtr<ID3D11ShaderResourceView> srv_karis;
+            DrawKarisAverage(native_device, native_device_context, device_data, scene_srv.get(), srv_karis.put());
+            if (srv_karis)
+               DrawBloom(native_device, native_device_context, device_data, srv_karis.get(), g_bloom_nmips, g_bloom_sigmas, gd.srv_luma_bloom.put());
+
+            bloom_state.Restore(native_device_context);
+
+            if (gd.srv_luma_bloom)
+            {
+               ID3D11ShaderResourceView* b = gd.srv_luma_bloom.get();
+               native_device_context->PSSetShaderResources(is_tps ? kLumaBloomSlotTPS : kLumaBloomSlotBL2, 1, &b);
+            }
+         }
+#endif
+
+         // DoF source for the tonemap, by type (DOFType selects the tonemap branch): Gaussian builds the half-res
+         // Karis prefilter, separable-blurs it, and binds the blurred half-res at PS t7 (single tap); Vanilla binds
+         // nothing (the tonemap reads the game's t4).
+         {
+            const float dof_type_f = (float)g_dof_type;
+            if (cb_luma_global_settings.GameSettings.DOFType != dof_type_f)
+            {
+               cb_luma_global_settings.GameSettings.DOFType = dof_type_f;
+               device_data.cb_luma_global_settings_dirty = true;
+            }
+            if (scene_srv && g_dof_type == 2) // Luma separable Gaussian
+            {
+               RunDoFGaussian(native_device, native_device_context, device_data, gd, scene_srv.get());
+               if (gd.srv_dof_blur_out)
+               {
+                  ID3D11ShaderResourceView* bl = gd.srv_dof_blur_out.get();
+                  native_device_context->PSSetShaderResources(kLumaDoFSlot, 1, &bl);
+               }
+            }
+         }
+
+#if ENABLE_SMAA
+         // SMAA runs POST-tonemap (can't perturb the DoF): manually run the original tonemap draw, then SMAA on its
+         // LDR output. Native FXAA left untouched -> DoF vanilla-identical. Falls back to a normal draw if no callback.
+         if (g_smaa_enable && original_draw_dispatch_func != nullptr)
+         {
+            // Returning Replaced short-circuits core's per-pass SetLumaConstantBuffers (core.hpp), so upload the
+            // (possibly dirty) grade/DOFType CB ourselves before running the tonemap draw - else it samples
+            // last-present's values (1-frame lag on grade sliders / DoF toggle). The standard fleet custom-pass idiom.
+            SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, reshade::api::shader_stage::pixel, LumaConstantBufferType::LumaSettings);
+            updated_cbuffers = true;
+            (*original_draw_dispatch_func)();
+            if (rtv)
+            {
+               ComPtr<ID3D11Resource> ldr_res;
+               rtv->GetResource(ldr_res.put());
+               if (ldr_res)
+                  RunPostTonemapSMAA(native_device, native_device_context, device_data, gd, ldr_res.get());
+            }
+            return DrawOrDispatchOverrideType::Replaced; // we ran the original draw ourselves
+         }
+#endif
+      }
+
+      // Hide HUD: drop post-tonemap alpha-blended draws. Tonemap/FXAA/composite are all OPAQUE; the HUD (Scaleform)
+      // is the only alpha-blended geometry after the tonemap. Keying on blend state (not the RT handle) is
+      // buffer-independent: BL2 draws the HUD on the tonemap's LDR, but TPS routes it to a separate post-FXAA buffer.
+      // `tonemap_fired_this_frame` scopes this to the current frame's post-tonemap span (so next frame's pre-tonemap
+      // transparents survive). RT==LDR kept as a BL2 superset; the mod menu draws post-composition, stays visible.
+      if (g_hide_ui && is_immediate && !is_custom_pass && gd.tonemap_fired_this_frame && !original_shader_hashes.Contains(kTonemapHash, reshade::api::shader_stage::pixel) && !original_shader_hashes.Contains(kTonemapHashTPS, reshade::api::shader_stage::pixel) && !original_shader_hashes.Contains(kFXAAResolveHash, reshade::api::shader_stage::pixel))
+      {
+         ComPtr<ID3D11BlendState> blend_state;
+         FLOAT blend_factor[4];
+         UINT sample_mask = 0;
+         native_device_context->OMGetBlendState(blend_state.put(), blend_factor, &sample_mask);
+         bool alpha_blended = false;
+         if (blend_state)
+         {
+            D3D11_BLEND_DESC bd;
+            blend_state->GetDesc(&bd);
+            alpha_blended = bd.RenderTarget[0].BlendEnable != FALSE;
+         }
+
+         bool on_ldr_buffer = false;
+         if (gd.ldr_buffer_handle)
+         {
+            ComPtr<ID3D11RenderTargetView> rtv;
+            native_device_context->OMGetRenderTargets(1, rtv.put(), nullptr);
+            if (rtv)
+            {
+               ComPtr<ID3D11Resource> res;
+               rtv->GetResource(res.put());
+               on_ldr_buffer = (res && (uint64_t)res.get() == gd.ldr_buffer_handle);
+            }
+         }
+
+         if (alpha_blended || on_ldr_buffer)
+            return DrawOrDispatchOverrideType::Skip;
+      }
+
+      return DrawOrDispatchOverrideType::None;
+   }
+
+   void OnPresent(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+      auto& gd = GetGameDeviceData(device_data);
+      gd.tonemap_fired_this_frame = false; // new frame: re-arm Hide UI's post-tonemap alpha-blend scope
+   }
+
+   void LoadConfigs() override
+   {
+      reshade::get_config_value(nullptr, PROJECT_NAME, "SMAAEnable", g_smaa_enable);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "RCASSharpness", g_rcas_sharpness);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "HideUI", g_hide_ui);
+
+      // HDR grade sliders (cb_luma_global_settings_dirty is already true at init -> uploaded on first frame).
+      auto& gs = cb_luma_global_settings.GameSettings;
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Exposure", gs.Exposure);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Saturation", gs.Saturation);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "HighlightDechroma", gs.HighlightDechroma);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "BloomIntensity", gs.BloomIntensity);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Contrast", gs.Contrast);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "VignetteIntensity", gs.VignetteIntensity);
+
+      g_dof_type = 2; // default = Luma Gaussian
+      reshade::get_config_value(nullptr, PROJECT_NAME, "DOFType", g_dof_type);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "DOFRadius", g_dof_radius);
+      gs.DOFType = (float)g_dof_type;
+      gs.DOFRadius = g_dof_radius;
+
+      reshade::get_config_value(nullptr, PROJECT_NAME, "LumaBloomEnable", g_luma_bloom_enable);
+      gs.LumaBloomEnable = g_luma_bloom_enable ? 1.f : 0.f; // mirror to the shader composite switch
+
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Dithering", gs.Dithering);
+   }
+
+   void DrawImGuiSettings(DeviceData& device_data) override
+   {
+      ImGui::SeparatorText("Anti-Aliasing");
+      if (ImGui::Checkbox("SMAA Enable", &g_smaa_enable))
+         reshade::set_config_value(nullptr, PROJECT_NAME, "SMAAEnable", g_smaa_enable);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's FXAA with SMAA (requires AA enabled in the game's video settings).");
+      ImGui::BeginDisabled(!g_smaa_enable);
+      ImGui::SliderFloat("RCAS Sharpness", &g_rcas_sharpness, 0.f, 1.f);
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "RCASSharpness", g_rcas_sharpness);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("RCAS sharpening applied to the SMAA output (0 = off).");
+      DrawResetButton(g_rcas_sharpness, 0.f, "RCASSharpness");
+      ImGui::EndDisabled();
+
+      // --- HDR grade (read in Tonemap_0xD00AA2A7.ps_5_0.hlsl via LumaSettings.GameSettings). All vanilla by default.
+      // Exposure/Bloom/Vignette act on SDR+HDR; Saturation/Highlights/Contrast on the HDR display path only. ---
+      ImGui::SeparatorText("Grade");
+      auto& gs = cb_luma_global_settings.GameSettings;
+      auto& gd_def = default_luma_global_game_settings;
+
+      if (ImGui::SliderFloat("Exposure", &gs.Exposure, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Exposure", gs.Exposure);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Scene-referred exposure multiplier (1 = vanilla).");
+      if (DrawResetButton(gs.Exposure, gd_def.Exposure, "Exposure"))
+         device_data.cb_luma_global_settings_dirty = true;
+
+      if (ImGui::SliderFloat("Contrast", &gs.Contrast, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Contrast", gs.Contrast);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Slope contrast around 18% mid-gray, HDR only (1 = vanilla).");
+      if (DrawResetButton(gs.Contrast, gd_def.Contrast, "Contrast"))
+         device_data.cb_luma_global_settings_dirty = true;
+
+      if (ImGui::SliderFloat("Saturation", &gs.Saturation, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Saturation", gs.Saturation);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Color saturation (Oklab), HDR only (1 = vanilla).");
+      if (DrawResetButton(gs.Saturation, gd_def.Saturation, "Saturation"))
+         device_data.cb_luma_global_settings_dirty = true;
+
+      if (ImGui::SliderFloat("Highlights Desaturation", &gs.HighlightDechroma, 0.f, 1.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "HighlightDechroma", gs.HighlightDechroma);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("How soon bright sources fade to neutral white, HDR only (0 = keep color at any brightness).");
+      if (DrawResetButton(gs.HighlightDechroma, gd_def.HighlightDechroma, "HighlightDechroma"))
+         device_data.cb_luma_global_settings_dirty = true;
+
+      if (ImGui::Checkbox("Luma HDR Bloom", &g_luma_bloom_enable))
+      {
+         gs.LumaBloomEnable = g_luma_bloom_enable ? 1.f : 0.f;
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "LumaBloomEnable", g_luma_bloom_enable);
+      }
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's bloom with a wider, softer HDR bloom. Off = vanilla game bloom.");
+
+      if (ImGui::SliderFloat("Bloom Intensity", &gs.BloomIntensity, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "BloomIntensity", gs.BloomIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Bloom strength (1 = vanilla). Scales the Luma HDR bloom when enabled, else the vanilla game bloom.");
+      if (DrawResetButton(gs.BloomIntensity, gd_def.BloomIntensity, "BloomIntensity"))
+         device_data.cb_luma_global_settings_dirty = true;
+
+      if (ImGui::SliderFloat("Vignette Intensity", &gs.VignetteIntensity, 0.f, 1.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "VignetteIntensity", gs.VignetteIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Scales the game's vignette darkening (1 = vanilla, 0 = none).");
+      if (DrawResetButton(gs.VignetteIntensity, gd_def.VignetteIntensity, "VignetteIntensity"))
+         device_data.cb_luma_global_settings_dirty = true;
+
+      // DoF: one checkbox toggles the Luma separable HDR Gaussian (g_dof_type 2) vs the vanilla game DoF (0).
+      bool dof_on = (g_dof_type != 0);
+      if (ImGui::Checkbox("Luma Gaussian DoF", &dof_on))
+      {
+         g_dof_type = dof_on ? 2 : 0;
+         gs.DOFType = (float)g_dof_type;
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "DOFType", g_dof_type);
+      }
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's depth-of-field with a smoother HDR version. Off = vanilla game DoF.");
+
+      ImGui::BeginDisabled(g_dof_type == 0);
+      if (ImGui::SliderFloat("DoF Strength", &g_dof_radius, 1.f, 64.f))
+      {
+         gs.DOFRadius = g_dof_radius;
+         device_data.cb_luma_global_settings_dirty = true;
+      }
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "DOFRadius", g_dof_radius);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Depth of Field blur strength.");
+      if (DrawResetButton(g_dof_radius, 9.f, "DOFRadius"))
+      {
+         gs.DOFRadius = g_dof_radius;
+         device_data.cb_luma_global_settings_dirty = true;
+      }
+      ImGui::EndDisabled();
+
+      bool dithering = gs.Dithering > 0.5f;
+      if (ImGui::Checkbox("Dithering", &dithering))
+      {
+         gs.Dithering = dithering ? 1.f : 0.f;
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Dithering", gs.Dithering);
+      }
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Reduces gradient banding.");
+
+      ImGui::SeparatorText("UI");
+      if (ImGui::Checkbox("Hide Gameplay UI", &g_hide_ui))
+         reshade::set_config_value(nullptr, PROJECT_NAME, "HideUI", g_hide_ui);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Disables the in-game UI.");
+   }
+
+   void PrintImGuiAbout() override
+   {
+      ImGui::PushTextWrapPos(0.f);
+      ImGui::Text(
+         "Luma for \"Borderlands 2 & The Pre-Sequel\" is developed by DristoforColumb and is open source and free.\n"
+         "It adds native HDR, replaces the game's FXAA with SMAA, and adds HDR bloom, depth-of-field, and 16x anisotropic filtering.\n"
+         "It runs through dgVoodoo2 (DirectX 9 -> 11).\n"
+         "Thanks to the Luma team and contributors.\n"
+         "Do NOT run another HDR mod (e.g. RenoDX) alongside it.");
+      ImGui::PopTextWrapPos();
+
+      ImGui::NewLine();
+      static const std::string social_link = std::string("Join our \"HDR Den\" Discord ") + std::string(ICON_FK_SEARCH);
+      if (ImGui::Button(social_link.c_str()))
+      {
+         // Unique link for Luma's HDR Den (tracks the origin of people joining); do not share for other purposes.
+         static const std::string discord_link = std::string("https://discord.gg/J9fM") + std::string("3EVuEZ");
+         ShellExecuteA(nullptr, "open", discord_link.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+      }
+      static const std::string contributing_link = std::string("Contribute on Github ") + std::string(ICON_FK_FILE_CODE);
+      if (ImGui::Button(contributing_link.c_str()))
+         ShellExecuteA(nullptr, "open", "https://github.com/Filoppi/Luma-Framework", nullptr, nullptr, SW_SHOWNORMAL);
+
+      ImGui::NewLine();
+      ImGui::Text("Build Date: %s %s", __DATE__, __TIME__);
+
+      ImGui::NewLine();
+      ImGui::Text("Credits:"
+                  "\n\nMain:"
+                  "\nDristoforColumb"
+                  "\n\nThird Party:"
+                  "\nReShade"
+                  "\nImGui"
+                  "\nRenoDX (HDR tonemap method)"
+                  "\nDICE (HDR tonemapper)"
+                  "\nOklab (hue/chroma restoration)"
+                  "\nSMAA (Iryoku)"
+                  "\nAMD FidelityFX (RCAS)"
+                  "\ndgVoodoo2 (DirectX 9 -> 11 wrapper, required)"
+                  "");
+   }
+};
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+   {
+      Globals::SetGlobals(PROJECT_NAME, "Borderlands 2 & The Pre-Sequel Luma mod");
+      Globals::VERSION = 1;
+
+      swapchain_format_upgrade_type = TextureFormatUpgradesType::AllowedEnabled;
+      swapchain_upgrade_type = SwapchainUpgradeType::scRGB;
+      texture_format_upgrades_type = TextureFormatUpgradesType::AllowedEnabled;
+      enable_indirect_texture_format_upgrades = true;
+      enable_chain_indirect_texture_format_upgrades = ChainTextureFormatUpgradesType::DirectDependencies;
+      texture_upgrade_formats = {
+         reshade::api::format::r8g8b8a8_unorm,
+         reshade::api::format::r8g8b8a8_unorm_srgb,
+         reshade::api::format::r8g8b8a8_typeless,
+         reshade::api::format::r8g8b8x8_unorm,
+         reshade::api::format::r8g8b8x8_unorm_srgb,
+         reshade::api::format::b8g8r8a8_unorm,
+         reshade::api::format::b8g8r8a8_unorm_srgb,
+         reshade::api::format::b8g8r8a8_typeless,
+         reshade::api::format::b8g8r8x8_unorm,
+         reshade::api::format::b8g8r8x8_unorm_srgb,
+         reshade::api::format::b8g8r8x8_typeless,
+
+         reshade::api::format::r16g16b16a16_unorm,
+
+         reshade::api::format::r10g10b10a2_unorm,
+         reshade::api::format::r10g10b10a2_typeless,
+
+         reshade::api::format::r11g11b10_float,
+      };
+      // The LDR backbuffer the tonemap writes (8-bit) + the bloom buffers are swapchain-res/aspect.
+      texture_format_upgrades_2d_size_filters = 0 | (uint32_t)TextureFormatUpgrades2DSizeFilters::SwapchainResolution | (uint32_t)TextureFormatUpgrades2DSizeFilters::SwapchainAspectRatio | (uint32_t)TextureFormatUpgrades2DSizeFilters::No1Px;
+      // The game runs within 16:9 unless aspect ratio is unlocked; force-upgrade that aspect too.
+      int screen_width = GetSystemMetrics(SM_CXSCREEN);
+      int screen_height = GetSystemMetrics(SM_CYSCREEN);
+      texture_format_upgrades_2d_size_filters |= (uint32_t)TextureFormatUpgrades2DSizeFilters::CustomAspectRatio;
+      texture_format_upgrades_2d_custom_aspect_ratios = {float(screen_width) / float(screen_height), 16.f / 9.f};
+
+      // AF16x: mode 4 upgrades the game's AF samplers to MaxAnisotropy=16 (clarity on oblique surfaces, zero
+      // risk). LOD bias offset stays 0 (no TAA here; a negative bias would shimmer).
+      enable_samplers_upgrade = true; // boot-time only (can't change after device creation)
+      samplers_upgrade_mode = 4;
+
+      game = new Borderlands2();
+   }
+
+   CoreMain(hModule, ul_reason_for_call, lpReserved);
+
+   return TRUE;
+}


### PR DESCRIPTION
Luma addon for Borderlands 2 and The Pre-Sequel
- Native HDR: scRGB fp16 swapchain, recovers clipped highlights
- AA: replaces the FXAA resolve with SMAA (ULTRA + color edge + depth predication) + optional RCAS sharpen
- HDR bloom: replaces the game's clamped quarter-res bloom with a wider pyramidal HDR bloom
- HDR depth-of-field: replaces the vanilla DoF with a smoother separable Gaussian, HDR-preserving
- Forces 16x anisotropic filtering
- AutoHDR for the pre-rendered videos
- Grade controls (exposure, contrast, saturation, highlight desaturation, bloom, vignette, dithering) + Hide Gameplay UI toggle
