### PR TITLE
perf(Quantum Break): avoid repeated SR constant buffer readbacks

### DIFF
--- a/Source/Games/Quantum Break/ConstantBufferCache.hpp
+++ b/Source/Games/Quantum Break/ConstantBufferCache.hpp
@@ -1,0 +1,498 @@
+#pragma once
+
+#include "shared.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace QuantumBreakUpscaling
+{
+#if ENABLE_SR
+   // The SR path needs current camera and jitter constants on the CPU. A direct staging readback at
+   // every temporal resolve serializes the CPU with the GPU, so later CPU uploads are mirrored here.
+   // The exact PS CB0/CB1 resources are discovered at the temporal resolve; subsequent Map/Unmap or
+   // UpdateSubresource events refresh their snapshots. First use, unmirrorable writes, thread changes,
+   // and tracking-capacity misses retain the original CopyResource + Map fallback.
+   class ConstantBufferCache
+   {
+   public:
+      // Each source buffer gets its own reusable staging resource for the fallback readback.
+      enum class ReadbackSlot : uint8_t
+      {
+         FrameData,
+         TemporalAA,
+         Count
+      };
+
+      // Event callbacks -------------------------------------------------------
+
+      // Map callbacks happen before the game writes through the returned pointer. Save the pointer
+      // here; RecordUnmap copies it only after the game has finished writing.
+      void RecordMap(ID3D11Buffer* buffer, void* mapped_data)
+      {
+         if (mapped_data == nullptr)
+         {
+            return;
+         }
+
+         auto* snapshot = FindTrackedSnapshot(buffer);
+         if (snapshot != nullptr && !snapshot->requires_gpu_readback)
+         {
+            snapshot->pending_map = mapped_data;
+         }
+      }
+
+      void RecordUnmap(ID3D11Buffer* buffer)
+      {
+         auto* snapshot = FindTrackedSnapshot(buffer);
+         if (snapshot == nullptr || snapshot->requires_gpu_readback || snapshot->pending_map == nullptr)
+         {
+            return;
+         }
+
+         std::memcpy(snapshot->bytes.data(), snapshot->pending_map, snapshot->bytes.size());
+         snapshot->pending_map = nullptr;
+         snapshot->has_data = true;
+      }
+
+      // UpdateSubresource-style uploads provide the new bytes directly, so they can be copied now.
+      void RecordUpdate(ID3D11Buffer* buffer, const void* source_data, uint64_t offset, uint64_t size)
+      {
+         if (source_data == nullptr)
+         {
+            return;
+         }
+
+         auto* snapshot = FindTrackedSnapshot(buffer);
+         if (snapshot == nullptr || snapshot->requires_gpu_readback)
+         {
+            return;
+         }
+
+         if (offset >= snapshot->bytes.size())
+         {
+            snapshot->has_data = false;
+            return;
+         }
+
+         const uint64_t available_size = snapshot->bytes.size() - offset;
+         const uint64_t write_size = size == UINT64_MAX ? available_size : size;
+         if (write_size > available_size)
+         {
+            snapshot->has_data = false;
+            return;
+         }
+
+         std::memcpy(
+            snapshot->bytes.data() + static_cast<size_t>(offset),
+            source_data,
+            static_cast<size_t>(write_size));
+         if (offset == 0u && write_size == snapshot->bytes.size())
+         {
+            snapshot->has_data = true;
+         }
+      }
+
+      // A GPU-side copy does not expose its resulting bytes to the CPU. Permanently use the safe
+      // readback path for this resource rather than risking an out-of-date snapshot.
+      void RequireGpuReadback(ID3D11Buffer* buffer)
+      {
+         auto* snapshot = FindTrackedSnapshot(buffer);
+         if (snapshot == nullptr)
+         {
+            return;
+         }
+
+         snapshot->pending_map = nullptr;
+         snapshot->has_data = false;
+         snapshot->requires_gpu_readback = true;
+      }
+
+      // Destruction may be reported from another thread. Only clear the atomic identity there;
+      // the owner thread removes the stale byte snapshot the next time it tracks a new resource.
+      void Forget(ID3D11Buffer* buffer)
+      {
+         if (buffer == nullptr)
+         {
+            return;
+         }
+
+         bool was_tracked = false;
+         for (auto& tracked_buffer : tracked_buffers_)
+         {
+            ID3D11Buffer* expected_buffer = buffer;
+            if (tracked_buffer.compare_exchange_strong(
+                   expected_buffer,
+                   nullptr,
+                   std::memory_order_acq_rel,
+                   std::memory_order_acquire))
+            {
+               was_tracked = true;
+               break;
+            }
+         }
+
+         if (was_tracked && IsCaptureThread())
+         {
+            snapshots_.erase(buffer);
+         }
+      }
+
+      // Temporal-resolve read ------------------------------------------------
+
+      // Returns the requested bytes from the write-through snapshot when possible. Otherwise it
+      // performs the original CopyResource + Map readback and seeds the snapshot for later frames.
+      bool Read(
+         ID3D11Device* device,
+         ID3D11DeviceContext* context,
+         ID3D11Buffer* buffer,
+         ReadbackSlot readback_slot,
+         void* destination_data,
+         uint32_t minimum_size)
+      {
+         if (device == nullptr || context == nullptr || buffer == nullptr || destination_data == nullptr)
+         {
+            return false;
+         }
+
+         if (CopySnapshot(buffer, destination_data, minimum_size))
+         {
+#if DEVELOPMENT || TEST
+            ++cache_hits_;
+#endif
+            return true;
+         }
+
+         D3D11_BUFFER_DESC source_desc = {};
+         buffer->GetDesc(&source_desc);
+         if (source_desc.ByteWidth < minimum_size)
+         {
+            return false;
+         }
+
+         const bool tracked = Track(buffer, source_desc.ByteWidth);
+         auto& readback_buffer = readback_buffers_[static_cast<size_t>(readback_slot)];
+         if (!PrepareReadbackBuffer(device, source_desc.ByteWidth, readback_buffer))
+         {
+            return false;
+         }
+
+         context->CopyResource(readback_buffer.get(), buffer);
+
+         D3D11_MAPPED_SUBRESOURCE mapped = {};
+         const HRESULT map_result = context->Map(readback_buffer.get(), 0, D3D11_MAP_READ, 0, &mapped);
+         if (FAILED(map_result) || mapped.pData == nullptr)
+         {
+            if (SUCCEEDED(map_result))
+            {
+               context->Unmap(readback_buffer.get(), 0);
+            }
+            return false;
+         }
+
+         std::memcpy(destination_data, mapped.pData, minimum_size);
+         if (tracked)
+         {
+            StoreSnapshot(buffer, mapped.pData, source_desc.ByteWidth);
+         }
+         context->Unmap(readback_buffer.get(), 0);
+
+#if DEVELOPMENT || TEST
+         ++gpu_readbacks_;
+#endif
+         return true;
+      }
+
+      // Cache lifecycle -------------------------------------------------------
+
+      // Enable event processing only while SR consumes these values. Deactivation discards the
+      // snapshots so re-enabling SR cannot accidentally reuse values from an earlier frame.
+      void Activate()
+      {
+         capture_active_.store(true, std::memory_order_release);
+      }
+
+      void Deactivate()
+      {
+         if (!capture_active_.exchange(false, std::memory_order_acq_rel))
+         {
+            return;
+         }
+
+         // Stop every callback from finding these resources immediately. This is safe from any
+         // thread and prevents old snapshots from being reused if SR is enabled again later.
+         for (auto& tracked_buffer : tracked_buffers_)
+         {
+            tracked_buffer.store(nullptr, std::memory_order_release);
+         }
+
+         // snapshots_ belongs to the render thread. If another thread disabled capture, leave the
+         // now-unreachable entries for RemoveUntrackedSnapshots() to discard on the next safe read.
+         const DWORD cached_thread_id = capture_thread_id_.load(std::memory_order_acquire);
+         if (capture_thread_changed_.load(std::memory_order_acquire) || (cached_thread_id != 0u && cached_thread_id != GetCurrentThreadId()))
+         {
+            return;
+         }
+
+         snapshots_.clear();
+      }
+
+      // The real temporal-resolve draw establishes the one thread allowed to touch snapshots_.
+      // Other threads are rejected before they look up device or cache data, so no mutex is needed.
+      bool BindToCurrentThread()
+      {
+         if (capture_thread_changed_.load(std::memory_order_acquire))
+         {
+            return false;
+         }
+
+         const DWORD current_thread_id = GetCurrentThreadId();
+         DWORD expected_thread_id = 0u;
+         if (capture_thread_id_.compare_exchange_strong(
+                expected_thread_id,
+                current_thread_id,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire))
+         {
+            return true;
+         }
+
+         if (expected_thread_id == current_thread_id)
+         {
+            return true;
+         }
+
+         // If the game's render thread ever changes, disable the optimization instead of risking
+         // concurrent access or stale values. Read() will continue through GPU readback.
+         capture_thread_changed_.store(true, std::memory_order_release);
+         capture_active_.store(false, std::memory_order_release);
+         ASSERT_ONCE(expected_thread_id == current_thread_id);
+         return false;
+      }
+
+      void ReleaseResources()
+      {
+         Deactivate();
+         for (auto& readback_buffer : readback_buffers_)
+         {
+            readback_buffer = nullptr;
+         }
+      }
+
+      // Cheap callback filters ------------------------------------------------
+
+      static bool IsWriteAccess(reshade::api::map_access access)
+      {
+         return access == reshade::api::map_access::write_only || access == reshade::api::map_access::read_write || access == reshade::api::map_access::write_discard;
+      }
+
+      static bool IsCaptureThread()
+      {
+         if (!capture_active_.load(std::memory_order_acquire) || capture_thread_changed_.load(std::memory_order_acquire))
+         {
+            return false;
+         }
+
+         const DWORD cached_thread_id = capture_thread_id_.load(std::memory_order_acquire);
+         return cached_thread_id != 0u && cached_thread_id == GetCurrentThreadId();
+      }
+
+      static void ResetCaptureThread()
+      {
+         capture_active_.store(false, std::memory_order_release);
+         capture_thread_changed_.store(false, std::memory_order_release);
+         capture_thread_id_.store(0u, std::memory_order_release);
+      }
+
+#if DEVELOPMENT || TEST
+      uint64_t CacheHitCount() const
+      {
+         return cache_hits_;
+      }
+
+      uint64_t GpuReadbackCount() const
+      {
+         return gpu_readbacks_;
+      }
+#endif
+
+   private:
+      static constexpr size_t tracked_buffer_capacity = 16u;
+
+      struct Snapshot
+      {
+         std::vector<uint8_t> bytes;
+         void* pending_map = nullptr;
+         bool has_data = false;
+         bool requires_gpu_readback = false;
+      };
+
+      Snapshot* FindTrackedSnapshot(ID3D11Buffer* buffer)
+      {
+         if (!IsTracked(buffer))
+         {
+            return nullptr;
+         }
+
+         const auto snapshot_it = snapshots_.find(buffer);
+         return snapshot_it != snapshots_.end() ? &snapshot_it->second : nullptr;
+      }
+
+      bool IsTracked(ID3D11Buffer* buffer) const
+      {
+         if (buffer == nullptr)
+         {
+            return false;
+         }
+
+         for (const auto& tracked_buffer : tracked_buffers_)
+         {
+            if (tracked_buffer.load(std::memory_order_acquire) == buffer)
+            {
+               return true;
+            }
+         }
+         return false;
+      }
+
+      // The fixed atomic list is only a fast callback filter. If all slots are occupied, Read()
+      // simply keeps using the correct but slower GPU path for additional resources.
+      bool Track(ID3D11Buffer* buffer, uint32_t byte_width)
+      {
+         if (buffer == nullptr || byte_width == 0u || !IsCaptureThread())
+         {
+            return false;
+         }
+
+         if (IsTracked(buffer))
+         {
+            auto [snapshot_it, inserted] = snapshots_.try_emplace(buffer);
+            auto& snapshot = snapshot_it->second;
+            if (inserted || snapshot.bytes.size() != byte_width)
+            {
+               snapshot = {};
+               snapshot.bytes.resize(byte_width);
+            }
+            return true;
+         }
+
+         auto free_slot_it = std::find_if(
+            tracked_buffers_.begin(),
+            tracked_buffers_.end(),
+            [](const auto& tracked_buffer)
+            { return tracked_buffer.load(std::memory_order_acquire) == nullptr; });
+         if (free_slot_it == tracked_buffers_.end())
+         {
+            return false;
+         }
+
+         RemoveUntrackedSnapshots();
+         auto& snapshot = snapshots_[buffer];
+         snapshot = {};
+         snapshot.bytes.resize(byte_width);
+
+         // Publish the resource identity only after its snapshot is fully constructed.
+         free_slot_it->store(buffer, std::memory_order_release);
+         return true;
+      }
+
+      void RemoveUntrackedSnapshots()
+      {
+         for (auto snapshot_it = snapshots_.begin(); snapshot_it != snapshots_.end();)
+         {
+            if (!IsTracked(snapshot_it->first))
+            {
+               snapshot_it = snapshots_.erase(snapshot_it);
+            }
+            else
+            {
+               ++snapshot_it;
+            }
+         }
+      }
+
+      bool CopySnapshot(ID3D11Buffer* buffer, void* destination_data, uint32_t minimum_size)
+      {
+         if (buffer == nullptr || destination_data == nullptr || !IsCaptureThread())
+         {
+            return false;
+         }
+
+         auto* snapshot = FindTrackedSnapshot(buffer);
+         if (snapshot == nullptr || snapshot->requires_gpu_readback || !snapshot->has_data || snapshot->bytes.size() < minimum_size)
+         {
+            return false;
+         }
+
+         std::memcpy(destination_data, snapshot->bytes.data(), minimum_size);
+         return true;
+      }
+
+      void StoreSnapshot(ID3D11Buffer* buffer, const void* source_data, uint32_t size)
+      {
+         if (buffer == nullptr || source_data == nullptr || !IsCaptureThread())
+         {
+            return;
+         }
+
+         auto* snapshot = FindTrackedSnapshot(buffer);
+         if (snapshot == nullptr || snapshot->bytes.size() != size)
+         {
+            return;
+         }
+
+         if (snapshot->requires_gpu_readback)
+         {
+            return;
+         }
+
+         std::memcpy(snapshot->bytes.data(), source_data, size);
+         snapshot->has_data = true;
+      }
+
+      static bool PrepareReadbackBuffer(ID3D11Device* device, uint32_t byte_width, com_ptr<ID3D11Buffer>& readback_buffer)
+      {
+         bool needs_recreate = readback_buffer.get() == nullptr;
+         if (!needs_recreate)
+         {
+            D3D11_BUFFER_DESC readback_desc = {};
+            readback_buffer->GetDesc(&readback_desc);
+            needs_recreate = readback_desc.ByteWidth != byte_width;
+         }
+
+         if (!needs_recreate)
+         {
+            return true;
+         }
+
+         D3D11_BUFFER_DESC readback_desc = {};
+         readback_desc.ByteWidth = byte_width;
+         readback_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+         readback_desc.Usage = D3D11_USAGE_STAGING;
+
+         readback_buffer = nullptr;
+         const HRESULT create_result = device->CreateBuffer(&readback_desc, nullptr, &readback_buffer);
+         return SUCCEEDED(create_result) && readback_buffer.get() != nullptr;
+      }
+
+      inline static std::atomic<DWORD> capture_thread_id_ = 0u;
+      inline static std::atomic_bool capture_thread_changed_ = false;
+      inline static std::atomic_bool capture_active_ = false;
+
+      std::unordered_map<ID3D11Buffer*, Snapshot> snapshots_;
+      std::array<std::atomic<ID3D11Buffer*>, tracked_buffer_capacity> tracked_buffers_ = {};
+      std::array<com_ptr<ID3D11Buffer>, static_cast<size_t>(ReadbackSlot::Count)> readback_buffers_;
+
+#if DEVELOPMENT || TEST
+      uint64_t cache_hits_ = 0u;
+      uint64_t gpu_readbacks_ = 0u;
+#endif
+   };
+#endif
+} // namespace QuantumBreakUpscaling

--- a/Source/Games/Quantum Break/Quantum Break.vcxproj
+++ b/Source/Games/Quantum Break/Quantum Break.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="17.0"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
@@ -312,6 +313,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\Core\unity_build.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClInclude Include="ConstantBufferCache.hpp" />
     <ClInclude Include="shared.h" />
     <ClInclude Include="Upscaling.hpp" />
   </ItemGroup>

--- a/Source/Games/Quantum Break/Quantum Break.vcxproj.filters
+++ b/Source/Games/Quantum Break/Quantum Break.vcxproj.filters
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="..\..\Core\unity_build.cpp" />
+    <ClInclude Include="ConstantBufferCache.hpp" />
     <ClInclude Include="shared.h" />
     <ClInclude Include="Upscaling.hpp" />
   </ItemGroup>

--- a/Source/Games/Quantum Break/Upscaling.hpp
+++ b/Source/Games/Quantum Break/Upscaling.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "shared.h"
+#include "ConstantBufferCache.hpp"
+
+#include <array>
 
 // Quantum Break's SR hook is assembled from several stable Remedy passes:
 // - 0xA43343D6 "Depth Linearization" reads clip/device depth from PS SRV0 and writes linear depth to RTV0.
@@ -73,9 +76,9 @@ namespace QuantumBreakUpscaling
    // Byte offsets into QB's cb_update_1 cbuffer for the SR inputs that are not available from textures.
    constexpr uint32_t cb_update_1_inv_near_offset = 47u * 16u;
    constexpr uint32_t cb_update_1_view_to_clip_offset = 10u * 16u;
-   constexpr uint32_t cb_update_1_tess_view_to_clip_11_offset = 112u * 16u + 12u;
+   constexpr uint32_t cb_update_1_tess_view_to_clip_11_offset = (112u * 16u) + 12u;
    constexpr uint32_t cb_update_1_jitter_offset = 121u * 16u;
-   constexpr uint32_t cb_update_1_min_size = cb_update_1_jitter_offset + sizeof(float) * 2u;
+   constexpr uint32_t cb_update_1_min_size = cb_update_1_jitter_offset + (sizeof(float) * 2u);
    // The temporal resolve samples current color with g_vSSAAJitterOffset[0], directly added to UVs.
    // Logged scene frames repeat a 4-sample raw UV pattern:
    //   ( 0.00014648, -0.00008681), (-0.00014648,  0.00008681),
@@ -84,7 +87,7 @@ namespace QuantumBreakUpscaling
    // this becomes roughly (0.375, 0.125), (-0.375, -0.125),
    // (0.125, -0.375), (-0.125, 0.375) render pixels after the SR Y flip.
    constexpr uint32_t ssaa_jitter_offset = 12u * 16u;
-   constexpr uint32_t ssaa_min_size = ssaa_jitter_offset + sizeof(float) * 2u;
+   constexpr uint32_t ssaa_min_size = ssaa_jitter_offset + (sizeof(float) * 2u);
 
    struct Data
    {
@@ -97,8 +100,8 @@ namespace QuantumBreakUpscaling
       // sr_clip_depth is captured from 0xA43343D6 PS SRV0, the pre-linearized clip/device depth.
       com_ptr<ID3D11Resource> sr_clip_depth;
       com_ptr<ID3D11Resource> sr_motion_vectors;
-      com_ptr<ID3D11Buffer> cb_update_1_readback;
-      com_ptr<ID3D11Buffer> ssaa_readback;
+      // Mirrors CPU uploads so current game constants can be read without waiting for the GPU.
+      ConstantBufferCache constant_buffer_cache;
       // Conversion scratch texture: game gamma color -> DLSS linear input.
       com_ptr<ID3D11Texture2D> sr_linear_input_color;
       com_ptr<ID3D11ShaderResourceView> sr_linear_input_color_srv;
@@ -287,20 +290,20 @@ namespace QuantumBreakUpscaling
       // so keep the largest depth seen this frame to avoid replacing the main depth with downscaled copies.
       com_ptr<ID3D11ShaderResourceView> clip_depth_srv;
       native_device_context->PSGetShaderResources(0, 1, &clip_depth_srv);
-      if (!clip_depth_srv.get())
+      if (clip_depth_srv.get() == nullptr)
       {
          return;
       }
 
       com_ptr<ID3D11Resource> clip_depth_resource;
       clip_depth_srv->GetResource(&clip_depth_resource);
-      if (!clip_depth_resource.get())
+      if (clip_depth_resource.get() == nullptr)
       {
          return;
       }
 
       com_ptr<ID3D11Texture2D> clip_depth_texture;
-      if (FAILED(clip_depth_resource->QueryInterface(&clip_depth_texture)) || !clip_depth_texture.get())
+      if (FAILED(clip_depth_resource->QueryInterface(&clip_depth_texture)) || clip_depth_texture.get() == nullptr)
       {
          return;
       }
@@ -316,7 +319,7 @@ namespace QuantumBreakUpscaling
       const uint64_t previous_area = data.has_sr_clip_depth_desc
                                         ? (static_cast<uint64_t>(data.sr_clip_depth_desc.Width) * static_cast<uint64_t>(data.sr_clip_depth_desc.Height))
                                         : 0ull;
-      if (!data.sr_clip_depth.get() || current_area > previous_area)
+      if (data.sr_clip_depth.get() == nullptr || current_area > previous_area)
       {
          data.sr_clip_depth = clip_depth_resource;
          data.sr_clip_depth_desc = clip_depth_desc;
@@ -334,7 +337,7 @@ namespace QuantumBreakUpscaling
       // The history reprojection pass has the motion-vector resource bound as CS SRV 0.
       com_ptr<ID3D11ShaderResourceView> motion_vectors_srv;
       native_device_context->CSGetShaderResources(0, 1, &motion_vectors_srv);
-      if (motion_vectors_srv.get())
+      if (motion_vectors_srv.get() != nullptr)
       {
          data.sr_motion_vectors = nullptr;
          motion_vectors_srv->GetResource(&data.sr_motion_vectors);
@@ -346,76 +349,28 @@ namespace QuantumBreakUpscaling
    }
 
 #if ENABLE_SR
-   inline bool MapPixelShaderConstantBufferForReadback(
-      ID3D11Device* native_device,
-      ID3D11DeviceContext* native_device_context,
-      UINT slot,
-      uint32_t min_size,
-      com_ptr<ID3D11Buffer>& readback_buffer,
-      D3D11_MAPPED_SUBRESOURCE& mapped)
-   {
-      // Constant buffers are GPU-only, so copy them into a staging buffer before CPU-side parsing.
-      com_ptr<ID3D11Buffer> constant_buffer;
-      native_device_context->PSGetConstantBuffers(slot, 1, &constant_buffer);
-      if (!constant_buffer.get())
-      {
-         return false;
-      }
-
-      D3D11_BUFFER_DESC source_desc = {};
-      constant_buffer->GetDesc(&source_desc);
-      if (source_desc.ByteWidth < min_size)
-      {
-         return false;
-      }
-
-      bool needs_recreate = !readback_buffer.get();
-      if (!needs_recreate)
-      {
-         D3D11_BUFFER_DESC readback_desc = {};
-         readback_buffer->GetDesc(&readback_desc);
-         needs_recreate = readback_desc.ByteWidth != source_desc.ByteWidth;
-      }
-
-      if (needs_recreate)
-      {
-         D3D11_BUFFER_DESC readback_desc = source_desc;
-         readback_desc.BindFlags = 0;
-         readback_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-         readback_desc.Usage = D3D11_USAGE_STAGING;
-         readback_desc.MiscFlags = 0;
-         readback_desc.StructureByteStride = 0;
-
-         readback_buffer = nullptr;
-         HRESULT hr = native_device->CreateBuffer(&readback_desc, nullptr, &readback_buffer);
-         if (FAILED(hr) || !readback_buffer.get())
-         {
-            return false;
-         }
-      }
-
-      native_device_context->CopyResource(readback_buffer.get(), constant_buffer.get());
-
-      HRESULT hr = native_device_context->Map(readback_buffer.get(), 0, D3D11_MAP_READ, 0, &mapped);
-      return SUCCEEDED(hr) && mapped.pData != nullptr;
-   }
-
-   inline bool CaptureCBUpdate1Data(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, Data& data)
+   inline bool CaptureCBUpdate1Data(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, Data& data, ID3D11Buffer* constant_buffer)
    {
       // cb_update_1 supplies fallback jitter, projection scale, and near plane for SR.
       data.sr_cb_jitter_x = 0.f;
       data.sr_cb_jitter_y = 0.f;
-      D3D11_MAPPED_SUBRESOURCE mapped = {};
-      if (!MapPixelShaderConstantBufferForReadback(native_device, native_device_context, 0, cb_update_1_min_size, data.cb_update_1_readback, mapped))
+      std::array<uint8_t, cb_update_1_min_size> buffer_data;
+      if (!data.constant_buffer_cache.Read(
+             native_device,
+             native_device_context,
+             constant_buffer,
+             ConstantBufferCache::ReadbackSlot::FrameData,
+             buffer_data.data(),
+             cb_update_1_min_size))
       {
          return false;
       }
 
-      const auto* base = static_cast<const uint8_t*>(mapped.pData);
+      const auto* base = buffer_data.data();
       ReadCBufferFloat2(base, cb_update_1_jitter_offset, data.sr_cb_jitter_x, data.sr_cb_jitter_y);
       const float inv_near = ReadCBufferValue<float>(base, cb_update_1_inv_near_offset);
       const float projection_scale_x = ReadCBufferValue<float>(base, cb_update_1_view_to_clip_offset);
-      const float projection_scale_y = ReadCBufferValue<float>(base, cb_update_1_view_to_clip_offset + sizeof(float) * 5u);
+      const float projection_scale_y = ReadCBufferValue<float>(base, cb_update_1_view_to_clip_offset + (sizeof(float) * 5u));
       const float tess_view_to_clip_11 = ReadCBufferValue<float>(base, cb_update_1_tess_view_to_clip_11_offset);
       if (std::isfinite(inv_near) && inv_near > 0.f)
       {
@@ -439,11 +394,10 @@ namespace QuantumBreakUpscaling
          data.sr_vertical_fov = vertical_fov;
       }
 
-      native_device_context->Unmap(data.cb_update_1_readback.get(), 0);
       return true;
    }
 
-   inline bool CaptureSSAAData(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, Data& data)
+   inline bool CaptureSSAAData(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, Data& data, ID3D11Buffer* constant_buffer)
    {
       // Prefer the temporal resolve's SSAA jitter over cb_update_1. It is the exact UV offset
       // used for the current color/depth sample, and the captured values identify QB's 4-sample pattern.
@@ -451,20 +405,24 @@ namespace QuantumBreakUpscaling
       data.sr_jitter_x = 0.f;
       data.sr_jitter_y = 0.f;
 
-      D3D11_MAPPED_SUBRESOURCE mapped = {};
-      if (!MapPixelShaderConstantBufferForReadback(native_device, native_device_context, 1, ssaa_min_size, data.ssaa_readback, mapped))
+      std::array<uint8_t, ssaa_min_size> buffer_data;
+      if (!data.constant_buffer_cache.Read(
+             native_device,
+             native_device_context,
+             constant_buffer,
+             ConstantBufferCache::ReadbackSlot::TemporalAA,
+             buffer_data.data(),
+             ssaa_min_size))
       {
          return false;
       }
 
-      const auto* base = static_cast<const uint8_t*>(mapped.pData);
+      const auto* base = buffer_data.data();
       ReadCBufferFloat2(base, ssaa_jitter_offset, data.sr_jitter_x, data.sr_jitter_y);
       data.sr_jitter_x = std::isfinite(data.sr_jitter_x) ? data.sr_jitter_x : 0.f;
       data.sr_jitter_y = std::isfinite(data.sr_jitter_y) ? data.sr_jitter_y : 0.f;
 
       data.has_ssaa_data = true;
-
-      native_device_context->Unmap(data.ssaa_readback.get(), 0);
       return true;
    }
 
@@ -475,7 +433,7 @@ namespace QuantumBreakUpscaling
       bool recreated_output_texture = false;
 
       auto* sr_instance_data = device_data.GetSRInstanceData();
-      if (!sr_instance_data)
+      if (sr_instance_data == nullptr)
       {
          return false;
       }
@@ -487,18 +445,18 @@ namespace QuantumBreakUpscaling
       D3D11_TEXTURE2D_DESC sr_output_desc = output_desc;
       sr_output_desc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE;
 
-      if (device_data.sr_output_color.get())
+      if (device_data.sr_output_color.get() != nullptr)
       {
          D3D11_TEXTURE2D_DESC prev_desc = {};
          device_data.sr_output_color->GetDesc(&prev_desc);
          data.output_changed = prev_desc.Width != sr_output_desc.Width || prev_desc.Height != sr_output_desc.Height || prev_desc.Format != sr_output_desc.Format;
       }
 
-      if (!device_data.sr_output_color.get() || data.output_changed)
+      if (device_data.sr_output_color.get() == nullptr || data.output_changed)
       {
          device_data.sr_output_color = nullptr;
-         HRESULT hr = native_device->CreateTexture2D(&sr_output_desc, nullptr, &device_data.sr_output_color);
-         if (FAILED(hr) || !device_data.sr_output_color.get())
+         const HRESULT hr = native_device->CreateTexture2D(&sr_output_desc, nullptr, &device_data.sr_output_color);
+         if (FAILED(hr) || device_data.sr_output_color.get() == nullptr)
          {
             return false;
          }
@@ -506,11 +464,11 @@ namespace QuantumBreakUpscaling
          recreated_output_texture = true;
       }
 
-      if (!data.sr_output_color_srv.get() || data.output_changed || recreated_output_texture)
+      if (data.sr_output_color_srv.get() == nullptr || data.output_changed || recreated_output_texture)
       {
          data.sr_output_color_srv = nullptr;
-         HRESULT hr = native_device->CreateShaderResourceView(device_data.sr_output_color.get(), nullptr, &data.sr_output_color_srv);
-         if (FAILED(hr) || !data.sr_output_color_srv.get())
+         const HRESULT hr = native_device->CreateShaderResourceView(device_data.sr_output_color.get(), nullptr, &data.sr_output_color_srv);
+         if (FAILED(hr) || data.sr_output_color_srv.get() == nullptr)
          {
             return false;
          }
@@ -562,7 +520,7 @@ namespace QuantumBreakUpscaling
       desc.SampleDesc.Count = 1u;
       desc.SampleDesc.Quality = 0u;
 
-      bool recreate_texture = !texture.get();
+      bool recreate_texture = texture.get() == nullptr;
       if (!recreate_texture)
       {
          D3D11_TEXTURE2D_DESC previous_desc = {};
@@ -576,26 +534,26 @@ namespace QuantumBreakUpscaling
          srv = nullptr;
          rtv = nullptr;
 
-         HRESULT hr = native_device->CreateTexture2D(&desc, nullptr, &texture);
-         if (FAILED(hr) || !texture.get())
+         const HRESULT hr = native_device->CreateTexture2D(&desc, nullptr, &texture);
+         if (FAILED(hr) || texture.get() == nullptr)
          {
             return false;
          }
       }
 
-      if (!srv.get())
+      if (srv.get() == nullptr)
       {
-         HRESULT hr = native_device->CreateShaderResourceView(texture.get(), nullptr, &srv);
-         if (FAILED(hr) || !srv.get())
+         const HRESULT hr = native_device->CreateShaderResourceView(texture.get(), nullptr, &srv);
+         if (FAILED(hr) || srv.get() == nullptr)
          {
             return false;
          }
       }
 
-      if (!rtv.get())
+      if (rtv.get() == nullptr)
       {
-         HRESULT hr = native_device->CreateRenderTargetView(texture.get(), nullptr, &rtv);
-         if (FAILED(hr) || !rtv.get())
+         const HRESULT hr = native_device->CreateRenderTargetView(texture.get(), nullptr, &rtv);
+         if (FAILED(hr) || rtv.get() == nullptr)
          {
             return false;
          }
@@ -609,9 +567,9 @@ namespace QuantumBreakUpscaling
       // Shared fullscreen draw for gamma->linear and linear->gamma SR color conversion.
       const auto vs_it = device_data.native_vertex_shaders.find(CompileTimeStringHash("Copy VS"));
       const auto ps_it = device_data.native_pixel_shaders.find(pixel_shader_hash);
-      if (vs_it == device_data.native_vertex_shaders.end() || !vs_it->second.get() ||
-          ps_it == device_data.native_pixel_shaders.end() || !ps_it->second.get() ||
-          !source_srv || !target_rtv || width == 0u || height == 0u)
+      if (vs_it == device_data.native_vertex_shaders.end() || vs_it->second.get() == nullptr ||
+          ps_it == device_data.native_pixel_shaders.end() || ps_it->second.get() == nullptr ||
+          source_srv == nullptr || target_rtv == nullptr || width == 0u || height == 0u)
       {
          return false;
       }
@@ -644,6 +602,14 @@ namespace QuantumBreakUpscaling
       result.requested = IsRequested(device_data);
 
 #if ENABLE_SR
+      if (result.requested)
+      {
+         data.constant_buffer_cache.Activate();
+      }
+      else
+      {
+         data.constant_buffer_cache.Deactivate();
+      }
       data.used_cached_clip_depth = false;
       // Switching into DLSS is equivalent to a fresh scene start for DLSS history purposes.
       if (data.previous_sr_type != device_data.sr_type)
@@ -653,10 +619,10 @@ namespace QuantumBreakUpscaling
       }
 
       com_ptr<ID3D11ShaderResourceView> ps_shader_resources[3];
-      com_ptr<ID3D11RenderTargetView> render_target_views[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];
-      com_ptr<ID3D11DepthStencilView> depth_stencil_view;
+      com_ptr<ID3D11RenderTargetView> render_target_view;
+      com_ptr<ID3D11Buffer> temporal_constant_buffers[2];
       const bool immediate_context = native_device_context->GetType() == D3D11_DEVICE_CONTEXT_IMMEDIATE;
-      const bool has_main_temporal_resolve_bindings = [&]()
+      const bool has_main_temporal_resolve_bindings = result.requested && [&]()
       {
          if (!immediate_context)
          {
@@ -665,18 +631,20 @@ namespace QuantumBreakUpscaling
 
          // UI/menu-only resolves can hit the same shader without the scene color/depth/RTV bindings SR needs.
          native_device_context->PSGetShaderResources(0, ARRAYSIZE(ps_shader_resources), reinterpret_cast<ID3D11ShaderResourceView**>(ps_shader_resources));
-         native_device_context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, &render_target_views[0], &depth_stencil_view);
-         return ps_shader_resources[0].get() && ps_shader_resources[2].get() && render_target_views[0].get();
+         native_device_context->OMGetRenderTargets(1, &render_target_view, nullptr);
+         return ps_shader_resources[0].get() != nullptr && ps_shader_resources[2].get() != nullptr && render_target_view.get() != nullptr;
       }();
 
       bool captured_cb_update_1 = false;
       bool captured_ssaa = false;
-      if (has_main_temporal_resolve_bindings)
+      if (result.requested && has_main_temporal_resolve_bindings)
       {
          // These constant buffers distinguish the real scene temporal resolve from transition variants
          // that use the same shader/resources but do not carry valid scene camera/jitter state.
-         captured_cb_update_1 = CaptureCBUpdate1Data(native_device, native_device_context, data);
-         captured_ssaa = CaptureSSAAData(native_device, native_device_context, data);
+         data.constant_buffer_cache.BindToCurrentThread();
+         native_device_context->PSGetConstantBuffers(0, ARRAYSIZE(temporal_constant_buffers), reinterpret_cast<ID3D11Buffer**>(temporal_constant_buffers));
+         captured_cb_update_1 = CaptureCBUpdate1Data(native_device, native_device_context, data, temporal_constant_buffers[0].get());
+         captured_ssaa = CaptureSSAAData(native_device, native_device_context, data, temporal_constant_buffers[1].get());
       }
 
       if (result.requested && has_main_temporal_resolve_bindings && !captured_cb_update_1 && !captured_ssaa)
@@ -703,9 +671,9 @@ namespace QuantumBreakUpscaling
          return result;
       }
 
-      if (result.requested && immediate_context && data.sr_motion_vectors.get() && has_main_temporal_resolve_bindings)
+      if (result.requested && immediate_context && data.sr_motion_vectors.get() != nullptr && has_main_temporal_resolve_bindings)
       {
-         if (ps_shader_resources[0].get() && ps_shader_resources[2].get() && render_target_views[0].get())
+         if (ps_shader_resources[0].get() != nullptr && ps_shader_resources[2].get() != nullptr && render_target_view.get() != nullptr)
          {
             com_ptr<ID3D11Resource> source_color_resource;
             ps_shader_resources[2]->GetResource(&source_color_resource);
@@ -718,19 +686,19 @@ namespace QuantumBreakUpscaling
 
             // The temporal resolve RTV is the final SR output target size.
             com_ptr<ID3D11Resource> output_resource;
-            render_target_views[0]->GetResource(&output_resource);
+            render_target_view->GetResource(&output_resource);
 
             com_ptr<ID3D11Texture2D> source_color_texture;
             com_ptr<ID3D11Texture2D> output_texture;
             com_ptr<ID3D11Texture2D> temporal_resolve_depth_texture;
             com_ptr<ID3D11Texture2D> motion_vectors_texture;
 
-            const HRESULT source_hr = source_color_resource.get() ? source_color_resource->QueryInterface(&source_color_texture) : E_FAIL;
-            const HRESULT output_hr = output_resource.get() ? output_resource->QueryInterface(&output_texture) : E_FAIL;
-            const HRESULT temporal_depth_hr = temporal_resolve_depth_resource.get() ? temporal_resolve_depth_resource->QueryInterface(&temporal_resolve_depth_texture) : E_FAIL;
-            const HRESULT motion_vectors_hr = data.sr_motion_vectors.get() ? data.sr_motion_vectors->QueryInterface(&motion_vectors_texture) : E_FAIL;
+            const HRESULT source_hr = source_color_resource.get() != nullptr ? source_color_resource->QueryInterface(&source_color_texture) : E_FAIL;
+            const HRESULT output_hr = output_resource.get() != nullptr ? output_resource->QueryInterface(&output_texture) : E_FAIL;
+            const HRESULT temporal_depth_hr = temporal_resolve_depth_resource.get() != nullptr ? temporal_resolve_depth_resource->QueryInterface(&temporal_resolve_depth_texture) : E_FAIL;
+            const HRESULT motion_vectors_hr = data.sr_motion_vectors.get() != nullptr ? data.sr_motion_vectors->QueryInterface(&motion_vectors_texture) : E_FAIL;
 
-            if (SUCCEEDED(source_hr) && SUCCEEDED(output_hr) && SUCCEEDED(temporal_depth_hr) && SUCCEEDED(motion_vectors_hr) && source_color_texture.get() && output_texture.get() && temporal_resolve_depth_texture.get() && motion_vectors_texture.get())
+            if (SUCCEEDED(source_hr) && SUCCEEDED(output_hr) && SUCCEEDED(temporal_depth_hr) && SUCCEEDED(motion_vectors_hr) && source_color_texture.get() != nullptr && output_texture.get() != nullptr && temporal_resolve_depth_texture.get() != nullptr && motion_vectors_texture.get() != nullptr)
             {
                // Descs drive DLSS settings, conversion texture allocation, and history reset decisions.
                D3D11_TEXTURE2D_DESC source_desc = {};
@@ -750,7 +718,7 @@ namespace QuantumBreakUpscaling
                // The depth-linearization pass can also produce half/quarter-res linear-depth copies.
                // Only use the cached clip-depth input if it matches the main color and MV size for this SR draw;
                // otherwise keep the temporal resolve PS SRV0 fallback, which is also named g_tClipDepth.
-               if (data.sr_clip_depth.get() && data.has_sr_clip_depth_desc &&
+               if (data.sr_clip_depth.get() != nullptr && data.has_sr_clip_depth_desc &&
                    data.sr_clip_depth_desc.Width == source_desc.Width &&
                    data.sr_clip_depth_desc.Height == source_desc.Height &&
                    data.sr_clip_depth_desc.Width == motion_vectors_desc.Width &&
@@ -765,7 +733,7 @@ namespace QuantumBreakUpscaling
                if (output_ready)
                {
                   auto* sr_instance_data = device_data.GetSRInstanceData();
-                  if (sr_instance_data)
+                  if (sr_instance_data != nullptr)
                   {
                      // Use the smallest SR input texture so color, depth, and motion vectors all cover the full render area.
                      const uint32_t input_width = (std::min)(source_desc.Width, (std::min)(depth_desc.Width, motion_vectors_desc.Width));
@@ -964,6 +932,7 @@ namespace QuantumBreakUpscaling
    inline void CleanResources(DeviceData& device_data, Data& data)
    {
 #if ENABLE_SR
+      data.constant_buffer_cache.ReleaseResources();
       // Drop all transient SR resources so the next valid scene frame rebuilds them and resets DLSS history.
       // If DLSS is currently selected, the rebuild is also treated as a fresh scene warmup.
       device_data.force_reset_sr = true;
@@ -1054,7 +1023,7 @@ namespace QuantumBreakUpscaling
          }
 
          const float field_column_width = (std::max)(420.f,
-            ImGui::CalcTextSize("Had Scene Temporal Resolve Last Frame:").x + ImGui::GetStyle().CellPadding.x * 2.f + 48.f);
+            ImGui::CalcTextSize("Had Scene Temporal Resolve Last Frame:").x + (ImGui::GetStyle().CellPadding.x * 2.f) + 48.f);
          ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthFixed, field_column_width);
          ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
          return true;
@@ -1078,6 +1047,12 @@ namespace QuantumBreakUpscaling
       {
          table_row_label(label);
          ImGui::Text("%u", value);
+      };
+
+      auto table_row_uint64 = [&](const char* label, uint64_t value)
+      {
+         table_row_label(label);
+         ImGui::Text("%llu", static_cast<unsigned long long>(value));
       };
 
       auto table_row_float = [&](const char* label, float value)
@@ -1119,6 +1094,8 @@ namespace QuantumBreakUpscaling
             table_row_float("Last SR Pixel Jitter Y:", data.sr_render_pixel_jitter_y);
             table_row_float("Active MV Scale Multiplier:", Settings::mv_scale);
             table_row_float("Active Jitter Scale Multiplier:", Settings::jitter_scale);
+            table_row_uint64("CBuffer Upload Cache Hits:", data.constant_buffer_cache.CacheHitCount());
+            table_row_uint64("CBuffer GPU Readbacks:", data.constant_buffer_cache.GpuReadbackCount());
             ImGui::EndTable();
          }
       }

--- a/Source/Games/Quantum Break/UpscalingNotes.md
+++ b/Source/Games/Quantum Break/UpscalingNotes.md
@@ -7,6 +7,7 @@ These notes describe the current Quantum Break SR/DLSS integration in Luma.
 Relevant files:
 
 - `Source/Games/Quantum Break/main.cpp`
+- `Source/Games/Quantum Break/ConstantBufferCache.hpp`
 - `Source/Games/Quantum Break/Upscaling.hpp`
 - `Source/Games/Quantum Break/Quantum Break.vcxproj`
 - `Shaders/Quantum Break/Luma_QB_PreSRDecode.hlsl`
@@ -70,7 +71,7 @@ Temporal resolve pass:
 - Falls back to temporal resolve `PS SRV slot 0`, named `g_tClipDepth` in the shader dump, if the explicit depth cache is missing or mismatched.
 - Captures source color from `PS SRV slot 2`.
 - Captures final resolve RTV from `OM RTV slot 0`.
-- Reads only the SR-required values from `cb_update_1` and the temporal resolve `ssaa` cbuffer through staging readback.
+- Reads only the SR-required values from `cb_update_1` and the temporal resolve `ssaa` cbuffer through the write-through upload cache, with staging readback retained as the safety path.
 - Runs SR before executing the original temporal resolve draw.
 
 MSAA-specific depth path:
@@ -216,6 +217,41 @@ Important resolution naming quirk:
 
 The temporal resolve shader samples current color/depth with `g_vSSAAJitterOffset[0]` added directly to UVs, so this remains the most authoritative jitter source until proven otherwise.
 
+### CPU Readback Avoidance
+
+`ConstantBufferCache.hpp` owns the cbuffer capture mechanism. `Upscaling.hpp` keeps the Quantum Break-specific byte offsets and decoding, while `main.cpp` owns the ReShade event registration and forwards relevant writes to the cache.
+
+The previous path copied `PS CB0` and `PS CB1` to D3D11 staging buffers and mapped them during every valid temporal resolve. Mapping immediately after `CopyResource` can block the render thread until the GPU reaches the copy. The current path avoids that synchronization when the game updated the same buffers through a CPU-visible operation:
+
+1. A valid scene temporal resolve binds the current thread as the cache owner and identifies the exact `ID3D11Buffer*` resources in `PS CB0` and `PS CB1`.
+2. The first read of each resource uses the original `CopyResource` + `Map` path and stores the full cbuffer contents in a CPU snapshot.
+3. Later `map_buffer_region`/`unmap_buffer_region` and `update_buffer_region` events mirror the game's actual writes into that snapshot.
+4. The next temporal resolve copies only the required prefix from the snapshot into local data and decodes the current jitter/camera values.
+
+This is write-through caching, not a frame-based cache. Values are reused only after observing writes to the same resource identity, so constantly changing jitter and camera data remain current.
+
+The callback path is deliberately narrow:
+
+- Capture is active only while SR is requested.
+- The valid scene temporal resolve establishes the render-thread ID.
+- Buffer callbacks reject inactive capture, a mismatched thread, null handles, and non-write maps before looking up device state.
+- A fixed atomic list of 16 tracked resource identities provides the cheap callback filter. Capacity overflow does not evict a live entry; additional resources continue through staging readback.
+- The byte snapshots and their map are accessed only by the bound render thread, so this path does not use a mutex.
+- If the temporal resolve is ever observed on another thread, upload caching is disabled and reads continue through staging readback.
+
+Fallback and invalidation rules:
+
+- A resource's first read uses staging readback because no CPU snapshot exists yet.
+- A GPU-side `copy_resource` or `copy_buffer_region` cannot be mirrored from CPU data. The destination resource is permanently marked for staging readback.
+- Invalid or out-of-range partial updates invalidate the snapshot instead of retaining questionable data.
+- Resource destruction clears its atomic tracked identity. Owner-thread cleanup erases the corresponding snapshot; off-thread destruction leaves an unreachable entry for later owner-thread cleanup.
+- Disabling capture immediately clears every tracked identity, including when called off-thread. This prevents snapshots from before SR was disabled from being reused after it is enabled again.
+- Releasing SR resources also releases the reusable staging buffers.
+
+The two staging resources are separated by `ReadbackSlot::FrameData` and `ReadbackSlot::TemporalAA`, matching `cb_update_1` and `ssaa`. They are recreated only when the source cbuffer byte width changes.
+
+ReShade cbuffer events are registered after a successful addon load and unregistered during process detach. Device teardown clears `device_data.game` before deleting the game data because releasing cached D3D resources may re-enter the resource-destruction callback.
+
 ## Jitter Units
 
 Raw jitter source priority:
@@ -359,6 +395,8 @@ In development/test builds, collapsible SR debug sections show:
 - SR render-pixel jitter sent to DLSS/FSR
 - MV scale multiplier
 - jitter scale multiplier
+- cbuffer upload-cache hits
+- cbuffer GPU readbacks
 
 User tuning controls:
 
@@ -375,6 +413,7 @@ Validated in this work:
 - Raw QB jitter is converted to SR render-pixel units before being sent to DLSS/FSR; the preferred SSAA jitter path uses full UV-to-pixel scaling, not raw cbuffer values or half-amplitude projection conversion.
 - DLSS selected before loading a save no longer hangs on the AA-off path after the transition guard and DLSS warmup.
 - The Luma core `CreateRenderTargetView` assert observed during debugging was a secondary symptom of device removal, so no core workaround is kept.
+- The cbuffer path now mirrors observed CPU writes and retains staging readback for first use and unsafe update paths. Both `Development-Release|x64` and `Publishing-Release|x64` compile successfully.
 
 Remaining validation/follow-up work:
 
@@ -384,6 +423,7 @@ Remaining validation/follow-up work:
 - Derive far plane if a reliable source is found.
 - Validate color stability with the gamma->linear->SR->gamma path across gameplay, menus, cutscenes, and resolution changes.
 - Replace the conservative `120`-resolve DLSS warmup with a tighter state-based stability check if a reliable signal is found.
+- Profile the cbuffer cache in gameplay. After first-use readbacks, upload-cache hits should dominate unless Quantum Break updates these resources through GPU copies or another unmirrorable path.
 
 Most useful runtime checks:
 
@@ -392,3 +432,4 @@ Most useful runtime checks:
 3. Confirm the cached clip-depth path stays selected with MSAA off; MSAA reconstruction/resolve hashes should not appear in that mode.
 4. Test DLSS selected before save load with Anti Aliasing off.
 5. Test camera cuts, pause/menu transitions, loading, and resolution changes.
+6. Compare `CBuffer Upload Cache Hits` and `CBuffer GPU Readbacks`; repeated readbacks identify a fallback path that needs investigation rather than data that should be cached across frames.

--- a/Source/Games/Quantum Break/main.cpp
+++ b/Source/Games/Quantum Break/main.cpp
@@ -1,4 +1,5 @@
 #include "shared.h"
+#include "ConstantBufferCache.hpp"
 #include "Upscaling.hpp"
 
 namespace
@@ -183,7 +184,7 @@ namespace
             DrawFloatSetting(setting, value, runtime);
          }
 
-         if (setting.tooltip && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         if (setting.tooltip != nullptr && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
          {
             ImGui::SetTooltip("%s", setting.tooltip);
          }
@@ -211,7 +212,7 @@ namespace
       void ApplyUltrawidePatches()
       {
          HMODULE module_handle = GetModuleHandle(nullptr);
-         if (!module_handle)
+         if (module_handle == nullptr)
          {
             assert(false);
             return;
@@ -240,7 +241,7 @@ namespace
          const int hardcoded_res_height = 1440;
          const char hardcoded_res_str[] = "3440 x 1440";
 
-         std::vector<std::byte*> hardcoded_res_width_addresses = System::ScanMemoryForPattern(base, section_size, reinterpret_cast<const std::byte*>(&hardcoded_res_width), sizeof(hardcoded_res_width));
+         const std::vector<std::byte*> hardcoded_res_width_addresses = System::ScanMemoryForPattern(base, section_size, reinterpret_cast<const std::byte*>(&hardcoded_res_width), sizeof(hardcoded_res_width));
          assert(!hardcoded_res_width_addresses.empty());
          for (std::byte* hardcoded_res_width_address : hardcoded_res_width_addresses)
          {
@@ -312,6 +313,8 @@ struct GameDeviceDataQuantumBreak final : public GameDeviceData
 
 class QuantumBreakGame final : public Game
 {
+   inline static bool cbuffer_events_registered_ = false;
+
    static GameDeviceDataQuantumBreak& GetGameDeviceData(DeviceData& device_data)
    {
       return *static_cast<GameDeviceDataQuantumBreak*>(device_data.game);
@@ -322,7 +325,167 @@ class QuantumBreakGame final : public Game
       return *static_cast<const GameDeviceDataQuantumBreak*>(device_data.game);
    }
 
+   static QuantumBreakUpscaling::ConstantBufferCache* TryGetConstantBufferCache(reshade::api::device* device)
+   {
+      if (device == nullptr)
+      {
+         return nullptr;
+      }
+
+      DeviceData* device_data = device->get_private_data<DeviceData>();
+      if (device_data == nullptr || device_data->game == nullptr)
+      {
+         return nullptr;
+      }
+
+      auto& game_device_data = *static_cast<GameDeviceDataQuantumBreak*>(device_data->game);
+      return &game_device_data.upscaling.constant_buffer_cache;
+   }
+
 public:
+   // These callbacks are emitted for buffers throughout the entire game. Keep cheap checks here,
+   // before looking up per-device state, so unrelated work and shadow-rendering threads return early.
+   static void OnMapBufferRegion(reshade::api::device* device, reshade::api::resource resource, uint64_t offset, uint64_t size, reshade::api::map_access access, void** mapped_data)
+   {
+      (void)offset;
+      (void)size;
+      if (resource.handle == 0u || mapped_data == nullptr || *mapped_data == nullptr || !QuantumBreakUpscaling::ConstantBufferCache::IsWriteAccess(access) || !QuantumBreakUpscaling::ConstantBufferCache::IsCaptureThread())
+      {
+         return;
+      }
+
+      if (auto* cache = TryGetConstantBufferCache(device))
+      {
+         cache->RecordMap(reinterpret_cast<ID3D11Buffer*>(resource.handle), *mapped_data);
+      }
+   }
+
+   // Unmap marks the point where a CPU write is complete and safe to copy into the snapshot.
+   static void OnUnmapBufferRegion(reshade::api::device* device, reshade::api::resource resource)
+   {
+      if (resource.handle == 0u || !QuantumBreakUpscaling::ConstantBufferCache::IsCaptureThread())
+      {
+         return;
+      }
+
+      if (auto* cache = TryGetConstantBufferCache(device))
+      {
+         cache->RecordUnmap(reinterpret_cast<ID3D11Buffer*>(resource.handle));
+      }
+   }
+
+   // Unlike Map, an Update call already supplies the bytes being written.
+   // ReShade expects false when an add-on only observes the update instead of replacing it.
+   static bool OnUpdateBufferRegion(reshade::api::device* device, const void* source_data, reshade::api::resource resource, uint64_t offset, uint64_t size)
+   {
+      if (resource.handle == 0u || source_data == nullptr || !QuantumBreakUpscaling::ConstantBufferCache::IsCaptureThread())
+      {
+         return false;
+      }
+
+      if (auto* cache = TryGetConstantBufferCache(device))
+      {
+         cache->RecordUpdate(
+            reinterpret_cast<ID3D11Buffer*>(resource.handle),
+            source_data,
+            offset,
+            size);
+      }
+      return false;
+   }
+
+   static bool OnCopyResource(reshade::api::command_list* command_list, reshade::api::resource source, reshade::api::resource destination)
+   {
+      (void)source;
+      if (command_list == nullptr || destination.handle == 0u || !QuantumBreakUpscaling::ConstantBufferCache::IsCaptureThread())
+      {
+         return false;
+      }
+
+      if (auto* cache = TryGetConstantBufferCache(command_list->get_device()))
+      {
+         // A GPU copy has no CPU-visible source bytes, so this resource must use safe readback.
+         cache->RequireGpuReadback(reinterpret_cast<ID3D11Buffer*>(destination.handle));
+      }
+      return false;
+   }
+
+   static bool OnCopyBufferRegion(reshade::api::command_list* command_list, reshade::api::resource source, uint64_t source_offset, reshade::api::resource destination, uint64_t destination_offset, uint64_t size)
+   {
+      (void)source;
+      (void)source_offset;
+      (void)destination_offset;
+      (void)size;
+      if (command_list == nullptr || destination.handle == 0u || !QuantumBreakUpscaling::ConstantBufferCache::IsCaptureThread())
+      {
+         return false;
+      }
+
+      if (auto* cache = TryGetConstantBufferCache(command_list->get_device()))
+      {
+         cache->RequireGpuReadback(reinterpret_cast<ID3D11Buffer*>(destination.handle));
+      }
+      return false;
+   }
+
+   static void OnDestroyResource(reshade::api::device* device, reshade::api::resource resource)
+   {
+      if (resource.handle == 0u)
+      {
+         return;
+      }
+
+      if (auto* cache = TryGetConstantBufferCache(device))
+      {
+         cache->Forget(reinterpret_cast<ID3D11Buffer*>(resource.handle));
+      }
+   }
+
+   static void RegisterCBufferEvents()
+   {
+#if ENABLE_SR
+      if (cbuffer_events_registered_)
+      {
+         return;
+      }
+
+      reshade::register_event<reshade::addon_event::map_buffer_region>(OnMapBufferRegion);
+      reshade::register_event<reshade::addon_event::unmap_buffer_region>(OnUnmapBufferRegion);
+      reshade::register_event<reshade::addon_event::update_buffer_region>(OnUpdateBufferRegion);
+      reshade::register_event<reshade::addon_event::copy_resource>(OnCopyResource);
+      reshade::register_event<reshade::addon_event::copy_buffer_region>(OnCopyBufferRegion);
+      reshade::register_event<reshade::addon_event::destroy_resource>(OnDestroyResource);
+      cbuffer_events_registered_ = true;
+#endif
+   }
+
+   static void UnregisterCBufferEvents()
+   {
+#if ENABLE_SR
+      if (!cbuffer_events_registered_)
+      {
+         return;
+      }
+
+      reshade::unregister_event<reshade::addon_event::map_buffer_region>(OnMapBufferRegion);
+      reshade::unregister_event<reshade::addon_event::unmap_buffer_region>(OnUnmapBufferRegion);
+      reshade::unregister_event<reshade::addon_event::update_buffer_region>(OnUpdateBufferRegion);
+      reshade::unregister_event<reshade::addon_event::copy_resource>(OnCopyResource);
+      reshade::unregister_event<reshade::addon_event::copy_buffer_region>(OnCopyBufferRegion);
+      reshade::unregister_event<reshade::addon_event::destroy_resource>(OnDestroyResource);
+      cbuffer_events_registered_ = false;
+#endif
+   }
+
+   void OnLoad(std::filesystem::path& file_path, bool failed) override
+   {
+      (void)file_path;
+      if (!failed)
+      {
+         RegisterCBufferEvents();
+      }
+   }
+
    void OnInit(bool async) override
    {
       (void)async;
@@ -350,13 +513,25 @@ public:
       device_data.game = new GameDeviceDataQuantumBreak;
    }
 
+   void OnDestroyDeviceData(DeviceData& device_data) override
+   {
+      auto* game_device_data = static_cast<GameDeviceDataQuantumBreak*>(device_data.game);
+      // Resource releases during destruction may re-enter OnDestroyResource.
+      device_data.game = nullptr;
+      delete game_device_data;
+      QuantumBreakUpscaling::ConstantBufferCache::ResetCaptureThread();
+   }
+
    DrawOrDispatchOverrideType OnDrawOrDispatch(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, CommandListData& cmd_list_data, DeviceData& device_data, reshade::api::shader_stage stages, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass, bool& updated_cbuffers, std::function<void()>* original_draw_dispatch_func) override
    {
       auto& game_device_data = GetGameDeviceData(device_data);
 
       if (QuantumBreakUpscaling::IsDepthLinearizationPass(original_shader_hashes))
       {
-         QuantumBreakUpscaling::CaptureClipDepthFromLinearizationPass(native_device_context, game_device_data.upscaling);
+         if (QuantumBreakUpscaling::IsRequested(device_data))
+         {
+            QuantumBreakUpscaling::CaptureClipDepthFromLinearizationPass(native_device_context, game_device_data.upscaling);
+         }
 
          return DrawOrDispatchOverrideType::None;
       }
@@ -365,7 +540,10 @@ public:
       {
          game_device_data.saw_history_reprojection_pass = true;
          device_data.taa_detected = true;
-         QuantumBreakUpscaling::CaptureMotionVectors(native_device_context, game_device_data.upscaling);
+         if (QuantumBreakUpscaling::IsRequested(device_data))
+         {
+            QuantumBreakUpscaling::CaptureMotionVectors(native_device_context, game_device_data.upscaling);
+         }
 
          return DrawOrDispatchOverrideType::None;
       }
@@ -391,18 +569,19 @@ public:
       QuantumBreakUpscaling::SetSRTypeForTemporalResolve(device_data, sr_result.succeeded);
       QuantumBreakUpscaling::ForceResetIfRequestedAndFailed(device_data, sr_result);
 
-      if (original_draw_dispatch_func && *original_draw_dispatch_func)
+      if (original_draw_dispatch_func != nullptr && *original_draw_dispatch_func)
       {
          // Post-draw callback path lets us bind the SR result and then execute QB's original resolve draw once.
          com_ptr<ID3D11ShaderResourceView> original_ps_srv_2;
-         native_device_context->PSGetShaderResources(2, 1, &original_ps_srv_2);
+         if (sr_result.succeeded)
+         {
+            native_device_context->PSGetShaderResources(2, 1, &original_ps_srv_2);
+         }
 
-         com_ptr<ID3D11Buffer> original_luma_settings_cb;
-         com_ptr<ID3D11Buffer> original_luma_data_cb;
+         com_ptr<ID3D11Buffer> original_luma_cbuffers[2];
          if (is_custom_pass)
          {
-            native_device_context->PSGetConstantBuffers(luma_settings_cbuffer_index, 1, &original_luma_settings_cb);
-            native_device_context->PSGetConstantBuffers(luma_data_cbuffer_index, 1, &original_luma_data_cb);
+            native_device_context->PSGetConstantBuffers(luma_data_cbuffer_index, ARRAYSIZE(original_luma_cbuffers), reinterpret_cast<ID3D11Buffer**>(original_luma_cbuffers));
 
             SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, stages, LumaConstantBufferType::LumaSettings);
             SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, stages, LumaConstantBufferType::LumaData);
@@ -413,15 +592,19 @@ public:
 
          (*original_draw_dispatch_func)();
 
-         ID3D11ShaderResourceView* original_ps_srv_2_ptr = original_ps_srv_2.get();
-         native_device_context->PSSetShaderResources(2, 1, &original_ps_srv_2_ptr);
+         if (sr_result.succeeded)
+         {
+            ID3D11ShaderResourceView* original_ps_srv_2_ptr = original_ps_srv_2.get();
+            native_device_context->PSSetShaderResources(2, 1, &original_ps_srv_2_ptr);
+         }
 
          if (is_custom_pass)
          {
-            ID3D11Buffer* original_luma_settings_cb_ptr = original_luma_settings_cb.get();
-            ID3D11Buffer* original_luma_data_cb_ptr = original_luma_data_cb.get();
-            native_device_context->PSSetConstantBuffers(luma_settings_cbuffer_index, 1, &original_luma_settings_cb_ptr);
-            native_device_context->PSSetConstantBuffers(luma_data_cbuffer_index, 1, &original_luma_data_cb_ptr);
+            ID3D11Buffer* original_luma_cbuffer_ptrs[] = {
+               original_luma_cbuffers[0].get(),
+               original_luma_cbuffers[1].get(),
+            };
+            native_device_context->PSSetConstantBuffers(luma_data_cbuffer_index, ARRAYSIZE(original_luma_cbuffer_ptrs), original_luma_cbuffer_ptrs);
          }
 
          return DrawOrDispatchOverrideType::Replaced;
@@ -570,6 +753,10 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
       RuntimeConfig::ConfigureSwapchainAndFormatUpgrades();
 
       game = new QuantumBreakGame();
+   }
+   else if (ul_reason_for_call == DLL_PROCESS_DETACH)
+   {
+      QuantumBreakGame::UnregisterCBufferEvents();
    }
 
    CoreMain(hModule, ul_reason_for_call, lpReserved);


### PR DESCRIPTION
Mirror tracked constant buffer writes on the CPU while retaining GPU readback fallbacks for unsafe paths. Reduce unnecessary temporal-resolve state queries and document the cache behavior.