### PR TITLE
[RFC] Granblue native SDR workaround for severe output color corruption

### DIFF
--- a/Source/Games/Granblue Fantasy Relink/main.cpp
+++ b/Source/Games/Granblue Fantasy Relink/main.cpp
@@ -1437,8 +1437,14 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
       shader_hashes_Bloom.pixel_shaders.emplace(std::stoul("1C5F92B9", nullptr, 16));
       shader_hashes_UIBackgroundDownscale.pixel_shaders.emplace(std::stoul("C4013554", nullptr, 16));
 
-      swapchain_format_upgrade_type = TextureFormatUpgradesType::AllowedEnabled;
-      swapchain_upgrade_type = SwapchainUpgradeType::scRGB;
+      // Keep the game's native R8G8B8A8_UNORM SDR back buffer unchanged so
+      // third-party overlays are not rendered as gamma-encoded colors into a linear scRGB target.
+      swapchain_format_upgrade_type = TextureFormatUpgradesType::None;
+      swapchain_upgrade_type = SwapchainUpgradeType::None;
+
+      // The shared display-composition shader outputs linear scRGB and currently only supports
+      // R16G16B16A16_FLOAT/R10G10B10A2_UNORM targets, so do not run it on the native UNORM buffer.
+      force_disable_display_composition = true;
       texture_format_upgrades_type = TextureFormatUpgradesType::AllowedEnabled;
 
       texture_upgrade_formats = {


### PR DESCRIPTION
> [!WARNING]
> **This is a diagnostic workaround / RFC, not a complete solution and should not be merged as-is without deciding the intended SDR/HDR behavior.** The patch deliberately disables Granblue's swapchain upgrade and Luma display composition for every display mode. It fixes the reported severe SDR output corruption, but it also removes Luma HDR output for this addon.

## What this draft establishes

This is **not an overlay-only issue**. On the affected SDR system, enabling the original Granblue addon makes the game image itself severely and unacceptably distorted in color and brightness. ReShade, Steam, and RTSS overlays are corrupted at the same time, with bright UI colors becoming especially neon-looking. Selecting SDR in Luma's Display Mode does not prevent the problem. Disabling the addon restores both the game image and the overlays immediately.

Granblue Fantasy: Relink creates a `DXGI_FORMAT_R8G8B8A8_UNORM` SDR swapchain. The addon currently upgrades it to a linear scRGB backbuffer and runs Luma's display-composition path even when SDR output is selected. As a minimal A/B test, this patch preserves the native UNORM swapchain and disables that display-composition path. On the affected system, this restores normal color and brightness for both the actual game rendering and third-party overlays.

The result isolates the problem to the upgraded swapchain / final display-composition output path. Because this diagnostic patch changes both parts together, it does not yet prove which individual operation, or combination of operations, is solely responsible.

## What the patch currently does

- Set `swapchain_format_upgrade_type` to `TextureFormatUpgradesType::None`.
- Set `swapchain_upgrade_type` to `SwapchainUpgradeType::None`.
- Set `force_disable_display_composition = true`, because the shared display-composition path currently targets scRGB/HDR10 and outputs linear scRGB rather than an sRGB-encoded UNORM result.
- Keep `texture_format_upgrades_type = TextureFormatUpgradesType::AllowedEnabled`, so internal texture format upgrades are not globally disabled.

## Why this is not the final solution

- The behavior is unconditional: selecting an HDR display mode cannot restore the upgraded swapchain.
- Disabling display composition also disables the Luma HDR output path for Granblue.
- There is no persisted user option or automatic SDR-only condition.
- Switching behavior safely may require swapchain recreation or a game restart.
- The DLSS, render-scale, TAA replacement, and internal FP16 upgrade code paths are not explicitly disabled, but they have not all been exhaustively runtime-tested with this workaround.
- Validation was performed on one SDR system; no HDR-display validation has been performed.

## Possible final directions

1. Add a persisted `Native SDR Swapchain` option and require a restart or swapchain recreation when it changes.
2. Apply the native swapchain behavior automatically only when SDR output is selected, while retaining scRGB/HDR10 and display composition for HDR modes. This depends on the display-mode setting being available before swapchain creation.
3. Extend display composition to support an `R8G8B8A8_UNORM` target with an explicit linear-to-sRGB output transform, so the complete SDR game image and later overlay rendering use the expected encoding.

## Validation

- Built successfully with both `Development-Release | x64` and `Publishing-Release | x64` using Visual Studio 2022 Build Tools.
- `git diff --check` passes.
- In-game SDR testing confirmed that the game loads normally and that both the severe game-image corruption and the ReShade/overlay color corruption no longer reproduce.
- HDR behavior is intentionally not claimed as working in this draft.
