### PR TITLE
Mass Effect Legendary Edition: Add Luma mod

### DIFF
--- a/Luma.sln
+++ b/Luma.sln
@@ -113,6 +113,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Heaven Burns Red", "Source\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Borderlands GOTY Enhanced", "Source\Games\Borderlands GOTY Enhanced\Borderlands GOTY Enhanced.vcxproj", "{B0DE12A4-5C7A-4E91-9F3B-08891303C0DE}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mass Effect Legendary Edition", "Source\Games\Mass Effect Legendary Edition\Mass Effect Legendary Edition.vcxproj", "{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Middle-earth Shadow of War", "Source\Games\Middle-earth Shadow of War\Middle-earth Shadow of War.vcxproj", "{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18}"
 EndProject
 Global
@@ -791,6 +793,18 @@ Global
 		{7FC545FF-0D9A-4F33-B0D2-7AF72239FBD4}.Test-Release|Win32.ActiveCfg = Test-Release|x64
 		{7FC545FF-0D9A-4F33-B0D2-7AF72239FBD4}.Test-Release|x64.ActiveCfg = Test-Release|x64
 		{7FC545FF-0D9A-4F33-B0D2-7AF72239FBD4}.Test-Release|x64.Build.0 = Test-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Development-Debug|Win32.ActiveCfg = Development-Debug|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Development-Debug|x64.ActiveCfg = Development-Debug|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Development-Debug|x64.Build.0 = Development-Debug|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Development-Release|Win32.ActiveCfg = Development-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Development-Release|x64.ActiveCfg = Development-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Development-Release|x64.Build.0 = Development-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Publishing-Release|Win32.ActiveCfg = Publishing-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Publishing-Release|x64.ActiveCfg = Publishing-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Publishing-Release|x64.Build.0 = Publishing-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Test-Release|Win32.ActiveCfg = Test-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Test-Release|x64.ActiveCfg = Test-Release|x64
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37}.Test-Release|x64.Build.0 = Test-Release|x64
 		{73FD1D51-5863-4617-B48A-F1C31AF79793}.Development-Debug|Win32.ActiveCfg = Development-Debug|x64
 		{73FD1D51-5863-4617-B48A-F1C31AF79793}.Development-Debug|Win32.Build.0 = Development-Debug|x64
 		{73FD1D51-5863-4617-B48A-F1C31AF79793}.Development-Debug|x64.ActiveCfg = Development-Debug|x64
@@ -902,6 +916,7 @@ Global
 		{5A0992EF-93A2-4565-86C1-11610EC27193} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{7FC545FF-0D9A-4F33-B0D2-7AF72239FBD4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{73FD1D51-5863-4617-B48A-F1C31AF79793} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{7D3E1C92-5A64-4B18-9F2A-1E8C4D6B0A37} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{1180032D-8EEB-4A60-B120-E838393947DF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{B0DE12A4-5C7A-4E91-9F3B-08891303C0DE} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}

--- a/Shaders/Mass Effect Legendary Edition/Includes/Common.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Includes/Common.hlsl
@@ -1,0 +1,46 @@
+// Define game cbuffer types before shared Common declares LumaSettings.
+// clang-format off
+#include "GameCBuffers.hlsl"
+#include "../../Includes/Common.hlsl"
+// clang-format on
+
+// Transport ratio R = UI Paper White / Game Paper White. Stage 1 divides by it before the native gamma HUD
+// blends, so UI-authored content stays relative to the Game Paper White scale applied further down.
+float MELE_GetUIPaperWhiteRelativeToGame()
+{
+   return LumaSettings.UIPaperWhiteNits / max(LumaSettings.GamePaperWhiteNits, 1.0);
+}
+
+// Absolute scRGB scale G = Game Paper White / 80. Under EARLY_DISPLAY_ENCODING 1 the game owns it, so exactly two
+// passes apply it: stage 2 and direct-to-swapchain Bink. Core's Display Composition divides it back out under the
+// same define, so the two agree whether or not that pass runs.
+float MELE_GetGamePaperWhiteScale()
+{
+   return LumaSettings.GamePaperWhiteNits / sRGB_WhiteLevelNits;
+}
+
+// Nothing contains the frame after stage 1, by design: the display's per-channel clip preserves more highlight
+// detail than any luminance, max-channel, or desaturation correction, which move all three channels at once.
+
+// Native SDR gamma curve shared by the stage-1 grade chains: scale, optional black floor, then pow(1/gamma) as
+// log2/exp2. The floor differs per permutation and is not cosmetic. The ME1/ME2 analytic shaders 0xAAE8755A and
+// 0xCC76075F feed mul_sat straight into log, so log2(0) drives their result to 0; every LUT permutation and the
+// ME3 analytic 0x225A8330 clamp first, lifting black to 1e-4^(1/gamma), about 0.0117 at gamma 2.2. Both forms
+// come from the dumped bytecode, so clampFloor stays faithful per entry point.
+float3 MELE_NativeGammaCurve(float3 c, float3 scale, float invGamma, bool clampFloor)
+{
+   c = saturate(scale * c);
+   if (clampFloor)
+   {
+      c = max(float3(9.99999975e-05, 9.99999975e-05, 9.99999975e-05), c);
+   }
+   c = log2(c);
+   c = invGamma * c;
+   return exp2(c);
+}
+
+// Native radial-vignette floors, transcribed from the stage-1 decompiles and selected through TM_VIG_FLOOR. The
+// shared tail rebuilds each white point as TM_VIG_FLOOR + 1, so these carry the tint too: ME1 nearly neutral,
+// ME2 strongly blue.
+static const float3 kMELE_ME1VignetteFloor = float3(0.0103630004, 5.75000013e-06, 0.0130924946);
+static const float3 kMELE_ME2VignetteFloor = float3(0.0103630004, 5.75000013e-06, 0.163092494);

--- a/Shaders/Mass Effect Legendary Edition/Includes/GameCBuffers.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Includes/GameCBuffers.hlsl
@@ -1,0 +1,37 @@
+#ifndef LUMA_GAME_CB_STRUCTS
+#define LUMA_GAME_CB_STRUCTS
+
+#ifdef __cplusplus
+// Expose HLSL-compatible types to C++.
+#include "../../../Source/Core/includes/shader_types.h"
+#endif
+
+// Mirrors the C++ namespace.
+namespace CB
+{
+// C++/HLSL ABI for user controls and per-draw video classification. Preserve field order and alignment.
+struct LumaGameSettings
+{
+   float Exposure;           // 1 = vanilla. Scene exposure multiplier, scene-referred / pre-grade.
+   float Saturation;         // 1 = vanilla. Luminance-based saturation multiplier on the final HDR color.
+   float HighlightDechroma;  // 0 = off (only the mandatory DICE/gamut desat applies); higher = bright sources fade to white sooner.
+   float Contrast;           // 1 = vanilla. Overall image contrast on the final HDR color.
+   float VignetteIntensity;  // 1 = vanilla. Scales the game's vignette darkening (0 = no vignette).
+   float FilmGrainIntensity; // 1 = vanilla. Scales the game's film grain (0 = off).
+   float BloomIntensity;     // 1 = vanilla-matched. Scales the Luma fp16 pyramidal bloom (0 = no bloom).
+   float BloomThreshold;     // = native bright-pass cb0.y (per-scene artist dial), captured live; 1.2 = ME1 vanilla default until first readback.
+   float Dithering;          // 0/1 toggle. Animated triangular output dither in HDR and SDR.
+   float VideoAutoHDREnable; // 0/1 toggle. 1 = expand Bink movie highlights into HDR, 0 = vanilla SDR videos (no expansion).
+   float VideoAutoHDRBoost;  // 0..1. Bink highlight range relative to UI white: 0 = 1x/no-op, 1 = up to 3.125x. Default 0.5.
+   float VideoOnSwapchain;   // Set by C++ per draw: 1 = Bink writes Game-relative linear scRGB, 0 = intermediate gamma buffer.
+};
+
+// Game-specific per-pass cbuffer data.
+struct LumaGameData
+{
+   // 1 when stage 2 has not decoded the final swapchain into Game-relative linear scRGB this frame.
+   float SwapchainGammaEncoded;
+};
+} // namespace CB
+
+#endif // LUMA_GAME_CB_STRUCTS

--- a/Shaders/Mass Effect Legendary Edition/Includes/Tonemap_MELE_Filmic.hlsli
+++ b/Shaders/Mass Effect Legendary Edition/Includes/Tonemap_MELE_Filmic.hlsli
@@ -1,0 +1,43 @@
+#ifndef LUMA_MELE_TONEMAP_FILMIC
+#define LUMA_MELE_TONEMAP_FILMIC
+
+// Max-channel highlight extrapolation for the native 4096x1 R16_UNORM filmic LUT, shared by the ME2 filmic and
+// all ME3 LUT permutations. RenoDX-style wrap, following Unreal Engine/Luma_UpgradeTonemapLUT.hlsl: match the
+// filmic value and slope at scene mid-gray, keep the native curve below it, ease highlights toward that tangent,
+// then shoulder-compress reversibly. Only the expansion scalar leaves this function, so the native per-channel
+// value still reaches the grade untouched and the vanilla white blowout survives into HDR.
+//
+// Include after the permutation declares smpFilmicLUT and its sampler. MELE_FILMIC_PRECURVE supplies the domain
+// the LUT is addressed in: ME3 samples scene-linear directly, ME2 pre-applies the native 1-exp2(-1.7x) curve.
+#ifndef MELE_FILMIC_PRECURVE
+#define MELE_FILMIC_PRECURVE(x) (x)
+#endif
+
+float MELE_FilmicMaxChannelExpand(float3 untonemapped)
+{
+   // Input scale covers scene-linear to about 16.2.
+   const float SC = 0.0616082214;
+   float mele_mch = max(max3(untonemapped), 1e-6);
+   // Data-driven central difference around scene mid-gray.
+   float y_mid = smpFilmicLUT.SampleLevel(smpFilmicLUTSampler_s, float2(SC * MELE_FILMIC_PRECURVE(0.18), 0.5), 0).x;
+   float g_lo = smpFilmicLUT.SampleLevel(smpFilmicLUTSampler_s, float2(SC * MELE_FILMIC_PRECURVE(0.16), 0.5), 0).x;
+   float g_hi = smpFilmicLUT.SampleLevel(smpFilmicLUTSampler_s, float2(SC * MELE_FILMIC_PRECURVE(0.20), 0.5), 0).x;
+   float slope = (g_hi - g_lo) / 0.04;
+   float g_mch = smpFilmicLUT.SampleLevel(smpFilmicLUTSampler_s, float2(SC * MELE_FILMIC_PRECURVE(mele_mch), 0.5), 0).x;
+   // Curve ceiling read through the includer's domain, never a fixed 1.0: ME2's pre-curve saturates at 1, so its
+   // coordinate stays inside the first 6.16% of the LUT and a 1.0 denominator would starve its expansion by 1.7x
+   // to 6.5x. g_mch converges to exactly this ceiling, so progress still reaches 1 with no overshoot. Sample the
+   // last texel center rather than u = 1.0 so the game's sampler addressing mode cannot affect the read.
+   const float LUT_LAST_TEXEL = 4095.5 / 4096.0;
+   float uv_top = min(LUT_LAST_TEXEL, SC * MELE_FILMIC_PRECURVE(1e4));
+   float g_top = smpFilmicLUT.SampleLevel(smpFilmicLUTSampler_s, float2(uv_top, 0.5), 0).x;
+   float tm_tan = y_mid + slope * (mele_mch - 0.18); // C1 tangent at mid-gray.
+   // Zero at and below mid-gray for any curve, one at the ceiling. The guard only covers a degenerate flat LUT.
+   float progress = saturate((g_mch - y_mid) / max(g_top - y_mid, 1e-4));
+   float tm = lerp(g_mch, tm_tan, progress * progress);   // Delay highlight expansion through upper mids.
+   float fit = Reinhard::ReinhardPiecewise(tm, 1.0, 0.9); // Identity below 0.9, shoulder to [0,1].
+   // Reinhard's shoulder exposure is 10 here, so this is exactly tm + 0.1 and reaches 1.0 at the 0.9 seam.
+   return (tm > 0.9) ? (tm / fit) : 1.0;
+}
+
+#endif // LUMA_MELE_TONEMAP_FILMIC

--- a/Shaders/Mass Effect Legendary Edition/Includes/Tonemap_MELE_Output.hlsli
+++ b/Shaders/Mass Effect Legendary Edition/Includes/Tonemap_MELE_Output.hlsli
@@ -1,0 +1,135 @@
+// Shared stage-1 output tail, included inside each main() after it defines graded_hdr, sdr_gamma, v0, v1, o0, o1.
+// Includer macros, all defaulting to off: TM_VIGNETTE_TYPE (none / radial-power / ME3 smoothstep), TM_HAS_GRAIN,
+// TM_ALPHA_LUMA (native ME3 output luma to alpha).
+#ifndef TM_VIGNETTE_TYPE
+#define TM_VIGNETTE_TYPE 0
+#endif
+#ifndef TM_HAS_GRAIN
+#define TM_HAS_GRAIN 0
+#endif
+#ifndef TM_ALPHA_LUMA
+#define TM_ALPHA_LUMA 0
+#endif
+
+const float paperWhite = LumaSettings.GamePaperWhiteNits / sRGB_WhiteLevelNits;
+const float peakWhite = LumaSettings.PeakWhiteNits / sRGB_WhiteLevelNits;
+
+float3 sdr_lin = gamma_to_linear(sdr_gamma, GCT_MIRROR);
+
+// Native vignette, hoisted ahead of the tonemap and expressed in linear so DICE absorbs its blue-tinted white
+// point instead of the frame leaving stage 1 above Scene Peak. linear_to_gamma is a signed pure pow, so this is
+// exactly the vanilla multiply in the encoded domain and SDR stays bit-identical. Grain and dither stay in gamma
+// below, where hoisting would amplify shadow noise.
+float3 vigLinear = 1.0;
+#if TM_VIGNETTE_TYPE == 1
+// The slider scales only radial darkening, so zero intensity does not alter the native white point tint.
+{
+   float2 vc = float2(-0.5, -0.5) + v0.zw;
+   vc = float2(0.832050323, 0.554700196) * vc;
+   float vd = max(9.99999975e-05, dot(vc, vc));
+   vd = exp2(3.25 * log2(vd));
+   vd = 1.0 - vd;
+   vd = exp2(TM_VIG_POW * log2(max(vd, 9.99999975e-05)));
+   const float3 white_point = TM_VIG_FLOOR + 1.0; // Floor plus center value.
+   float3 vig = TM_VIG_FLOOR + vd;
+   vig = white_point * lerp(1.0, vig / white_point, LumaSettings.GameSettings.VignetteIntensity);
+   vigLinear = gamma_to_linear(vig, GCT_MIRROR);
+}
+#elif TM_VIGNETTE_TYPE == 3
+// Native ME3 smoothstep vignette; scale only radial darkening, not its blue-tinted white point.
+{
+   float2 vc = v0.zw * ScreenUVScaleBias.xy + ScreenUVScaleBias.zw;
+   vc = float2(-0.5, -0.5) + vc;
+   vc = float2(0.832050323, 0.554700196) * vc;
+   float vd = dot(vc, vc);
+   vd = saturate(4.0 * (vd - 0.0500000007));
+   float vs = (3.0 - 2.0 * vd) * vd * vd; // smoothstep(0, 1, vd).
+   const float3 white_point = float3(1.01036298, 1.00000572, 1.16309249);
+   float3 vig = white_point - vs * LumaSettings.GameSettings.VignetteIntensity;
+   vigLinear = gamma_to_linear(vig, GCT_MIRROR);
+}
+#endif
+
+float3 postProcessedColor;
+if (LumaSettings.DisplayMode == 1) // HDR
+{
+   // graded_hdr arrives as paper-white-relative linear HDR; DICE owns peak rolloff and gamut from here.
+   float3 recovered = graded_hdr * vigLinear;
+
+   // DICE works in absolute-nit ratios, so its cap lands at the display peak. Type 2 also runs
+   // CorrectOutOfRangeColor. Grain, dither, and RCAS can still push the result ~2% past Scene Peak; accepted.
+   DICESettings settings = DefaultDICESettings(DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE);
+   float3 hdr = DICETonemap(recovered * paperWhite, peakWhite, settings) / paperWhite; // Game-Paper-White-relative.
+
+   // User HDR grade in Game-Paper-White-relative linear RGB; defaults are no-ops.
+   const float highlightDechroma = LumaSettings.GameSettings.HighlightDechroma;
+   if (highlightDechroma > 0.0)
+   {
+      float dcExp = lerp(1.0, 0.05, highlightDechroma);
+      // hdr is Game-Paper-White-relative while peakWhite is 80-nit-relative, so convert the peak before dividing.
+      const float relativePeak = peakWhite / max(paperWhite, 1e-6);
+      float dcWeight = saturate(pow(saturate(GetLuminance(hdr) / relativePeak), dcExp));
+      hdr = Saturation(hdr, 1.0 - dcWeight);
+   }
+   hdr = Saturation(hdr, LumaSettings.GameSettings.Saturation);
+   const float midGray = 0.18; // Game-Paper-White-relative mid-gray.
+   hdr = (hdr - midGray) * LumaSettings.GameSettings.Contrast + midGray;
+
+   postProcessedColor = hdr;
+}
+else // SDR still uses the scRGB swapchain; sdr_lin is the exact native grade.
+{
+   // No tonemap sits between here and the encode, so the linear vignette equals the vanilla gamma multiply.
+   postProcessedColor = sdr_lin * vigLinear;
+}
+
+postProcessedColor = IsNaN_Strict(postProcessedColor) ? 0.0 : postProcessedColor; // Replace NaN with zero.
+postProcessedColor = max(0.0, postProcessedColor);
+
+// Encode gamma(scene / R), R = UI Paper White / Game Paper White. The native gamma HUD blends before stage 2,
+// which restores R; Core then applies Game Paper White once to the combined frame.
+const float uiPaperWhiteRelativeToGame = MELE_GetUIPaperWhiteRelativeToGame();
+o0.xyz = linear_to_gamma(postProcessedColor / max(uiPaperWhiteRelativeToGame, 1e-4), GCT_MIRROR);
+
+#if TM_HAS_GRAIN
+// Native film grain stays in gamma after encoding, as vanilla did, scaled by the user control.
+{
+   float2 nuv = v0.zw * NoiseTextureOffset.xy + NoiseTextureOffset.zw;
+   float n = NoiseTexture.Sample(NoiseTextureSampler_s, nuv).x;
+   n = (n - 0.5) * FilmGrain_Scale * LumaSettings.GameSettings.FilmGrainIntensity;
+   o0.xyz = o0.xyz + n;
+}
+#endif
+
+o0.xyz = max(0.0, o0.xyz); // Grain may make shadows negative; retain HDR headroom above 1.
+
+// linear_to_gamma is a pure pow, so dividing by R in linear equals dividing by gamma(R) in the encoded domain.
+// Used by the metering below and by the native SDR clamp at the end of this tail.
+const float pw_norm = linear_to_gamma1(uiPaperWhiteRelativeToGame, GCT_MIRROR);
+
+// Native eye adaptation meters the final gamma scene after vignette, grain, and SDR clamp, HUD not yet present.
+// Cancelling transport with gamma(x / R) * gamma(R) = gamma(x) keeps both Paper White controls out of exposure.
+{
+   float3 metered = saturate(o0.xyz * pw_norm);
+   float adaptLuma = dot(metered, float3(0.212670997, 0.715160012, 0.0721689984));
+   o1 = 0.25 * log2(adaptLuma * 15 + 1);
+}
+
+// Apply animated triangular dither in gamma for HDR and SDR.
+if (LumaSettings.GameSettings.Dithering > 0.5)
+   ApplyDithering(o0.xyz, v1.xy, true, 1.0, DITHERING_BIT_DEPTH, LumaSettings.FrameIndex, true);
+
+#if TM_ALPHA_LUMA
+o0.w = dot(o0.xyz, float3(0.298999995, 0.587000012, 0.114)); // Preserve native ME3 luma alpha, unclamped as native.
+#else
+o0.w = 0;
+#endif
+
+// Vanilla ended stage 1 with mov_sat into an 8-bit UNORM target, so the gamma HUD always composited against a
+// value capped at white; the Luma intermediate is fp16, so the cap must be explicit. Applied last, after the
+// alpha dot product, to keep vanilla's clamp position, and in the transport-normalized domain so neither Paper
+// White control moves it. HDR keeps its headroom.
+if (LumaSettings.DisplayMode != 1)
+{
+   o0.xyz = min(o0.xyz, 1.0 / max(pw_norm, 1e-4));
+}

--- a/Shaders/Mass Effect Legendary Edition/Includes/Tonemap_MELE_Scene.hlsli
+++ b/Shaders/Mass Effect Legendary Edition/Includes/Tonemap_MELE_Scene.hlsli
@@ -1,0 +1,86 @@
+#ifndef LUMA_MELE_TONEMAP_SCENE
+#define LUMA_MELE_TONEMAP_SCENE
+
+// Native pixel-shader offsets. The layout is identical in every stage-1 permutation.
+cbuffer PSOffsetConstants : register(b2)
+{
+   float4 ScreenPositionScaleBias : packoffset(c0);
+   float4 MinZ_MaxZRatio : packoffset(c1);
+   float4 DynamicScale : packoffset(c2);
+}
+
+// Trilogy-wide native near/far depth-of-field composite, transcribed from the live CSOs. Register names mirror
+// the decompiled source so the block stays diffable against the original bytecode. Include after _Globals and
+// the permutation's DOF textures and samplers, which it reads at whatever slots that entry point assigns.
+//   uv         scene coordinate already scaled by DynamicScale (decompiled r0.xy)
+//   blurEnable near/far MinMaxBlurClamp enable flags            (decompiled r0.zw)
+//   scene      sampled scene color                              (decompiled r1.xyz)
+float3 MELE_CompositeDOF(float2 uv, float2 blurEnable, float3 scene)
+{
+   float4 r0, r1, r2, r3, r4;
+   r0.xy = uv;
+   r0.zw = blurEnable;
+   r1.xyz = scene;
+   r1.w = DOFTexture.Sample(DOFTextureSampler_s, r0.xy).x;
+   r1.w = saturate(r1.w);
+   r1.w = r1.w * MinZ_MaxZRatio.z + -MinZ_MaxZRatio.w;
+   r1.w = max(1.00000001e-07, r1.w);
+   r1.w = 1 / r1.w;
+   r2.xyzw = DOFBlurredNear.Sample(DOFBlurredNearSampler_s, r0.xy).xyzw;
+   r2.xyzw = r0.zzzz ? r2.xyzw : 0;
+   r3.xyzw = DOFBlurredFar.Sample(DOFBlurredFarSampler_s, r0.xy).xyzw;
+   r3.xyzw = r0.wwww ? r3.xyzw : 0;
+   r0.z = cmp(0 < PackedParameters.w);
+   r0.w = -PackedParameters.x + r1.w;
+   r4.x = saturate(-PackedParameters.y * r0.w);
+   r4.x = max(9.99999975e-05, r4.x);
+   r4.x = log2(r4.x);
+   r4.x = PackedParameters.w * r4.x;
+   r4.x = exp2(r4.x);
+   r1.w = PackedParameters.x + -r1.w;
+   r4.yz = float2(300, 500) * PackedParameters.zz;
+   r4.yz = max(float2(9.99999975e-05, 9.99999975e-05), r4.yz);
+   r1.w = saturate(r1.w / r4.y);
+   r4.x = r0.z ? r4.x : r1.w;
+   r1.w = saturate(PackedParameters.y * r0.w);
+   r1.w = max(9.99999975e-05, r1.w);
+   r1.w = log2(r1.w);
+   r1.w = PackedParameters.w * r1.w;
+   r1.w = exp2(r1.w);
+   r0.w = -PackedParameters.y + r0.w;
+   r0.w = saturate(r0.w / r4.z);
+   r4.y = r0.z ? r1.w : r0.w;
+   r4.xy = MinMaxBlurClamp.xy * r4.xy;
+   r4.xy = r4.xy * r4.xy;
+   r0.w = max(r4.x, r2.w);
+   r1.w = min(r4.y, r3.w);
+   r2.w = saturate(r0.w);
+   r3.w = r2.w * -2 + 3;
+   r2.w = r2.w * r2.w;
+   r4.y = r3.w * r2.w;
+   r4.z = saturate(DOFKernelParams.y * r1.w);
+   r4.x = saturate(DOFKernelParams.x * r0.w);
+   r0.zw = r0.zz ? r4.yz : r4.xz;
+   r3.xyz = r3.xyz + -r1.xyz;
+   r3.xyz = r0.www * r3.xyz + r1.xyz;
+   r2.xyz = -r3.xyz + r2.xyz;
+   r1.xyz = r0.zzz * r2.xyz + r3.xyz;
+   return r1.xyz;
+}
+
+// Native bloom screen blend, straight-RGB form used by the ME2 filmic, ME3, and analytic permutations. Tinted
+// bloom and screen-blend weight come out separately because the filmic path composites twice: into the linear
+// scene and into the native per-channel curve. The ME1/ME2 non-filmic path carries an internal BRG rotation on
+// these same operations and is deliberately not routed through here.
+float3 MELE_BloomScreenBlend(float2 uv, float3 scene, out float weight)
+{
+   float4 r0;
+   r0.xyz = BlurredImageSeperateBloom.Sample(BlurredImageSeperateBloomSampler_s, uv).xyz * LumaSettings.GameSettings.BloomIntensity;
+   r0.xyz = BloomTintAndScreenBlendThreshold.xyz * r0.xyz;
+   r0.w = dot(scene, float3(0.298999995, 0.587000012, 0.114));
+   r0.xyzw = float4(4, 4, 4, -3) * r0.xyzw;
+   r0.w = exp2(r0.w);
+   weight = saturate(BloomTintAndScreenBlendThreshold.w * r0.w);
+   return r0.xyz;
+}
+#endif // LUMA_MELE_TONEMAP_SCENE

--- a/Shaders/Mass Effect Legendary Edition/Luma_Bloom_impl.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Luma_Bloom_impl.hlsl
@@ -1,0 +1,21 @@
+// Trilogy-wide fp16 pyramidal bloom: native bright-pass selection over the shared fp16 Gaussian pyramid. Stage 1
+// samples the result through the native bloom slot and keeps the game's tint, luma-gated screen blend, and user
+// intensity. Bright pass 0xF8942FF1 supplies live BloomScale and Threshold in cb0.xy; C++ folds scale into the
+// effective intensity and the prefilter reads threshold from GameSettings.BloomThreshold. Tiny highlights end up
+// slightly dimmer than native because Luma thresholds before the blur rather than after it.
+
+// DrawBloom binds only b11; main.cpp explicitly preserves live LumaSettings in b13 for the prefilter.
+#include "Includes/Common.hlsl"
+
+// Native max-channel soft knee; the tonemap applies BloomTint downstream.
+float3 me1_bloom_threshold(float3 color)
+{
+   float w = saturate((max(color.r, max(color.g, color.b)) - LumaSettings.GameSettings.BloomThreshold) * 0.5);
+   return color * w;
+}
+
+#define LUMA_BLOOM_THRESHOLD_FUNCTION(color) me1_bloom_threshold(color)
+#define LUMA_BLOOM_SCALE                     0.25                  // 4 bilinear taps * 0.0625 = 0.25 of their mean.
+#define LUMA_BLOOM_TINT                      float3(1.0, 1.0, 1.0) // Tonemap applies BloomTint downstream.
+
+#include "../Includes/Bloom.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Luma_MELE_Sharpen.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Luma_MELE_Sharpen.hlsl
@@ -1,0 +1,20 @@
+// RCAS sharpens the gamma SMAA output before it is copied to the fp16 post buffer and decoded by stage 2. It uses
+// paperWhite=1 and an SDR-tuned lobe limiter bounded by RCAS_LIMIT, so gamma highlights above 1 may sharpen less
+// uniformly. Sharpness defaults to zero.
+
+#include "../Includes/RCAS.hlsl"
+
+cbuffer SharpenCB : register(b0)
+{
+   float4 SharpenParams; // (width, height, sharpness [0,1], unused).
+}
+
+Texture2D<float4> tex0 : register(t0);    // Gamma SMAA output.
+Texture2D<float2> dummyMV : register(t1); // Unused because dynamicSharpening is false.
+
+float4 sharpen_ps(float4 pos : SV_Position) : SV_Target
+{
+   int2 p = int2(pos.xy);
+   int2 maxPixel = int2((int)SharpenParams.x - 1, (int)SharpenParams.y - 1);
+   return RCAS(p, int2(0, 0), maxPixel, SharpenParams.z, tex0, dummyMV, 1.0, false, (float4)0, false);
+}

--- a/Shaders/Mass Effect Legendary Edition/Luma_MELE_XeGTAO.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Luma_MELE_XeGTAO.hlsl
@@ -1,0 +1,729 @@
+// XeGTAO replacement for the trilogy-wide NVIDIA HBAO+ chain, adapted from the repository's canonical port.
+// Source: https://github.com/GameTechDev/XeGTAO
+//
+// MELE-specific contracts shared by all three games:
+// - Run at native AO half resolution and write visibility to blur u0, the game's final R8_UNORM AO target.
+//   Apply shader 0x2E826C0F retains blend dst*src_color into the fp16 scene.
+// - Inherit cb0 HBAO+ $Globals and cb2 CSOffsetConstants; layouts come from live disassembly of
+//   0x80212FD6/0x06D92B08 and retain standard GFSDK offsets.
+// - Depth input = the game's half-res r24_unorm_x8 depth copy (deinterleave 0x497830D8 t0), read with explicit
+//   .Load: GatherRed on an r24_unorm_x8 view returns all-zeros on some drivers and silently kills the AO.
+// - ViewNormalTex from horizon shader 0x80212FD6 stores view-space xy in R8G8_UNORM; reconstruct z locally.
+// - With no TAA or motion vectors, freeze NoiseIndex at zero and rely on Very High quality plus two denoisers.
+// - Divide UE3 view Z by DepthScale=50 to approximate the meter-scale range expected by XeGTAO.
+
+// Native constant buffers inherited at the hooked dispatches; offsets come from live disassembly.
+
+cbuffer _Globals : register(b0) // NVIDIA GFSDK_SSAO $Globals.
+{
+   float RadiusToScreen;        // Offset:   0
+   float NegInvR2;              // Offset:   4; -1/R^2 in native view units.
+   float NDotVBias;             // Offset:   8
+   float2 InvFullResolution;    // Offset:  16; inverse AO resolution.
+   float2 InvQuarterResolution; // Offset:  24
+   int2 FullResOffset;          // Offset:  32
+   int2 QuarterResOffset;       // Offset:  40
+   float AOMultiplier;          // Offset:  48
+   float PowExponent;           // Offset:  52; native blur darkness control.
+   float4 ProjInfo;             // Offset:  64; view xy = (uv*xy + zw) * viewZ.
+   float2 Float2Offset;         // Offset:  80
+   float4 Jitter;               // Offset:  96
+   int ArrayOffset;             // Offset: 112
+   float4 JitterCS[8];          // Offset: 128
+}
+
+cbuffer CSOffsetConstants : register(b2)
+{
+   float4x4 ViewProjectionMatrixCS;  // Offset:   0
+   float4 CameraPositionCS;          // Offset:  64
+   float4 ScreenPositionScaleBiasCS; // Offset:  80
+   float4 MinZ_MaxZRatioCS;          // Offset:  96; viewZ = 1 / (d * z - w), non-reverse Z.
+   float4 DynamicScaleCS;            // Offset: 112
+}
+
+// Runtime parameters uploaded by main.cpp in b11.
+cbuffer LumaGTAO : register(b11)
+{
+   float FinalValuePowerRT; // Darkness control calibrated to native AO.
+   float DepthScaleRT;      // View-Z divisor from UE3 units to approximate meters.
+   float RadiusOverrideRT;  // Positive values override EFFECT_RADIUS after depth scaling.
+   float DebugViewRT;       // DEVELOPMENT: 0=off, 1=depth, 2=normals, 3=AO x8, 4=edges.
+}
+
+#include "Includes/Common.hlsl"
+
+#if XE_GTAO_QUALITY == 0 // Low
+#define SLICE_COUNT 4.0
+#elif XE_GTAO_QUALITY == 1 // Medium
+#define SLICE_COUNT 7.0
+#elif XE_GTAO_QUALITY == 2 // High
+#define SLICE_COUNT 10.0
+#elif XE_GTAO_QUALITY == 3 // Very High
+#define SLICE_COUNT 13.0
+#elif XE_GTAO_QUALITY == 4 // Ultra
+#define SLICE_COUNT 16.0
+#endif
+
+// Compile-time defaults; runtime b11 overrides the exposed controls.
+
+#ifndef EFFECT_RADIUS
+#define EFFECT_RADIUS 0.6 // Native ME1 radius: 30 UE3 units / DepthScale 50; runtime override wins.
+#endif
+
+#ifndef RADIUS_MULTIPLIER
+#define RADIUS_MULTIPLIER 1.457 // Default 1.457
+#endif
+
+#ifndef EFFECT_FALLOFF_RANGE
+#define EFFECT_FALLOFF_RANGE 0.005 // Hard falloff matches native contact AO; Intel default 0.615 is softer.
+#endif
+
+#ifndef SAMPLE_DISTRIBUTION_POWER
+#define SAMPLE_DISTRIBUTION_POWER 1.5 // Default 2.0
+#endif
+
+#ifndef THIN_OCCLUDER_COMPENSATION
+#define THIN_OCCLUDER_COMPENSATION 0.0 // Default 0.0; > 0 causes more mistakes than it fixes on big geometry
+#endif
+
+#ifndef FINAL_VALUE_POWER
+#define FINAL_VALUE_POWER 1.0 // Fallback only; runtime FinalValuePowerRT applies.
+#endif
+
+#ifndef DEPTH_MIP_SAMPLING_OFFSET
+#define DEPTH_MIP_SAMPLING_OFFSET 3.3 // Default 3.3
+#endif
+
+#ifndef SLICE_COUNT
+#define SLICE_COUNT 3.0 // Default 3.0
+#endif
+
+#ifndef STEPS_PER_SLICE
+#define STEPS_PER_SLICE 3.0 // Default 3.0
+#endif
+
+#ifndef DENOISE_BLUR_BETA
+#define DENOISE_BLUR_BETA 1.2 // Default 1.2
+#endif
+
+// ViewNormalTex z sign; view-space normals face the camera.
+#ifndef NORMAL_Z_SIGN
+#define NORMAL_Z_SIGN (-1.0)
+#endif
+
+//
+
+#define VIEWPORT_PIXEL_SIZE InvFullResolution
+
+// GFSDK ProjInfo contains the live NDC-to-view multiply/add pair, including dialogue zoom.
+#define NDC_TO_VIEW_MUL              ProjInfo.xy
+#define NDC_TO_VIEW_ADD              ProjInfo.zw
+#define NDC_TO_VIEW_MUL_X_PIXEL_SIZE (NDC_TO_VIEW_MUL * VIEWPORT_PIXEL_SIZE)
+
+#define XE_GTAO_DEPTH_MIP_LEVELS     5.0
+#define XE_GTAO_OCCLUSION_TERM_SCALE 1.5
+
+#define XE_GTAO_PI                   3.1415926535897932384626433832795
+#define XE_GTAO_PI_HALF              1.5707963267948966192313216916398
+
+// Convert non-reverse D24 through native MinZ_MaxZRatioCS, then scale UE3 units into XeGTAO's expected range.
+// Without scaling, its mip and falloff assumptions cause broad over-occlusion.
+float XeGTAO_ScreenSpaceToViewSpaceDepth(const float screenDepth)
+{
+   float viewZ = 1.0 / max(1e-7, screenDepth * MinZ_MaxZRatioCS.z - MinZ_MaxZRatioCS.w);
+   return max(0.0, viewZ) / max(1e-3, DepthScaleRT);
+}
+
+// Clamp the converted depth before mip generation.
+float XeGTAO_ClampDepth(float depth)
+{
+   return clamp(depth, 0.0, 3.402823466e+38);
+}
+
+float XeGTAO_EffectRadius()
+{
+   return (RadiusOverrideRT > 0.0 ? RadiusOverrideRT : EFFECT_RADIUS) * RADIUS_MULTIPLIER;
+}
+
+// Edge-aware depth mip filter.
+float XeGTAO_DepthMIPFilter(float depth0, float depth1, float depth2, float depth3)
+{
+   float maxDepth = max(max(depth0, depth1), max(depth2, depth3));
+
+   const float depthRangeScaleFactor = 0.75; // Empirical XeGTAO constant.
+   const float effectRadius = depthRangeScaleFactor * XeGTAO_EffectRadius();
+   const float falloffRange = EFFECT_FALLOFF_RANGE * effectRadius;
+   const float falloffFrom = effectRadius * (1.0 - EFFECT_FALLOFF_RANGE);
+
+   // Precompute falloff coefficients.
+   const float falloffMul = -1.0 / falloffRange;
+   const float falloffAdd = falloffFrom / falloffRange + 1.0;
+
+   float weight0 = saturate((maxDepth - depth0) * falloffMul + falloffAdd);
+   float weight1 = saturate((maxDepth - depth1) * falloffMul + falloffAdd);
+   float weight2 = saturate((maxDepth - depth2) * falloffMul + falloffAdd);
+   float weight3 = saturate((maxDepth - depth3) * falloffMul + falloffAdd);
+
+   float weightSum = weight0 + weight1 + weight2 + weight3;
+   return (weight0 * depth0 + weight1 * depth1 + weight2 * depth2 + weight3 * depth3) * rcp(weightSum);
+}
+
+groupshared float g_scratchDepths[8][8];
+void XeGTAO_PrefilterDepths16x16(uint2 dispatchThreadID, uint2 groupThreadID, Texture2D sourceNDCDepth, RWTexture2D<float> outDepth0, RWTexture2D<float> outDepth1, RWTexture2D<float> outDepth2, RWTexture2D<float> outDepth3, RWTexture2D<float> outDepth4)
+{
+   // MIP 0
+   const uint2 baseCoord = dispatchThreadID;
+   const uint2 pixCoord = baseCoord * 2;
+   // GatherRed returns zero on some R24_UNORM_X8 views. Integer Loads preserve depth; D3D11 defines
+   // out-of-bounds Loads as zero before conversion and clamping.
+   float d00 = sourceNDCDepth.Load(int3(pixCoord + uint2(0, 0), 0)).x;
+   float d10 = sourceNDCDepth.Load(int3(pixCoord + uint2(1, 0), 0)).x;
+   float d01 = sourceNDCDepth.Load(int3(pixCoord + uint2(0, 1), 0)).x;
+   float d11 = sourceNDCDepth.Load(int3(pixCoord + uint2(1, 1), 0)).x;
+   float depth0 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d00));
+   float depth1 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d10));
+   float depth2 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d01));
+   float depth3 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d11));
+   outDepth0[pixCoord + uint2(0, 0)] = depth0;
+   outDepth0[pixCoord + uint2(1, 0)] = depth1;
+   outDepth0[pixCoord + uint2(0, 1)] = depth2;
+   outDepth0[pixCoord + uint2(1, 1)] = depth3;
+
+   // MIP 1
+   float dm1 = XeGTAO_DepthMIPFilter(depth0, depth1, depth2, depth3);
+   outDepth1[baseCoord] = dm1;
+   g_scratchDepths[groupThreadID.x][groupThreadID.y] = dm1;
+
+   GroupMemoryBarrierWithGroupSync();
+
+   // MIP 2
+   [branch] if (all((groupThreadID.xy % 2) == 0))
+   {
+      float inTL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 0];
+      float inTR = g_scratchDepths[groupThreadID.x + 1][groupThreadID.y + 0];
+      float inBL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 1];
+      float inBR = g_scratchDepths[groupThreadID.x + 1][groupThreadID.y + 1];
+
+      float dm2 = XeGTAO_DepthMIPFilter(inTL, inTR, inBL, inBR);
+      outDepth2[baseCoord / 2] = dm2;
+      g_scratchDepths[groupThreadID.x][groupThreadID.y] = dm2;
+   }
+
+   GroupMemoryBarrierWithGroupSync();
+
+   // MIP 3
+   [branch] if (all((groupThreadID.xy % 4) == 0))
+   {
+      float inTL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 0];
+      float inTR = g_scratchDepths[groupThreadID.x + 2][groupThreadID.y + 0];
+      float inBL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 2];
+      float inBR = g_scratchDepths[groupThreadID.x + 2][groupThreadID.y + 2];
+
+      float dm3 = XeGTAO_DepthMIPFilter(inTL, inTR, inBL, inBR);
+      outDepth3[baseCoord / 4] = dm3;
+      g_scratchDepths[groupThreadID.x][groupThreadID.y] = dm3;
+   }
+
+   GroupMemoryBarrierWithGroupSync();
+
+   // MIP 4
+   [branch] if (all((groupThreadID.xy % 8) == 0))
+   {
+      float inTL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 0];
+      float inTR = g_scratchDepths[groupThreadID.x + 4][groupThreadID.y + 0];
+      float inBL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 4];
+      float inBR = g_scratchDepths[groupThreadID.x + 4][groupThreadID.y + 4];
+
+      float dm4 = XeGTAO_DepthMIPFilter(inTL, inTR, inBL, inBR);
+      outDepth4[baseCoord / 8] = dm4;
+      // g_scratchDepths[ groupThreadID.x ][ groupThreadID.y ] = dm4;
+   }
+}
+
+float4 XeGTAO_CalculateEdges(float centerZ, float leftZ, float rightZ, float topZ, float bottomZ)
+{
+   float4 edgesLRTB = float4(leftZ, rightZ, topZ, bottomZ) - centerZ;
+
+   float slopeLR = (edgesLRTB.y - edgesLRTB.x) * 0.5;
+   float slopeTB = (edgesLRTB.w - edgesLRTB.z) * 0.5;
+   float4 edgesLRTBSlopeAdjusted = edgesLRTB + float4(slopeLR, -slopeLR, slopeTB, -slopeTB);
+   edgesLRTB = min(abs(edgesLRTB), abs(edgesLRTBSlopeAdjusted));
+   return saturate(1.25 - edgesLRTB * rcp(centerZ * 0.011));
+}
+
+// Pack four edge gradients into two bits each: 0, 0.33, 0.66, or 1.
+float XeGTAO_PackEdges(float4 edgesLRTB)
+{
+   edgesLRTB = round(saturate(edgesLRTB) * 2.9);
+   return dot(edgesLRTB, float4(64.0 / 255.0, 16.0 / 255.0, 4.0 / 255.0, 1.0 / 255.0));
+}
+
+// Reconstruct view-space position from screen UV and view-space depth.
+float3 XeGTAO_ComputeViewspacePosition(float2 screenPos, float viewspaceDepth)
+{
+   float3 ret;
+   ret.xy = (NDC_TO_VIEW_MUL * screenPos.xy + NDC_TO_VIEW_ADD) * viewspaceDepth;
+   ret.z = viewspaceDepth;
+   return ret;
+}
+
+// http://h14s.p5r.org/2012/09/0x5f3759df.html, [Drobot2014a] Low Level Optimizations for GCN, https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf slide 63
+float XeGTAO_FastSqrt(float x)
+{
+   return asfloat(0x1fbd1df5 + (asint(x) >> 1));
+}
+
+// Maps [-1,1] to [0,PI]. Source: https://seblagarde.wordpress.com/2014/12/01/inverse-trigonometric-functions-gpu-optimization-for-amd-gcn-architecture/
+float XeGTAO_FastACos(float inX)
+{
+   // Shared Common defines PI as a macro, so use a literal locally.
+   float x = abs(inX);
+   float res = -0.156583 * x + 1.570796;
+   res *= XeGTAO_FastSqrt(1.0 - x);
+   return inX >= 0 ? res : 3.141593 - res;
+}
+
+void XeGTAO_MainPass(uint2 pixCoord, float2 localNoise, float3 viewspaceNormal, Texture2D sourceViewspaceDepth, SamplerState depthSampler, RWTexture2D<unorm float2> outWorkingAOTermAndEdges)
+{
+   float2 normalizedScreenPos = (pixCoord + 0.5) * VIEWPORT_PIXEL_SIZE;
+
+   // Gather is safe on the prefiltered R32F mip; the zero-read quirk applies only to native R24 depth.
+   float4 valuesUL = sourceViewspaceDepth.GatherRed(depthSampler, float2(pixCoord * VIEWPORT_PIXEL_SIZE));
+   float4 valuesBR = sourceViewspaceDepth.GatherRed(depthSampler, float2(pixCoord * VIEWPORT_PIXEL_SIZE), int2(1, 1));
+
+   // Center view-space Z.
+   float viewspaceZ = valuesUL.y;
+
+   // Neighbor view-space Z in left, top, right, bottom order.
+   const float pixLZ = valuesUL.x;
+   const float pixTZ = valuesUL.z;
+   const float pixRZ = valuesBR.z;
+   const float pixBZ = valuesBR.x;
+
+   float4 edgesLRTB = XeGTAO_CalculateEdges(viewspaceZ, pixLZ, pixRZ, pixTZ, pixBZ);
+   const float edges = XeGTAO_PackEdges(edgesLRTB);
+
+#if DEVELOPMENT
+   // Debug values pass unfiltered through denoise and native AO apply.
+   if (DebugViewRT > 0.5 && DebugViewRT < 1.5) // Depth gradient validates live conversion and scale.
+   {
+      outWorkingAOTermAndEdges[pixCoord] = float2(saturate(frac(log2(max(viewspaceZ, 1e-6)))), 1.0);
+      return;
+   }
+   if (DebugViewRT >= 3.5 && DebugViewRT < 4.5) // Edge confidence.
+   {
+      outWorkingAOTermAndEdges[pixCoord] = float2(dot(edgesLRTB, 0.25), 1.0);
+      return;
+   }
+#endif
+
+   // Move the center slightly toward the camera to suppress depth precision artifacts.
+   viewspaceZ *= 0.99999; // Tuned for FP32 view-space depth.
+
+   const float3 pixCenterPos = XeGTAO_ComputeViewspacePosition(normalizedScreenPos, viewspaceZ);
+   const float3 viewVec = normalize(-pixCenterPos);
+
+   // Fold back-facing normals toward the view vector for extreme cases.
+   viewspaceNormal = normalize(viewspaceNormal + max(0, -dot(viewspaceNormal, viewVec)) * viewVec);
+
+#if DEVELOPMENT
+   if (DebugViewRT >= 1.5 && DebugViewRT < 2.5) // Smooth view-facing shading indicates correct normal decode.
+   {
+      outWorkingAOTermAndEdges[pixCoord] = float2(saturate(abs(dot(viewspaceNormal, viewVec))), 1.0);
+      return;
+   }
+#endif
+
+   const float effectRadius = XeGTAO_EffectRadius();
+   const float sampleDistributionPower = SAMPLE_DISTRIBUTION_POWER;
+   const float thinOccluderCompensation = THIN_OCCLUDER_COMPENSATION;
+   const float falloffRange = EFFECT_FALLOFF_RANGE * effectRadius;
+   const float falloffFrom = effectRadius * (1.0 - EFFECT_FALLOFF_RANGE);
+
+   // Precompute falloff coefficients.
+   const float falloffMul = -1.0 / falloffRange;
+   const float falloffAdd = falloffFrom / falloffRange + 1.0;
+
+   float visibility = 0.0;
+
+   // Algorithm 1: https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf
+   {
+      const float noiseSlice = localNoise.x;
+      const float noiseSample = localNoise.y;
+
+      // Sampling heuristics.
+      const float pixelTooCloseThreshold = 1.3; // Push sub-pixel offsets to the minimum useful distance.
+
+      // Approximate view-space pixel size at the center depth.
+      const float2 pixelDirRBViewspaceSizeAtCenterZ = viewspaceZ.xx * NDC_TO_VIEW_MUL_X_PIXEL_SIZE;
+
+      float screenspaceRadius = effectRadius * rcp(abs(pixelDirRBViewspaceSizeAtCenterZ.x));
+
+      // Fade for small screen-space radii.
+      visibility += saturate((10.0 - screenspaceRadius) / 100.0) * 0.5;
+
+      // Minimum useful distance from the center pixel.
+      const float minS = pixelTooCloseThreshold * rcp(screenspaceRadius);
+
+      //[unroll]
+      for (float slice = 0.0; slice < SLICE_COUNT; slice++)
+      {
+         float sliceK = (slice + noiseSlice) / SLICE_COUNT;
+         // Algorithm 1, lines 5-6.
+         float phi = sliceK * XE_GTAO_PI;
+         float cosPhi = cos(phi);
+         float sinPhi = sin(phi);
+         float2 omega = float2(cosPhi, -sinPhi); // Keep full precision for large radii.
+
+         // Convert to screen-space pixels.
+         omega *= screenspaceRadius;
+
+         // Algorithm 1, line 8.
+         const float3 directionVec = float3(cosPhi, sinPhi, 0.0);
+
+         // Algorithm 1, line 9.
+         const float3 orthoDirectionVec = directionVec - (dot(directionVec, viewVec) * viewVec);
+
+         // Algorithm 1, line 10.
+         // axisVec is orthogonal to directionVec and viewVec, used to define projectedNormal
+         const float3 axisVec = normalize(cross(orthoDirectionVec, viewVec));
+
+         // Algorithm 1, line 11.
+         float3 projectedNormalVec = viewspaceNormal - axisVec * dot(viewspaceNormal, axisVec);
+
+         // Algorithm 1, line 13.
+         float signNorm = sign(dot(orthoDirectionVec, projectedNormalVec));
+
+         // Algorithm 1, line 14.
+         float projectedNormalVecLength = length(projectedNormalVec);
+         float cosNorm = saturate(dot(projectedNormalVec, viewVec) * rcp(projectedNormalVecLength));
+
+         // Algorithm 1, line 15.
+         float n = signNorm * XeGTAO_FastACos(cosNorm);
+
+         // Use the normal-dependent lower horizon rather than the paper's fixed -1 target.
+         const float lowHorizonCos0 = cos(n + XE_GTAO_PI_HALF);
+         const float lowHorizonCos1 = cos(n - XE_GTAO_PI_HALF);
+
+         // Algorithm 1, lines 17-18, with the side loop unrolled.
+         float horizonCos0 = lowHorizonCos0; //-1;
+         float horizonCos1 = lowHorizonCos1; //-1;
+
+         [unroll] for (float step = 0.0; step < STEPS_PER_SLICE; step++)
+         {
+            // R1 sequence (http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/)
+            const float stepBaseNoise = (slice + step * STEPS_PER_SLICE) * 0.6180339887498948482; // Compile-time unrolled.
+            float stepNoise = frac(noiseSample + stepBaseNoise);
+
+            // Approximate Algorithm 1 line 20 with noise.
+            float s = (step + stepNoise) / STEPS_PER_SLICE;
+
+            // Apply sample distribution power.
+            s = pow(s, sampleDistributionPower);
+
+            // Avoid the center pixel.
+            s += minS;
+
+            // Approximate Algorithm 1 lines 21-22.
+            float2 sampleOffset = s * omega;
+
+            float sampleOffsetLength = length(sampleOffset);
+
+            // Point XY sampling avoids interpolation between neighboring depths within a mip.
+            const float mipLevel = clamp(log2(sampleOffsetLength) - DEPTH_MIP_SAMPLING_OFFSET, 0.0, XE_GTAO_DEPTH_MIP_LEVELS);
+
+            // Snap to pixel centers for correct direction and slope math; retain full precision at high resolution.
+            sampleOffset = round(sampleOffset) * VIEWPORT_PIXEL_SIZE;
+
+            float2 sampleScreenPos0 = normalizedScreenPos + sampleOffset;
+            float SZ0 = sourceViewspaceDepth.SampleLevel(depthSampler, sampleScreenPos0, mipLevel).x;
+            float3 samplePos0 = XeGTAO_ComputeViewspacePosition(sampleScreenPos0, SZ0);
+
+            float2 sampleScreenPos1 = normalizedScreenPos - sampleOffset;
+            float SZ1 = sourceViewspaceDepth.SampleLevel(depthSampler, sampleScreenPos1, mipLevel).x;
+            float3 samplePos1 = XeGTAO_ComputeViewspacePosition(sampleScreenPos1, SZ1);
+
+            float3 sampleDelta0 = samplePos0 - pixCenterPos; // Reduced precision causes visible errors.
+            float3 sampleDelta1 = samplePos1 - pixCenterPos;
+            float sampleDist0 = length(sampleDelta0);
+            float sampleDist1 = length(sampleDelta1);
+
+            // Approximate Algorithm 1 lines 23-24.
+            float3 sampleHorizonVec0 = sampleDelta0 * rcp(sampleDist0);
+            float3 sampleHorizonVec1 = sampleDelta1 * rcp(sampleDist1);
+
+            // Bound sampling radius with a smooth falloff, following section 4.3. The thickness heuristic rejects
+            // samples behind the center earlier.
+            float falloffBase0 = length(float3(sampleDelta0.x, sampleDelta0.y, sampleDelta0.z * (1.0 + thinOccluderCompensation)));
+            float falloffBase1 = length(float3(sampleDelta1.x, sampleDelta1.y, sampleDelta1.z * (1.0 + thinOccluderCompensation)));
+            float weight0 = saturate(falloffBase0 * falloffMul + falloffAdd);
+            float weight1 = saturate(falloffBase1 * falloffMul + falloffAdd);
+
+            // Sample horizon cosines.
+            float shc0 = dot(sampleHorizonVec0, viewVec);
+            float shc1 = dot(sampleHorizonVec1, viewVec);
+
+            // Blend rejected samples toward the lower horizon.
+            shc0 = lerp(lowHorizonCos0, shc0, weight0); // Angular interpolation is more accurate but too expensive.
+            shc1 = lerp(lowHorizonCos1, shc1, weight1);
+
+            // THIN_OCCLUDER_COMPENSATION=0 disables the thickness adjustment.
+            horizonCos0 = max(horizonCos0, shc0);
+            horizonCos1 = max(horizonCos1, shc1);
+         }
+
+#if 1 // XeGTAO training-set slope adjustment: 0.05 gives PSNR 21.34 versus 21.45 when disabled.
+         projectedNormalVecLength = lerp(projectedNormalVecLength, 1.0, 0.05);
+#endif
+
+         // Approximate Algorithm 1 line 27.
+         float h0 = -XeGTAO_FastACos(horizonCos1);
+         float h1 = XeGTAO_FastACos(horizonCos0);
+         float iarc0 = (cosNorm + 2.0 * h0 * sin(n) - cos(2.0 * h0 - n)) / 4.0;
+         float iarc1 = (cosNorm + 2.0 * h1 * sin(n) - cos(2.0 * h1 - n)) / 4.0;
+         float localVisibility = projectedNormalVecLength * (iarc0 + iarc1);
+         visibility += localVisibility;
+      }
+      visibility /= SLICE_COUNT;
+      visibility = pow(visibility, max(0.05, FinalValuePowerRT)); // Runtime match to the native AO histogram.
+      visibility = max(0.03, visibility);                         // A visible surface cannot be fully occluded.
+   }
+
+   visibility = saturate(visibility / XE_GTAO_OCCLUSION_TERM_SCALE);
+   outWorkingAOTermAndEdges[pixCoord] = float2(visibility, edges);
+}
+
+void XeGTAO_DecodeGatherPartial(float4 packedValue, out float outDecoded[4])
+{
+   for (int i = 0; i < 4; i++)
+   {
+      outDecoded[i] = packedValue[i];
+   }
+}
+
+float4 XeGTAO_UnpackEdges(float _packedVal)
+{
+   uint packedVal = uint(_packedVal * 255.5);
+   float4 edgesLRTB;
+   edgesLRTB.x = float((packedVal >> 6) & 0x03) / 3.0; // Retain the mask for explicit packed-input safety.
+   edgesLRTB.y = float((packedVal >> 4) & 0x03) / 3.0;
+   edgesLRTB.z = float((packedVal >> 2) & 0x03) / 3.0;
+   edgesLRTB.w = float((packedVal >> 0) & 0x03) / 3.0;
+
+   return saturate(edgesLRTB);
+}
+
+void XeGTAO_AddSample(float ssaoValue, float edgeValue, inout float sum, inout float sumWeight)
+{
+   float weight = edgeValue;
+
+   sum += weight * ssaoValue;
+   sumWeight += weight;
+}
+
+void XeGTAO_Denoise(uint2 pixCoordBase, Texture2D sourceAOTermAndEdges, SamplerState texSampler,
+#if XE_GTAO_FINAL_APPLY
+                    RWTexture2D<unorm float> outputTexture // Native single-channel R8_UNORM AO target.
+#else
+                    RWTexture2D<unorm float2> outputTexture
+#endif
+)
+{
+#if DEVELOPMENT
+   // Pass debug values through without denoising.
+   if (DebugViewRT > 0.5)
+   {
+      for (int dside = 0; dside < 2; dside++)
+      {
+         const uint2 dpix = uint2(pixCoordBase.x + dside, pixCoordBase.y);
+         float v = sourceAOTermAndEdges.Load(int3(dpix, 0)).x;
+#if XE_GTAO_FINAL_APPLY
+         if (DebugViewRT >= 2.5 && DebugViewRT < 3.5) // AO x8 exposes broad over-occlusion.
+            v = saturate(1.0 - (1.0 - v * XE_GTAO_OCCLUSION_TERM_SCALE) * 8.0);
+         outputTexture[dpix] = v;
+#else
+         outputTexture[dpix] = float2(v, sourceAOTermAndEdges.Load(int3(dpix, 0)).y);
+#endif
+      }
+      return;
+   }
+#endif
+
+#if XE_GTAO_FINAL_APPLY
+   const float blurAmount = DENOISE_BLUR_BETA;
+#else
+   const float blurAmount = DENOISE_BLUR_BETA / 5.0;
+#endif
+
+   const float diagWeight = 0.85 * 0.5;
+
+   float aoTerm[2]; // pixCoordBase and its right neighbor.
+   float4 edgesC_LRTB[2];
+   float weightTL[2];
+   float weightTR[2];
+   float weightBL[2];
+   float weightBR[2];
+
+   // Gather edge and visibility quads.
+   const float2 gatherCenter = float2(pixCoordBase.x, pixCoordBase.y) * VIEWPORT_PIXEL_SIZE;
+   float4 edgesQ0 = sourceAOTermAndEdges.GatherGreen(texSampler, gatherCenter, int2(0, 0));
+   float4 edgesQ1 = sourceAOTermAndEdges.GatherGreen(texSampler, gatherCenter, int2(2, 0));
+   float4 edgesQ2 = sourceAOTermAndEdges.GatherGreen(texSampler, gatherCenter, int2(1, 2));
+
+   float visQ0[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(0, 0)), visQ0);
+   float visQ1[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(2, 0)), visQ1);
+   float visQ2[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(0, 2)), visQ2);
+   float visQ3[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(2, 2)), visQ3);
+
+   for (int side = 0; side < 2; side++)
+   {
+      const int2 pixCoord = int2(pixCoordBase.x + side, pixCoordBase.y);
+
+      float4 edgesL_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ0.x : edgesQ0.y);
+      float4 edgesT_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ0.z : edgesQ1.w);
+      float4 edgesR_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ1.x : edgesQ1.y);
+      float4 edgesB_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ2.w : edgesQ2.z);
+
+      edgesC_LRTB[side] = XeGTAO_UnpackEdges(side == 0 ? edgesQ0.y : edgesQ1.x);
+
+      // Edge detection is not guaranteed symmetric across neighboring pixels. Enforce symmetry for a sharper blur.
+      edgesC_LRTB[side] *= float4(edgesL_LRTB.y, edgesR_LRTB.x, edgesT_LRTB.w, edgesB_LRTB.z);
+
+#if 1 // Permit slight neighbor leakage across three or four edges to reduce aliasing.
+      const float leak_threshold = 2.5;
+      const float leak_strength = 0.5;
+      float edginess = (saturate(4.0 - leak_threshold - dot(edgesC_LRTB[side], 1.0)) * rcp(4.0 - leak_threshold)) * leak_strength;
+      edgesC_LRTB[side] = saturate(edgesC_LRTB[side] + edginess);
+#endif
+
+      // Diagonal weights shared by both denoise passes.
+      weightTL[side] = diagWeight * (edgesC_LRTB[side].x * edgesL_LRTB.z + edgesC_LRTB[side].z * edgesT_LRTB.x);
+      weightTR[side] = diagWeight * (edgesC_LRTB[side].z * edgesT_LRTB.y + edgesC_LRTB[side].y * edgesR_LRTB.z);
+      weightBL[side] = diagWeight * (edgesC_LRTB[side].w * edgesB_LRTB.x + edgesC_LRTB[side].x * edgesL_LRTB.w);
+      weightBR[side] = diagWeight * (edgesC_LRTB[side].y * edgesR_LRTB.w + edgesC_LRTB[side].w * edgesB_LRTB.y);
+
+      // Accumulate the 3x3 neighborhood.
+      float ssaoValue = side == 0 ? visQ0[1] : visQ1[0];
+      float ssaoValueL = side == 0 ? visQ0[0] : visQ0[1];
+      float ssaoValueT = side == 0 ? visQ0[2] : visQ1[3];
+      float ssaoValueR = side == 0 ? visQ1[0] : visQ1[1];
+      float ssaoValueB = side == 0 ? visQ2[2] : visQ3[3];
+      float ssaoValueTL = side == 0 ? visQ0[3] : visQ0[2];
+      float ssaoValueBR = side == 0 ? visQ3[3] : visQ3[2];
+      float ssaoValueTR = side == 0 ? visQ1[3] : visQ1[2];
+      float ssaoValueBL = side == 0 ? visQ2[3] : visQ2[2];
+
+      float sumWeight = blurAmount;
+      float sum = ssaoValue * sumWeight;
+
+      XeGTAO_AddSample(ssaoValueL, edgesC_LRTB[side].x, sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueR, edgesC_LRTB[side].y, sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueT, edgesC_LRTB[side].z, sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueB, edgesC_LRTB[side].w, sum, sumWeight);
+
+      XeGTAO_AddSample(ssaoValueTL, weightTL[side], sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueTR, weightTR[side], sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueBL, weightBL[side], sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueBR, weightBR[side], sum, sumWeight);
+
+      aoTerm[side] = sum / sumWeight;
+
+#if XE_GTAO_FINAL_APPLY
+      // Native R8_UNORM stores visibility only; the game applies it to the scene.
+      outputTexture[pixCoord] = saturate(aoTerm[side] * XE_GTAO_OCCLUSION_TERM_SCALE);
+#else
+      outputTexture[pixCoord] = float2(aoTerm[side], side == 0 ? edgesQ0.y : edgesQ1.x);
+#endif
+   }
+}
+
+// Shader entry points and bindings.
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+SamplerState smp : register(s0); // Luma binds point-clamp because native AO does not reliably set s0.
+
+Texture2D tex0 : register(t0);
+Texture2D tex1 : register(t1);
+
+RWTexture2D<float> out_working_depth_mip0 : register(u0);
+RWTexture2D<float> out_working_depth_mip1 : register(u1);
+RWTexture2D<float> out_working_depth_mip2 : register(u2);
+RWTexture2D<float> out_working_depth_mip3 : register(u3);
+RWTexture2D<float> out_working_depth_mip4 : register(u4);
+RWTexture2D<unorm float2> ao_term_and_edges : register(u0);
+
+#if XE_GTAO_FINAL_APPLY
+RWTexture2D<unorm float> final_output : register(u0); // Native final R8_UNORM AO.
+#else
+RWTexture2D<unorm float2> final_output : register(u0);
+#endif
+
+#define XE_GTAO_NUMTHREADS_X 8
+#define XE_GTAO_NUMTHREADS_Y 8
+
+// Hilbert mapping from https://www.shadertoy.com/view/3tB3z3, paired with an R2 sequence.
+#define XE_HILBERT_LEVEL 6U
+#define XE_HILBERT_WIDTH (1U << XE_HILBERT_LEVEL)
+#define XE_HILBERT_AREA  (XE_HILBERT_WIDTH * XE_HILBERT_WIDTH)
+uint HilbertIndex(uint posX, uint posY)
+{
+   uint index = 0U;
+   [unroll] for (uint curLevel = XE_HILBERT_WIDTH / 2U; curLevel > 0U; curLevel /= 2U)
+   {
+      uint regionX = (posX & curLevel) > 0U;
+      uint regionY = (posY & curLevel) > 0U;
+      index += curLevel * curLevel * ((3U * regionX) ^ regionY);
+      if (regionY == 0U)
+      {
+         if (regionX == 1U)
+         {
+            posX = XE_HILBERT_WIDTH - 1U - posX;
+            posY = XE_HILBERT_WIDTH - 1U - posY;
+         }
+         uint temp = posX;
+         posX = posY;
+         posY = temp;
+      }
+   }
+   return index;
+}
+
+// MELE has no TAA; callers keep temporalIndex at zero to prevent boiling.
+float2 SpatioTemporalNoise(uint2 pixCoord, uint temporalIndex)
+{
+   float2 noise;
+   uint index = HilbertIndex(pixCoord.x, pixCoord.y);
+   index += 288 * (temporalIndex % 64); // Empirical stride for XE_HILBERT_LEVEL=6.
+   // R2 sequence: http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+   return float2(frac(0.5 + index * float2(0.75487766624669276005, 0.5698402909980532659114)));
+}
+
+[numthreads(8, 8, 1)] // Each thread handles 2x2 pixels; dispatch in 16x16 blocks.
+    void prefilter_depths16x16_cs(uint2 dtid : SV_DispatchThreadID, uint2 gtid : SV_GroupThreadID) {
+       // tex0 = native half-resolution R24_UNORM_X8 depth captured at deinterleave.
+       XeGTAO_PrefilterDepths16x16(dtid, gtid, tex0, out_working_depth_mip0, out_working_depth_mip1, out_working_depth_mip2, out_working_depth_mip3, out_working_depth_mip4);
+    }
+
+        [numthreads(XE_GTAO_NUMTHREADS_X, XE_GTAO_NUMTHREADS_Y, 1)] void main_pass_cs(uint2 dtid : SV_DispatchThreadID)
+{
+   // tex0 = R32F view-space-depth pyramid; tex1 = native packed R8G8 normals; smp = point-clamp.
+
+   // Decode packed view-space xy and reconstruct unit z. Camera-facing normals use negative z.
+   float2 nxy = tex1.Load(int3(dtid, 0)).xy * 2.0 - 1.0;
+   float3 viewspaceNormal;
+   viewspaceNormal.xy = nxy;
+   viewspaceNormal.z = NORMAL_Z_SIGN * sqrt(saturate(1.0 - dot(nxy, nxy)));
+   viewspaceNormal = normalize(viewspaceNormal);
+
+   XeGTAO_MainPass(dtid, SpatioTemporalNoise(dtid, 0), viewspaceNormal, tex0, smp, ao_term_and_edges);
+}
+
+[numthreads(XE_GTAO_NUMTHREADS_X, XE_GTAO_NUMTHREADS_Y, 1)] void denoise_pass_cs(uint2 dtid : SV_DispatchThreadID) {
+   // tex0 = packed AO and edges; smp = point-clamp.
+   const uint2 pix_coord_base = dtid * uint2(2, 1); // Two horizontal pixels per thread.
+   XeGTAO_Denoise(pix_coord_base, tex0, smp, final_output);
+}

--- a/Shaders/Mass Effect Legendary Edition/Luma_SMAA_impl.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Luma_SMAA_impl.hlsl
@@ -1,0 +1,88 @@
+// SMAA Ultra replacement for the trilogy-wide MiniEngine FXAA chain.
+// Reference: https://github.com/iryoku/smaa
+// One gamma-encoded post snapshot feeds both color-edge detection and neighborhood blending; stage 2 decodes the
+// result later, so this path needs neither a linearization shader nor a second color copy.
+
+#include "../Includes/Common.hlsl"
+
+// Filled by the FXAA replacement hook in main.cpp.
+cbuffer SmaaMetricsCB : register(b1)
+{
+   float4 SmaaRtMetrics;
+   // x = off-edge threshold scale: 2 with valid same-sized depth, 1 for plain Ultra with null depth.
+   // y = depth-delta threshold; z = edge strength; w unused. Runtime values account for MELE's hyperbolic depth.
+   float4 SmaaPredication;
+}
+
+#define SMAA_RT_METRICS SmaaRtMetrics
+#define SMAA_PRESET_ULTRA
+#define SMAA_PREDICATION           1
+#define SMAA_PREDICATION_SCALE     SmaaPredication.x
+#define SMAA_PREDICATION_THRESHOLD SmaaPredication.y
+#define SMAA_PREDICATION_STRENGTH  SmaaPredication.z
+#define SMAA_CUSTOM_SL
+SamplerState LinearSampler : register(s0);
+SamplerState PointSampler : register(s1);
+#define SMAATexture2D(tex)                            Texture2D tex
+#define SMAATexturePass2D(tex)                        tex
+#define SMAASampleLevelZero(tex, coord)               tex.SampleLevel(LinearSampler, coord, 0)
+#define SMAASampleLevelZeroPoint(tex, coord)          tex.SampleLevel(PointSampler, coord, 0)
+#define SMAASampleLevelZeroOffset(tex, coord, offset) tex.SampleLevel(LinearSampler, coord, 0, offset)
+#define SMAASample(tex, coord)                        tex.Sample(LinearSampler, coord)
+#define SMAASamplePoint(tex, coord)                   tex.Sample(PointSampler, coord)
+#define SMAASampleOffset(tex, coord, offset)          tex.Sample(LinearSampler, coord, offset)
+#define SMAA_FLATTEN                                  [flatten]
+#define SMAA_BRANCH                                   [branch]
+#define SMAATexture2DMS2(tex)                         Texture2DMS<float4, 2> tex
+#define SMAALoad(tex, pos, sample)                    tex.Load(pos, sample)
+#define SMAAGather(tex, coord)                        tex.Gather(LinearSampler, coord, 0)
+#include "../Includes/SMAA.hlsl"
+
+Texture2D tex0 : register(t0);
+Texture2D tex1 : register(t1);
+Texture2D tex2 : register(t2);
+
+void fullscreen_triangle(uint id, out float4 position, out float2 texcoord)
+{
+   texcoord = float2((id << 1) & 2, id & 2);
+   position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}
+
+// SMAAEdgeDetection
+void smaa_edge_detection_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float4 offset[3] : TEXCOORD1)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAAEdgeDetectionVS(texcoord, offset);
+}
+
+float2 smaa_edge_detection_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float4 offset[3] : TEXCOORD1) : SV_Target
+{
+   // tex0 = gamma post color; tex1 = scene depth for predication.
+   return SMAAColorEdgeDetectionPS(texcoord, offset, tex0, tex1);
+}
+
+// SMAABlendingWeightCalculation
+void smaa_blending_weight_calculation_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float2 pixcoord : TEXCOORD1, out float4 offset[3] : TEXCOORD2)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAABlendingWeightCalculationVS(texcoord, pixcoord, offset);
+}
+
+float4 smaa_blending_weight_calculation_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float2 pixcoord : TEXCOORD1, float4 offset[3] : TEXCOORD2) : SV_Target
+{
+   // tex0 = edges, tex1 = area, tex2 = search.
+   return SMAABlendingWeightCalculationPS(texcoord, pixcoord, offset, tex0, tex1, tex2, 0);
+}
+
+// SMAANeighborhoodBlending
+void smaa_neighborhood_blending_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float4 offset : TEXCOORD1)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAANeighborhoodBlendingVS(texcoord, offset);
+}
+
+float4 smaa_neighborhood_blending_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float4 offset : TEXCOORD1) : SV_Target
+{
+   // tex0 = gamma post color; tex1 = blend weights.
+   return SMAANeighborhoodBlendingPS(texcoord, offset, tex0, tex1);
+}

--- a/Shaders/Mass Effect Legendary Edition/Output_0x0765601C.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Output_0x0765601C.ps_5_0.hlsl
@@ -1,0 +1,24 @@
+// Trilogy-wide stage-2 display map, decoding the gamma intermediate into absolute linear scRGB.
+//
+// Stage 1 writes gamma(scene / R) with R = UI Paper White / Game Paper White, and the native gamma HUD blends on
+// that buffer first, so decoding and multiplying by R restores the scene while leaving HUD white relative to Game
+// Paper White. This pass writes the swapchain directly as the frame's last draw, so under EARLY_DISPLAY_ENCODING
+// 1 it also applies G = Game Paper White / 80; Display Composition divides G back out when it does run.
+
+// clang-format off
+#include "Includes/Common.hlsl"   // Defines game settings; keep first.
+#include "../Includes/Color.hlsl" // Gamma transfer helpers.
+// clang-format on
+
+Texture2D<float4> SourceTexture : register(t0); // Stage-1 gamma scene with native HUD composition.
+SamplerState SourceTextureSampler_s : register(s0);
+
+void main(
+    float2 v0 : TEXCOORD0,
+    out float4 o0 : SV_Target0)
+{
+   // Both terms are cbuffer-uniform scalars: fold them so the decode is followed by a single vector multiply.
+   const float scale = MELE_GetUIPaperWhiteRelativeToGame() * MELE_GetGamePaperWhiteScale();
+   float3 c = SourceTexture.SampleLevel(SourceTextureSampler_s, v0.xy, 0).xyz;
+   o0 = float4(gamma_to_linear(c, GCT_MIRROR) * scale, 1.0);
+}

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x00944C2E.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x00944C2E.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// ME3 stage-1 tonemap: filmic and color-grade LUTs; no motion blur or film grain.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      0
+#include "Tonemap_ME3_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x109F3B6E.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x109F3B6E.ps_5_0.hlsl
@@ -1,0 +1,8 @@
+// ME1 stage-1 tonemap: LUT grade and film grain; no motion blur.
+// Shares the ME1/ME2 body; ME1 has no filmic axis and uses a power-100 vignette with a weaker blue floor.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      1
+#define TM_HAS_FILMIC     0
+#define TM_VIG_POW        100.0
+#define TM_VIG_FLOOR      kMELE_ME1VignetteFloor
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x151FE4CA.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x151FE4CA.ps_5_0.hlsl
@@ -1,0 +1,8 @@
+// ME1 stage-1 tonemap: LUT grade, motion blur, and film grain.
+// Shares the ME1/ME2 body; ME1 has no filmic axis and uses a power-100 vignette with a weaker blue floor.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      1
+#define TM_HAS_FILMIC     0
+#define TM_VIG_POW        100.0
+#define TM_VIG_FLOOR      kMELE_ME1VignetteFloor
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x1536C5B5.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x1536C5B5.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: LUT grade, motion blur, and film grain; no filmic LUT.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      1
+#define TM_HAS_FILMIC     0
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x222186F8.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x222186F8.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: filmic and color-grade LUTs; no motion blur or film grain.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      0
+#define TM_HAS_FILMIC     1
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x225A8330.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x225A8330.ps_5_0.hlsl
@@ -1,0 +1,128 @@
+// ME3 analytic stage-1 permutation used by the galaxy map and some cutscenes. It has no LUT, motion blur, grain,
+// or pre-grade tonemap curve: analytic Scene* operates directly on linear scene+bloom, followed by gamma, the
+// ME3 blue-tinted white point, and a clamp. Bindings: t0 scene, t1 DoF, t2/t3 near/far DoF, t4 bloom.
+//
+// Transcribed from live CSO 0x225A8330. With only an SDR clamp, the reversible max-channel wrap uses an identity
+// 0.18 -> 0.18 anchor before restoring linear HDR highlights.
+
+// clang-format off
+#include "Includes/Common.hlsl"
+#include "../Includes/Color.hlsl"
+#include "../Includes/DICE.hlsl"
+#include "../Includes/Reinhard.hlsl" // ReinhardScalable (max-channel compress)
+// clang-format on
+
+#define cmp -
+
+cbuffer _Globals : register(b0)
+{
+   float4 PackedParameters : packoffset(c0);
+   float4 InputTextureSize : packoffset(c1);
+   float4 MinMaxBlurClamp : packoffset(c2);
+   float4 DOFKernelParams : packoffset(c3);
+   float4 RenderTargetClampParameter : packoffset(c4);
+   float4 MotionBlurMaskScaleAndBias : packoffset(c5);
+   float4x4 ScreenToWorld : packoffset(c6);
+   float4x4 PrevViewProjMatrix : packoffset(c10);
+   float4 StaticVelocityParameters : packoffset(c14);
+   float4 DynamicVelocityParameters : packoffset(c15);
+   float StepOffsetsOpaque[5] : packoffset(c16);
+   float StepWeightsOpaque[5] : packoffset(c21);
+   float StepOffsetsTranslucent[5] : packoffset(c26);
+   float StepWeightsTranslucent[5] : packoffset(c31);
+   float4 BloomTintAndScreenBlendThreshold : packoffset(c36);
+   float4 HalfResMaskRect : packoffset(c37);
+   float4 SceneShadowsAndDesaturation : packoffset(c38);
+   float4 SceneInverseHighLights : packoffset(c39);
+   float4 SceneMidTones : packoffset(c40);
+   float4 SceneScaledLuminanceWeights : packoffset(c41);
+   float4 GammaColorScaleAndInverse : packoffset(c42);
+   float4 GammaOverlayColor : packoffset(c43);
+}
+
+SamplerState SceneColorTextureSampler_s : register(s0);
+SamplerState DOFTextureSampler_s : register(s1);
+SamplerState DOFBlurredNearSampler_s : register(s2);
+SamplerState DOFBlurredFarSampler_s : register(s3);
+SamplerState BlurredImageSeperateBloomSampler_s : register(s4);
+Texture2D<float4> SceneColorTexture : register(t0);
+Texture2D<float4> DOFTexture : register(t1);
+Texture2D<float4> DOFBlurredNear : register(t2);
+Texture2D<float4> DOFBlurredFar : register(t3);
+Texture2D<float4> BlurredImageSeperateBloom : register(t4);
+
+// Native analytic SDR grade transcribed from the live CSO, evaluated exactly once on the untouched per-channel
+// value in every Display Mode: SDR is its output and nothing else, HDR only scales it. Preserve its
+// register-level operations.
+float3 MELE_ME3Analytic_GradeChain(float3 c)
+{
+   float4 r0;
+   r0.xyz = c;
+   // Native analytic Scene grade directly on linear input.
+   r0.xyz = saturate(-SceneShadowsAndDesaturation.xyz + r0.xyz);
+   r0.xyz = SceneInverseHighLights.xyz * r0.xyz;
+   r0.xyz = log2(r0.xyz);
+   r0.xyz = SceneMidTones.xyz * r0.xyz;
+   r0.xyz = exp2(r0.xyz);
+   r0.w = dot(r0.xyz, SceneScaledLuminanceWeights.xyz);
+   r0.xyz = r0.xyz * SceneShadowsAndDesaturation.www + r0.www;
+   r0.xyz = GammaOverlayColor.xyz + r0.xyz;
+   // Native SDR gamma curve and ME3 white point.
+   r0.xyz = MELE_NativeGammaCurve(r0.xyz, GammaColorScaleAndInverse.xyz, GammaColorScaleAndInverse.w, true);
+
+   r0.xyz = float3(1.01036298, 1.00000572, 1.16309249) * r0.xyz; // Blue-tinted white point; no radial vignette.
+   r0.xyz = min(float3(1, 1, 1), r0.xyz);
+   return r0.xyz;
+}
+
+// Included here, not with the headers: MELE_CompositeDOF reads the _Globals fields and DOF textures declared above.
+#include "Includes/Tonemap_MELE_Scene.hlsli"
+
+void main(
+    float4 v0 : TEXCOORD0,
+    float2 v1 : TEXCOORD1,
+    out float4 o0 : SV_Target0,
+    out float o1 : SV_Target1)
+{
+   float4 r0, r1, r2, r3, r4;
+
+   r0.xy = DynamicScale.xy * v0.zw;
+   r1.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r0.xy).xyz;
+   r0.zw = cmp(float2(0, 0) < MinMaxBlurClamp.xy);
+   r1.w = (int)r0.w | (int)r0.z;
+
+   // Trilogy-wide native near/far depth-of-field composite.
+   if (r1.w != 0)
+   {
+      r1.xyz = MELE_CompositeDOF(r0.xy, r0.zw, r1.xyz);
+   }
+
+   // Scene-referred exposure before tonemapping.
+   r1.xyz = r1.xyz * LumaSettings.GameSettings.Exposure;
+
+   // Native bloom screen blend using Luma's rebound fp16 bloom.
+   r0.xyz = MELE_BloomScreenBlend(r0.xy, r1.xyz, r0.w);
+
+   float3 untonemapped = r0.xyz * r0.www + r1.xyz;
+   r0.xyz = untonemapped;
+   // No tonemap curve here, so the raw scene reaches the grade and the grade chain's own clamp is this
+   // permutation's vanilla blowout. HDR only measures the reversible max-channel ratio, with an identity mid-gray
+   // anchor because native SDR has no curve to match.
+   float mele_scale = 1.0;
+   if (LumaSettings.DisplayMode == 1)
+   {
+      float mele_mch = max(max3(untonemapped), 1e-6);
+      mele_scale = Reinhard::ReinhardScalable(mele_mch, 1.0, 0.0, 0.18, 0.18) / mele_mch;
+   }
+
+   float3 sdr_gamma = MELE_ME3Analytic_GradeChain(r0.xyz);
+
+   // Undo compression only where scale < 1, preserving native diffuse/shadow grading and restoring HDR
+   // highlights. SDR leaves mele_scale at 1.
+   float3 graded_hdr = gamma_to_linear(sdr_gamma, GCT_MIRROR) / min(1.0, mele_scale);
+
+   // ME3 analytic tail: no vignette or grain; preserve native output luma in alpha.
+#define TM_VIGNETTE_TYPE 0
+#define TM_ALPHA_LUMA    1
+#include "Includes/Tonemap_MELE_Output.hlsli"
+}

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x2754F750.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x2754F750.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: LUT grade and motion blur; no film grain or filmic LUT.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      0
+#define TM_HAS_FILMIC     0
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x36B90B12.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x36B90B12.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// ME3 stage-1 tonemap: filmic and color-grade LUTs with motion blur; no film grain.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      0
+#include "Tonemap_ME3_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x49BD5A95.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x49BD5A95.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// ME3 stage-1 tonemap: filmic and color-grade LUTs, motion blur, and film grain.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      1
+#include "Tonemap_ME3_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x5AA0BD09.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x5AA0BD09.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// ME3 stage-1 tonemap: filmic and color-grade LUTs with film grain; no motion blur.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      1
+#include "Tonemap_ME3_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x69F03340.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x69F03340.ps_5_0.hlsl
@@ -1,0 +1,8 @@
+// ME1 stage-1 tonemap: LUT grade and motion blur; no film grain.
+// Shares the ME1/ME2 body; ME1 has no filmic axis and uses a power-100 vignette with a weaker blue floor.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      0
+#define TM_HAS_FILMIC     0
+#define TM_VIG_POW        100.0
+#define TM_VIG_FLOOR      kMELE_ME1VignetteFloor
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x75BFAFBC.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x75BFAFBC.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: filmic and color-grade LUTs, motion blur, and film grain.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      1
+#define TM_HAS_FILMIC     1
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x8C8E8CA2.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x8C8E8CA2.ps_5_0.hlsl
@@ -1,0 +1,8 @@
+// ME1 stage-1 tonemap: LUT grade; no motion blur or film grain.
+// Shares the ME1/ME2 body; ME1 has no filmic axis and uses a power-100 vignette with a weaker blue floor.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      0
+#define TM_HAS_FILMIC     0
+#define TM_VIG_POW        100.0
+#define TM_VIG_FLOOR      kMELE_ME1VignetteFloor
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x8E0C0DBB.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x8E0C0DBB.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: color-grade LUT and film grain.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      1
+#define TM_HAS_FILMIC     0
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0x940979D8.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0x940979D8.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: filmic and color-grade LUTs with motion blur; no film grain.
+#define TM_HAS_MOTIONBLUR 1
+#define TM_HAS_GRAIN      0
+#define TM_HAS_FILMIC     1
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0xAAE8755A.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0xAAE8755A.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME1 stage-1 tonemap: analytic scene grade, no LUT, white point, or vignette. Verified against the dumped CSO:
+// after the native gamma curve it clamps to 1 and goes straight to the metering dot product and o0, with none of
+// the 0.832050323/3.25/pow-100 radial vignette constants the ME1 LUT permutations carry. ME2's 0xCC76075F matches.
+#define TM_VIGNETTE_TYPE 0
+#include "Tonemap_ME_Analytic_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0xCC76075F.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0xCC76075F.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// ME2 stage-1 tonemap: analytic scene grade with a blue-tinted white point; no LUT or vignette.
+#define TM_ANALYTIC_WHITEPOINT float3(1.01036298, 1.00000572, 1.16309249)
+#define TM_VIGNETTE_TYPE       0
+#include "Tonemap_ME_Analytic_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0xD077D06B.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0xD077D06B.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: color-grade LUT only.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      0
+#define TM_HAS_FILMIC     0
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_0xEC890842.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_0xEC890842.ps_5_0.hlsl
@@ -1,0 +1,5 @@
+// ME2 stage-1 tonemap: filmic and color-grade LUTs with film grain; no motion blur.
+#define TM_HAS_MOTIONBLUR 0
+#define TM_HAS_GRAIN      1
+#define TM_HAS_FILMIC     1
+#include "Tonemap_ME12_LUT_Body.hlsl"

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_ME12_LUT_Body.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_ME12_LUT_Body.hlsl
@@ -1,0 +1,380 @@
+// Shared ME1/ME2 stage-1 body for twelve LUT-graded permutations, selected by TM_HAS_MOTIONBLUR, TM_HAS_GRAIN,
+// TM_HAS_FILMIC and the ME1 vignette overrides. ME1 has no filmic axis; with the axes fixed the two games'
+// non-filmic paths are identical, verified bit-exact against the ME1 bytecode. The analytic shaders 0xAAE8755A
+// (ME1) and 0xCC76075F (ME2) use the shared analytic body instead.
+//   ME2: 0x2754F750 = MB         0x1536C5B5 = MB + grain      0x940979D8 = MB + filmic
+//        0x75BFAFBC = MB + grain + filmic
+//        0xD077D06B = (bare LUT) 0x8E0C0DBB = grain           0x222186F8 = filmic
+//        0xEC890842 = grain + filmic
+//   ME1: 0x151FE4CA = MB + grain 0x69F03340 = MB              0x109F3B6E = grain
+//        0x8C8E8CA2 = (bare LUT)
+//
+// Non-filmic grading is transcribed from 0x2754F750 and filmic grading from 0x222186F8; their register-level
+// swizzles differ, are each internally rotation-consistent, and must be preserved. The body emits linear
+// graded_hdr and native gamma sdr_gamma for the shared DICE/output tail.
+
+// clang-format off
+#include "Includes/Common.hlsl"      // Defines game settings; keep first.
+#include "../Includes/Color.hlsl"    // Transfer and color helpers.
+#include "../Includes/DICE.hlsl"     // Display-peak tonemap.
+#include "../Includes/Reinhard.hlsl" // Reversible max-channel compression.
+// clang-format on
+
+#ifndef TM_HAS_MOTIONBLUR
+#define TM_HAS_MOTIONBLUR 1
+#endif
+#ifndef TM_HAS_GRAIN
+#define TM_HAS_GRAIN 1
+#endif
+#ifndef TM_HAS_FILMIC
+#define TM_HAS_FILMIC 0
+#endif
+
+// Decompiler artifact kept so the verbatim transcription compiles unchanged.
+#define cmp -
+
+// Texture and sampler registers follow this fixed order:
+//   [depth (MB)] scene dof near far bloom lut [velocity (MB)] [noise (grain)] [filmic]
+#if TM_HAS_MOTIONBLUR
+#define R_DEPTH   t0
+#define R_SCENE   t1
+#define R_DOF     t2
+#define R_DOFNEAR t3
+#define R_DOFFAR  t4
+#define R_BLOOM   t5
+#define R_LUT     t6
+#define R_VEL     t7
+#define R_NOISE   t8
+#if TM_HAS_GRAIN
+#define R_FILMIC t9
+#else
+#define R_FILMIC t8
+#endif
+#define S_DEPTH   s0
+#define S_SCENE   s1
+#define S_DOF     s2
+#define S_DOFNEAR s3
+#define S_DOFFAR  s4
+#define S_BLOOM   s5
+#define S_LUT     s6
+#define S_VEL     s7
+#define S_NOISE   s8
+#if TM_HAS_GRAIN
+#define S_FILMIC s9
+#else
+#define S_FILMIC s8
+#endif
+#define CO_NOISEOFFSET c39
+#define CO_FILMGRAIN   c40
+#else
+#define R_SCENE   t0
+#define R_DOF     t1
+#define R_DOFNEAR t2
+#define R_DOFFAR  t3
+#define R_BLOOM   t4
+#define R_LUT     t5
+#define R_NOISE   t6
+#if TM_HAS_GRAIN
+#define R_FILMIC t7
+#define S_FILMIC s7
+#else
+#define R_FILMIC t6
+#define S_FILMIC s6
+#endif
+#define S_SCENE        s0
+#define S_DOF          s1
+#define S_DOFNEAR      s2
+#define S_DOFFAR       s3
+#define S_BLOOM        s4
+#define S_LUT          s5
+#define S_NOISE        s6
+#define CO_NOISEOFFSET c7
+#define CO_FILMGRAIN   c8
+#endif
+
+cbuffer _Globals : register(b0)
+{
+   float4 PackedParameters : packoffset(c0);
+   float4 InputTextureSize : packoffset(c1);
+   float4 MinMaxBlurClamp : packoffset(c2);
+   float4 DOFKernelParams : packoffset(c3);
+   float4 BloomTintAndScreenBlendThreshold : packoffset(c4);
+   float4 GammaColorScaleAndInverse : packoffset(c5);
+   float4 GammaOverlayColor : packoffset(c6);
+#if TM_HAS_MOTIONBLUR
+   float4 RenderTargetClampParameter : packoffset(c7);
+   float4 MotionBlurMaskScaleAndBias : packoffset(c8);
+   float4x4 ScreenToWorld : packoffset(c9);
+   float4x4 PrevViewProjMatrix : packoffset(c13);
+   float4 StaticVelocityParameters : packoffset(c17);
+   float4 DynamicVelocityParameters : packoffset(c18);
+   float StepOffsetsOpaque[5] : packoffset(c19);
+   float StepWeightsOpaque[5] : packoffset(c24);
+   float StepOffsetsTranslucent[5] : packoffset(c29);
+   float StepWeightsTranslucent[5] : packoffset(c34);
+#endif
+#if TM_HAS_GRAIN
+   float4 NoiseTextureOffset : packoffset(CO_NOISEOFFSET);
+   float FilmGrain_Scale : packoffset(CO_FILMGRAIN);
+#endif
+}
+
+#if TM_HAS_MOTIONBLUR
+Texture2D<float4> SceneDepthTexture : register(R_DEPTH);
+#endif
+Texture2D<float4> SceneColorTexture : register(R_SCENE);
+Texture2D<float4> DOFTexture : register(R_DOF);
+Texture2D<float4> DOFBlurredNear : register(R_DOFNEAR);
+Texture2D<float4> DOFBlurredFar : register(R_DOFFAR);
+Texture2D<float4> BlurredImageSeperateBloom : register(R_BLOOM);
+Texture2D<float4> ColorGradingLUT : register(R_LUT);
+#if TM_HAS_MOTIONBLUR
+Texture2D<float4> VelocityBuffer : register(R_VEL);
+#endif
+#if TM_HAS_GRAIN
+Texture2D<float4> NoiseTexture : register(R_NOISE);
+#endif
+#if TM_HAS_FILMIC
+Texture2D<float4> smpFilmicLUT : register(R_FILMIC);
+#endif
+
+#if TM_HAS_MOTIONBLUR
+SamplerState SceneDepthTextureSampler_s : register(S_DEPTH);
+#endif
+SamplerState SceneColorTextureSampler_s : register(S_SCENE);
+SamplerState DOFTextureSampler_s : register(S_DOF);
+SamplerState DOFBlurredNearSampler_s : register(S_DOFNEAR);
+SamplerState DOFBlurredFarSampler_s : register(S_DOFFAR);
+SamplerState BlurredImageSeperateBloomSampler_s : register(S_BLOOM);
+SamplerState ColorGradingLUTSampler_s : register(S_LUT);
+#if TM_HAS_MOTIONBLUR
+SamplerState VelocityBufferSampler_s : register(S_VEL);
+#endif
+#if TM_HAS_GRAIN
+SamplerState NoiseTextureSampler_s : register(S_NOISE);
+#endif
+#if TM_HAS_FILMIC
+SamplerState smpFilmicLUTSampler_s : register(S_FILMIC);
+#endif
+
+// Native ME1/ME2 SDR grade transcribed from live CSOs, evaluated exactly once on the untouched per-channel value
+// in every Display Mode: SDR is its output and nothing else, HDR only scales it. Preserve register-level
+// swizzles; the filmic 1D LUT stays inline in main().
+float3 MELE_ME12_GradeChain(float3 c)
+{
+   float4 r0, r1, r2;
+#if TM_HAS_FILMIC
+   r1.xyz = c;
+   // Native 16-slice LUT interpolation for filmic variants.
+   r0.yzw = float3(15, 0.05859375, 0.9375) * r1.xyz;
+   r0.y = floor(r0.y);
+   r1.x = r1.x * 15 + -r0.y;
+   r0.x = r0.y * 0.0625 + r0.z;
+   r0.xyzw = float4(0.001953125, 0.03125, 0.064453125, 0.03125) + r0.xwxw;
+   r1.yzw = ColorGradingLUT.Sample(ColorGradingLUTSampler_s, r0.xy).xyz;
+   r0.xyz = ColorGradingLUT.Sample(ColorGradingLUTSampler_s, r0.zw).xyz;
+   r0.xyz = r0.xyz + -r1.yzw;
+   r0.xyz = r1.xxx * r0.xyz + r1.yzw;
+#else
+   r0.xyz = c;
+   // Native highlight desaturation; keep swizzles.
+   r1.xyz = float3(0.993047416, 0.98082906, 0.980000436) * r0.xyz;
+   r0.w = dot(r0.yzx, float3(0.333000004, 0.333000004, 0.333000004));
+   r0.w = cmp(1.10000002 < r0.w);
+   r1.w = r0.w ? 1.000000 : 0;
+   r2.x = dot(r1.yzx, float3(0.300000012, 0.589999974, 0.109999999));
+   r2.xyz = -r0.xyz * float3(0.993047416, 0.98082906, 0.980000436) + r2.xxx;
+   r1.xyz = r2.xyz * float3(0.5, 0.5, 0.5) + r1.xyz;
+   r0.w = r0.w ? 0 : 1;
+   r0.xyz = r0.www * r0.xyz;
+   r0.xyz = r1.www * r1.xyz + r0.xyz;
+   // Native ImageAdjustments mix.
+   r0.w = dot(r0.yzx, float3(0.300000012, 0.589999974, 0.109999999));
+   r1.xyz = float3(0.400000006, 0.400000006, 0.400000006) * r0.xyz;
+   r1.xyz = r0.www * float3(0.600000024, 0.600000024, 0.600000024) + r1.xyz;
+   r1.xyz = r1.xyz * float3(1, 0.00658500008, 0.0199180003) + -r0.xyz;
+   r0.xyz = saturate(r1.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r0.xyz);
+   // Native 16-slice LUT interpolation.
+   r1.yzw = float3(15, 0.05859375, 0.9375) * r0.xyz;
+   r0.y = floor(r1.y);
+   r0.x = r0.x * 15 + -r0.y;
+   r1.x = r0.y * 0.0625 + r1.z;
+   r1.xyzw = float4(0.001953125, 0.03125, 0.064453125, 0.03125) + r1.xwxw;
+   r0.yzw = ColorGradingLUT.Sample(ColorGradingLUTSampler_s, r1.xy).xyz;
+   r1.xyz = ColorGradingLUT.Sample(ColorGradingLUTSampler_s, r1.zw).xyz;
+   r1.xyz = r1.xyz + -r0.yzw;
+   r0.xyz = r0.xxx * r1.xyz + r0.yzw;
+#endif
+   // Native GammaOverlayColor and SDR gamma curve.
+   r0.xyz = GammaOverlayColor.xyz + r0.xyz;
+   r0.xyz = MELE_NativeGammaCurve(r0.xyz, GammaColorScaleAndInverse.xyz, GammaColorScaleAndInverse.w, true);
+
+   return r0.xyz;
+}
+
+// Included here, not with the headers: MELE_CompositeDOF reads the _Globals fields and DOF textures declared above.
+#include "Includes/Tonemap_MELE_Scene.hlsli"
+#if TM_HAS_FILMIC
+// ME2's filmic LUT is addressed through the native exponential curve, not scene-linear.
+#define MELE_FILMIC_PRECURVE(x) (1.0 - exp2(-1.70000005 * (x)))
+#include "Includes/Tonemap_MELE_Filmic.hlsli"
+#endif
+
+void main(
+    float4 v0 : TEXCOORD0,
+    float2 v1 : TEXCOORD1,
+    out float4 o0 : SV_Target0,
+    out float o1 : SV_Target1)
+{
+   float4 r0, r1, r2, r3, r4;
+
+   r0.xy = DynamicScale.xy * v0.zw;
+   r1.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r0.xy).xyz;
+
+#if TM_HAS_MOTIONBLUR
+   // Native five-tap camera blur from 0x2754F750. VelocityBuffer.x is a SoftEdge mask that scales the vector.
+   r0.z = VelocityBuffer.Sample(VelocityBufferSampler_s, r0.xy).x;
+   r0.w = SceneDepthTexture.Sample(SceneDepthTextureSampler_s, r0.xy).x;
+   r0.w = r0.w * MinZ_MaxZRatio.z + -MinZ_MaxZRatio.w;
+   r0.w = max(1.00000001e-07, r0.w);
+   r0.w = 1 / r0.w;
+   r0.w = min(65504, r0.w);
+   r1.w = cmp(r0.w < 14);
+   r0.w = r1.w ? 65504 : r0.w;
+   r2.xy = v0.xy * r0.ww;
+   r2.yzw = PrevViewProjMatrix._m01_m11_m31 * r2.yyy;
+   r2.xyz = PrevViewProjMatrix._m00_m10_m30 * r2.xxx + r2.yzw;
+   r2.xyz = PrevViewProjMatrix._m02_m12_m32 * r0.www + r2.xyz;
+   r2.xyz = PrevViewProjMatrix._m03_m13_m33 + r2.xyz;
+   r2.xy = r2.xy / r2.zz;
+   r2.xy = v0.xy + -r2.xy;
+   r2.xy = StaticVelocityParameters.xy * r2.xy;
+   r0.w = dot(r2.xy, r2.xy);
+   r0.w = max(1, r0.w);
+   r0.w = rsqrt(r0.w);
+   r2.xy = r2.xy * r0.ww;
+   r0.zw = r2.xy * r0.zz;
+   r0.zw = DynamicVelocityParameters.xy * r0.zw;
+   r2.xy = r0.zw * StepOffsetsOpaque[1] + r0.xy;
+   r2.xy = max(RenderTargetClampParameter.xy, r2.xy);
+   r2.xy = min(RenderTargetClampParameter.zw, r2.xy);
+   r2.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r2.xy).xyz;
+   r2.xyz = float3(0.200000003, 0.200000003, 0.200000003) * r2.xyz;
+   r2.xyz = r1.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r2.xyz;
+   r3.xy = r0.zw * StepOffsetsOpaque[2] + r0.xy;
+   r3.xy = max(RenderTargetClampParameter.xy, r3.xy);
+   r3.xy = min(RenderTargetClampParameter.zw, r3.xy);
+   r3.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r3.xy).xyz;
+   r2.xyz = r3.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r2.xyz;
+   r3.xy = r0.zw * StepOffsetsOpaque[3] + r0.xy;
+   r3.xy = max(RenderTargetClampParameter.xy, r3.xy);
+   r3.xy = min(RenderTargetClampParameter.zw, r3.xy);
+   r3.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r3.xy).xyz;
+   r2.xyz = r3.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r2.xyz;
+   r3.xy = r0.zw * StepOffsetsOpaque[4] + r0.xy;
+   r3.xy = max(RenderTargetClampParameter.xy, r3.xy);
+   r3.xy = min(RenderTargetClampParameter.zw, r3.xy);
+   r3.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r3.xy).xyz;
+   r2.xyz = r3.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r2.xyz;
+   r0.zw = MotionBlurMaskScaleAndBias.xy * r0.zw;
+   r0.z = dot(r0.zw, r0.zw);
+   r0.z = sqrt(r0.z);
+   r0.z = min(1, r0.z);
+   r2.xyz = r2.xyz + -r1.xyz;
+   r1.xyz = r0.zzz * r2.xyz + r1.xyz;
+#endif
+   r0.zw = cmp(float2(0, 0) < MinMaxBlurClamp.xy);
+   r1.w = (int)r0.w | (int)r0.z;
+
+   // Native near/far depth-of-field composite shared with ME1.
+   if (r1.w != 0)
+   {
+      r1.xyz = MELE_CompositeDOF(r0.xy, r0.zw, r1.xyz);
+   }
+
+   // Scene-referred exposure before SDR and HDR tonemapping.
+   r1.xyz = r1.xyz * LumaSettings.GameSettings.Exposure;
+   float3 untonemapped;
+
+#if TM_HAS_FILMIC
+   // Filmic path from 0x222186F8: bloom, exponential curve, then per-channel 4096x1 LUT.
+   r0.xyz = MELE_BloomScreenBlend(r0.xy, r1.xyz, r0.w);
+
+   // Linear HDR scene plus bloom in RGB orientation.
+   untonemapped = r0.xyz * r0.www + r1.xyz;
+
+   // Native per-channel SDR curve: 1 - exp2(-1.7 * scene).
+   r1.xyz = float3(-1.70000005, -1.70000005, -1.70000005) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = float3(1, 1, 1) + -r1.xyz;
+   r0.xyz = r0.xyz * r0.www + r1.xyz;
+
+   // Native 4096x1 R16_UNORM filmic LUT. Preserve its channel rotation.
+   r0.xyz = float3(0.0616082214, 0.0616082214, 0.0616082214) * r0.xyz;
+   r1.y = smpFilmicLUT.Sample(smpFilmicLUTSampler_s, r0.xx).x;
+   r1.z = smpFilmicLUT.Sample(smpFilmicLUTSampler_s, r0.yy).x;
+   r1.x = smpFilmicLUT.Sample(smpFilmicLUTSampler_s, r0.zz).x;
+   r1.xyz = saturate(r1.xyz);
+   // The native per-channel filmic value reaches the 16-slice LUT untouched, so the vanilla white blowout survives
+   // into HDR: only the expansion scalar comes from the wrap.
+   float mele_expand = 1.0;
+   if (LumaSettings.DisplayMode == 1)
+   {
+      mele_expand = MELE_FilmicMaxChannelExpand(untonemapped);
+   }
+   // r1.xyz stays the native post-filmic value; only the expansion scalar comes from the wrap.
+#else
+   // Non-filmic path from 0x2754F750: bloom, exponential curve, highlight desaturation, adjustments, then LUT.
+   r0.xyz = BlurredImageSeperateBloom.Sample(BlurredImageSeperateBloomSampler_s, r0.xy).xyz * LumaSettings.GameSettings.BloomIntensity;
+   r0.xyz = BloomTintAndScreenBlendThreshold.zxy * r0.zxy;
+   r0.w = dot(r1.yzx, float3(0.298999995, 0.587000012, 0.114));
+   r0.xyzw = float4(4, 4, 4, -3) * r0.xyzw;
+   r0.w = exp2(r0.w);
+   r0.w = saturate(BloomTintAndScreenBlendThreshold.w * r0.w);
+
+   // Linear HDR scene plus bloom in RGB orientation.
+   untonemapped = r0.yzx * r0.www + r1.xyz;
+
+   // Native per-channel SDR curve: 1 - exp2(-1.7 * scene).
+   r1.xyz = float3(-1.70000005, -1.70000005, -1.70000005) * r1.zxy;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = float3(1, 1, 1) + -r1.xyz;
+   r0.xyz = r0.xyz * r0.www + r1.xyz;
+
+   // Non-filmic HDR wrap matches the ME1 max-channel path: the native per-channel value reaches the grade
+   // untouched and only the expansion scalar comes from the wrap.
+   float mele_scale = 1.0;
+   if (LumaSettings.DisplayMode == 1)
+   {
+      float mele_mch = max(max3(untonemapped), 1e-6);
+      // 1-exp2(-1.7*0.18) = 0.1911.
+      mele_scale = Reinhard::ReinhardScalable(mele_mch, 1.0, 0.0, 0.18, 0.1911) / mele_mch;
+   }
+   // r0.xyz stays the native per-channel value.
+#endif
+
+   // Use one native grade function for both the working value and SDR reference. Filmic feeds r1; non-filmic r0.
+#if TM_HAS_FILMIC
+   float3 sdr_gamma = MELE_ME12_GradeChain(r1.xyz);
+#else
+   float3 sdr_gamma = MELE_ME12_GradeChain(r0.xyz);
+#endif
+
+   // Scalar uncompression commutes with the LUT's channel restoration. Both paths reduce to native output in SDR.
+#if TM_HAS_FILMIC
+   float3 graded_hdr = gamma_to_linear(sdr_gamma, GCT_MIRROR) * mele_expand;
+#else
+   float3 graded_hdr = gamma_to_linear(sdr_gamma, GCT_MIRROR) / min(1.0, mele_scale);
+#endif
+
+   // Shared tail: radial vignette, optional grain, and zero alpha. Defaults are ME2's power-200 curve and blue
+   // white point; ME1 entry points override both.
+#define TM_VIGNETTE_TYPE 1
+#ifndef TM_VIG_POW
+#define TM_VIG_POW 200.0
+#endif
+#ifndef TM_VIG_FLOOR
+#define TM_VIG_FLOOR kMELE_ME2VignetteFloor
+#endif
+#include "Includes/Tonemap_MELE_Output.hlsli"
+}

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_ME3_LUT_Body.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_ME3_LUT_Body.hlsl
@@ -1,0 +1,290 @@
+// Shared ME3 stage-1 body for four filmic/LUT permutations, selected by TM_HAS_MOTIONBLUR and TM_HAS_GRAIN.
+//   0x36B90B12 = MB              0x49BD5A95 = MB + grain
+//   0x00944C2E = (bare)          0x5AA0BD09 = grain
+// Analytic shader 0x225A8330 remains standalone because its cbuffer and curve differ.
+//
+// Grade and filmic paths are transcribed from 0x00944C2E; motion blur comes from 0x36B90B12. Preserve their
+// register-level structure for comparison with live CSOs.
+// ME3 deltas vs the ME2 body:
+// - The 4096x1 R16_UNORM filmic LUT is the tonemap; input scale 0.0616082214 covers scene-linear to about 16.2.
+// - Channels remain straight RGB, bloom uses a 4x scale, and motion blur weights each tap by velocity.
+// - The smoothstep vignette contains a blue-tinted white point; the slider affects only radial darkening.
+// - All variants share one $Globals layout; grain appends c40/c41 and moves ScreenUVScaleBias from c40 to c42.
+
+// clang-format off
+#include "Includes/Common.hlsl"      // Defines game settings; keep first.
+#include "../Includes/Color.hlsl"    // Transfer and color helpers.
+#include "../Includes/DICE.hlsl"     // Display-peak tonemap.
+#include "../Includes/Reinhard.hlsl" // Reversible max-channel compression.
+// clang-format on
+
+#ifndef TM_HAS_MOTIONBLUR
+#define TM_HAS_MOTIONBLUR 1
+#endif
+#ifndef TM_HAS_GRAIN
+#define TM_HAS_GRAIN 1
+#endif
+
+// Decompiler artifact kept so the verbatim transcription compiles unchanged.
+#define cmp -
+
+// Texture and sampler registers follow this fixed order:
+//   [depth vel (MB)] scene dof near far bloom lut [noise (grain)] filmic
+// Unlike ME2, motion-blur velocity occupies t2 and shifts later DoF, bloom, and LUT slots by one.
+#if TM_HAS_MOTIONBLUR
+#define R_DEPTH   t0
+#define R_SCENE   t1
+#define R_VEL     t2
+#define R_DOF     t3
+#define R_DOFNEAR t4
+#define R_DOFFAR  t5
+#define R_BLOOM   t6
+#define R_LUT     t7
+#define S_DEPTH   s0
+#define S_SCENE   s1
+#define S_VEL     s2
+#define S_DOF     s3
+#define S_DOFNEAR s4
+#define S_DOFFAR  s5
+#define S_BLOOM   s6
+#define S_LUT     s7
+#if TM_HAS_GRAIN
+#define R_NOISE  t8
+#define S_NOISE  s8
+#define R_FILMIC t9
+#define S_FILMIC s9
+#else
+#define R_FILMIC t8
+#define S_FILMIC s8
+#endif
+#else
+#define R_SCENE   t0
+#define R_DOF     t1
+#define R_DOFNEAR t2
+#define R_DOFFAR  t3
+#define R_BLOOM   t4
+#define R_LUT     t5
+#define S_SCENE   s0
+#define S_DOF     s1
+#define S_DOFNEAR s2
+#define S_DOFFAR  s3
+#define S_BLOOM   s4
+#define S_LUT     s5
+#if TM_HAS_GRAIN
+#define R_NOISE  t6
+#define S_NOISE  s6
+#define R_FILMIC t7
+#define S_FILMIC s7
+#else
+#define R_FILMIC t6
+#define S_FILMIC s6
+#endif
+#endif
+
+cbuffer _Globals : register(b0)
+{
+   float4 PackedParameters : packoffset(c0);
+   float4 InputTextureSize : packoffset(c1);
+   float4 MinMaxBlurClamp : packoffset(c2);
+   float4 DOFKernelParams : packoffset(c3);
+   float4 RenderTargetClampParameter : packoffset(c4);
+   float4 MotionBlurMaskScaleAndBias : packoffset(c5);
+   float4x4 ScreenToWorld : packoffset(c6);
+   float4x4 PrevViewProjMatrix : packoffset(c10);
+   float4 StaticVelocityParameters : packoffset(c14);
+   float4 DynamicVelocityParameters : packoffset(c15);
+   float StepOffsetsOpaque[5] : packoffset(c16);
+   float StepWeightsOpaque[5] : packoffset(c21);
+   float StepOffsetsTranslucent[5] : packoffset(c26);
+   float StepWeightsTranslucent[5] : packoffset(c31);
+   float4 BloomTintAndScreenBlendThreshold : packoffset(c36);
+   float4 HalfResMaskRect : packoffset(c37);
+   float4 GammaColorScaleAndInverse : packoffset(c38);
+   float4 GammaOverlayColor : packoffset(c39);
+#if TM_HAS_GRAIN
+   float4 NoiseTextureOffset : packoffset(c40);
+   float FilmGrain_Scale : packoffset(c41);
+   float4 ScreenUVScaleBias : packoffset(c42);
+#else
+   float4 ScreenUVScaleBias : packoffset(c40);
+#endif
+}
+
+#if TM_HAS_MOTIONBLUR
+Texture2D<float4> SceneDepthTexture : register(R_DEPTH);
+Texture2D<float4> VelocityBuffer : register(R_VEL);
+#endif
+Texture2D<float4> SceneColorTexture : register(R_SCENE);
+Texture2D<float4> DOFTexture : register(R_DOF);
+Texture2D<float4> DOFBlurredNear : register(R_DOFNEAR);
+Texture2D<float4> DOFBlurredFar : register(R_DOFFAR);
+Texture2D<float4> BlurredImageSeperateBloom : register(R_BLOOM);
+Texture2D<float4> ColorGradingLUT : register(R_LUT);
+#if TM_HAS_GRAIN
+Texture2D<float4> NoiseTexture : register(R_NOISE);
+#endif
+Texture2D<float4> smpFilmicLUT : register(R_FILMIC);
+
+#if TM_HAS_MOTIONBLUR
+SamplerState SceneDepthTextureSampler_s : register(S_DEPTH);
+SamplerState VelocityBufferSampler_s : register(S_VEL);
+#endif
+SamplerState SceneColorTextureSampler_s : register(S_SCENE);
+SamplerState DOFTextureSampler_s : register(S_DOF);
+SamplerState DOFBlurredNearSampler_s : register(S_DOFNEAR);
+SamplerState DOFBlurredFarSampler_s : register(S_DOFFAR);
+SamplerState BlurredImageSeperateBloomSampler_s : register(S_BLOOM);
+SamplerState ColorGradingLUTSampler_s : register(S_LUT);
+#if TM_HAS_GRAIN
+SamplerState NoiseTextureSampler_s : register(S_NOISE);
+#endif
+SamplerState smpFilmicLUTSampler_s : register(S_FILMIC);
+
+// Native ME3 SDR grade transcribed from the live CSO, evaluated exactly once on the untouched per-channel value
+// in every Display Mode: SDR is its output and nothing else, HDR only scales it. Preserve register-level
+// operations; the filmic 1D LUT stays inline in main().
+float3 MELE_ME3_GradeChain(float3 c)
+{
+   float4 r0, r1;
+   r0.xyz = c;
+   // Native 16-slice LUT: slice from B, strip x from R.
+   r0.w = 15 * r0.z;
+   r1.w = floor(r0.w);
+   r0.z = r0.z * 15 + -r1.w;
+   r1.x = r1.w * 0.0625 + (0.05859375 * r0.x);
+   r1.y = 0.9375 * r0.y;
+   r1.xyzw = float4(0.001953125, 0.03125, 0.064453125, 0.03125) + r1.xyxy;
+   float3 lut_a = ColorGradingLUT.Sample(ColorGradingLUTSampler_s, r1.xy).xyz;
+   float3 lut_b = ColorGradingLUT.Sample(ColorGradingLUTSampler_s, r1.zw).xyz;
+   r0.xyz = r0.zzz * (lut_b - lut_a) + lut_a;
+   // Native GammaOverlayColor and SDR gamma curve.
+   r0.xyz = GammaOverlayColor.xyz + r0.xyz;
+   r0.xyz = MELE_NativeGammaCurve(r0.xyz, GammaColorScaleAndInverse.xyz, GammaColorScaleAndInverse.w, true);
+
+   return r0.xyz;
+}
+
+// Included here, not with the headers: MELE_CompositeDOF reads the _Globals fields and DOF textures declared above.
+#include "Includes/Tonemap_MELE_Filmic.hlsli"
+#include "Includes/Tonemap_MELE_Scene.hlsli"
+
+void main(
+    float4 v0 : TEXCOORD0,
+    float2 v1 : TEXCOORD1,
+    out float4 o0 : SV_Target0,
+    out float o1 : SV_Target1)
+{
+   float4 r0, r1, r2, r3, r4;
+
+   r0.xy = DynamicScale.xy * v0.zw;
+   r1.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r0.xy).xyz;
+
+#if TM_HAS_MOTIONBLUR
+   // Native camera blur from 0x36B90B12. VelocityBuffer.x is a SoftEdge mask; each tap uses weight 0.2*velocity
+   // and the result is normalized by their sum.
+   r0.z = VelocityBuffer.Sample(VelocityBufferSampler_s, r0.xy).x;
+   r0.w = SceneDepthTexture.Sample(SceneDepthTextureSampler_s, r0.xy).x;
+   r0.w = r0.w * MinZ_MaxZRatio.z + -MinZ_MaxZRatio.w;
+   r0.w = max(1.00000001e-07, r0.w);
+   r0.w = 1 / r0.w;
+   r0.w = min(65504, r0.w);
+   r1.w = cmp(r0.w < 14);
+   r0.w = r1.w ? 65504 : r0.w;
+   r2.xy = v0.xy * r0.ww;
+   r2.yzw = PrevViewProjMatrix._m01_m11_m31 * r2.yyy;
+   r2.xyz = PrevViewProjMatrix._m00_m10_m30 * r2.xxx + r2.yzw;
+   r2.xyz = PrevViewProjMatrix._m02_m12_m32 * r0.www + r2.xyz;
+   r2.xyz = PrevViewProjMatrix._m03_m13_m33 + r2.xyz;
+   r2.xy = r2.xy / r2.zz;
+   r2.xy = v0.xy + -r2.xy;
+   r2.xy = StaticVelocityParameters.xy * r2.xy;
+   r0.w = dot(r2.xy, r2.xy);
+   r0.w = max(1, r0.w);
+   r0.w = rsqrt(r0.w);
+   r2.xy = r2.xy * r0.ww;
+   r0.zw = r2.xy * r0.zz;
+   r0.zw = DynamicVelocityParameters.xy * r0.zw;
+   r2.xy = r0.zw * StepOffsetsOpaque[1] + r0.xy;
+   r2.xy = max(RenderTargetClampParameter.xy, r2.xy);
+   r2.xy = min(RenderTargetClampParameter.zw, r2.xy);
+   r1.w = VelocityBuffer.Sample(VelocityBufferSampler_s, r2.xy).x;
+   r2.z = 0.200000003 * r1.w;
+   r2.xyw = SceneColorTexture.Sample(SceneColorTextureSampler_s, r2.xy).xyz;
+   r2.xyz = r2.xyw * r2.zzz;
+   r2.xyz = r1.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r2.xyz;
+   r1.w = r1.w * 0.200000003 + 0.200000003;
+   r3.xy = r0.zw * StepOffsetsOpaque[2] + r0.xy;
+   r3.xy = max(RenderTargetClampParameter.xy, r3.xy);
+   r3.xy = min(RenderTargetClampParameter.zw, r3.xy);
+   r2.w = VelocityBuffer.Sample(VelocityBufferSampler_s, r3.xy).x;
+   r3.z = 0.200000003 * r2.w;
+   r3.xyw = SceneColorTexture.Sample(SceneColorTextureSampler_s, r3.xy).xyz;
+   r2.xyz = r3.xyw * r3.zzz + r2.xyz;
+   r1.w = r2.w * 0.200000003 + r1.w;
+   r3.xy = r0.zw * StepOffsetsOpaque[3] + r0.xy;
+   r3.xy = max(RenderTargetClampParameter.xy, r3.xy);
+   r3.xy = min(RenderTargetClampParameter.zw, r3.xy);
+   r2.w = VelocityBuffer.Sample(VelocityBufferSampler_s, r3.xy).x;
+   r3.z = 0.200000003 * r2.w;
+   r3.xyw = SceneColorTexture.Sample(SceneColorTextureSampler_s, r3.xy).xyz;
+   r2.xyz = r3.xyw * r3.zzz + r2.xyz;
+   r1.w = r2.w * 0.200000003 + r1.w;
+   r3.xy = r0.zw * StepOffsetsOpaque[4] + r0.xy;
+   r3.xy = max(RenderTargetClampParameter.xy, r3.xy);
+   r3.xy = min(RenderTargetClampParameter.zw, r3.xy);
+   r2.w = VelocityBuffer.Sample(VelocityBufferSampler_s, r3.xy).x;
+   r3.z = 0.200000003 * r2.w;
+   r3.xyw = SceneColorTexture.Sample(SceneColorTextureSampler_s, r3.xy).xyz;
+   r2.xyz = r3.xyw * r3.zzz + r2.xyz;
+   r1.w = r2.w * 0.200000003 + r1.w;
+   r2.xyz = r2.xyz / r1.www;
+   r0.zw = MotionBlurMaskScaleAndBias.xy * r0.zw;
+   r0.z = dot(r0.zw, r0.zw);
+   r0.z = sqrt(r0.z);
+   r0.z = min(1, r0.z);
+   r2.xyz = r2.xyz + -r1.xyz;
+   r1.xyz = r0.zzz * r2.xyz + r1.xyz;
+#endif
+   r0.zw = cmp(float2(0, 0) < MinMaxBlurClamp.xy);
+   r1.w = (int)r0.w | (int)r0.z;
+
+   // Trilogy-wide native composite of fp16 near/far DoF buffers.
+   if (r1.w != 0)
+   {
+      r1.xyz = MELE_CompositeDOF(r0.xy, r0.zw, r1.xyz);
+   }
+
+   // Scene-referred exposure before SDR and HDR tonemapping.
+   r1.xyz = r1.xyz * LumaSettings.GameSettings.Exposure;
+   // Native bloom screen blend from 0x00944C2E.
+   r0.xyz = MELE_BloomScreenBlend(r0.xy, r1.xyz, r0.w);
+
+   // Linear HDR scene plus bloom.
+   float3 untonemapped = r0.xyz * r0.www + r1.xyz;
+   r0.xyz = untonemapped;
+
+   // Native per-channel 4096x1 R16_UNORM filmic tonemap; input scale covers scene-linear to about 16.2.
+   r0.xyz = float3(0.0616082214, 0.0616082214, 0.0616082214) * r0.xyz;
+   r0.x = smpFilmicLUT.Sample(smpFilmicLUTSampler_s, r0.xx).x;
+   r0.y = smpFilmicLUT.Sample(smpFilmicLUTSampler_s, r0.yy).x;
+   r0.z = smpFilmicLUT.Sample(smpFilmicLUTSampler_s, r0.zz).x;
+   // The native per-channel filmic value reaches the grade untouched, so the vanilla white blowout survives into
+   // HDR: only the hue-preserving expansion scalar comes from the wrap.
+   float mele_expand = 1.0; // Post-grade uncompression; 1 in the native range.
+   if (LumaSettings.DisplayMode == 1)
+   {
+      mele_expand = MELE_FilmicMaxChannelExpand(untonemapped);
+   }
+
+   // Use one native grade function for both the working value and SDR reference.
+   float3 sdr_gamma = MELE_ME3_GradeChain(r0.xyz);
+
+   // Scalar uncompression preserves native mids/shadows and restores extrapolated HDR highlights. SDR leaves
+   // mele_expand at 1.
+   float3 graded_hdr = gamma_to_linear(sdr_gamma, GCT_MIRROR) * mele_expand;
+
+   // ME3 tail: smoothstep vignette, optional grain, and native output luma in alpha.
+#define TM_VIGNETTE_TYPE 3
+#define TM_ALPHA_LUMA    1
+#include "Includes/Tonemap_MELE_Output.hlsli"
+}

--- a/Shaders/Mass Effect Legendary Edition/Tonemap_ME_Analytic_Body.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Tonemap_ME_Analytic_Body.hlsl
@@ -1,0 +1,143 @@
+// Shared stage-1 body for ME1/ME2 analytic scene permutations used by the galaxy map, some Mako scenes, and
+// cutscenes. These permutations have no LUT, motion blur, or film grain. Bindings: t0 scene, t1 DoF, t2/t3
+// near/far DoF, t4 bloom.
+//
+// ME1 0xAAE8755A and ME2 0xCC76075F share the decompiled scene preparation and grade. Thin entry points select
+// vignette parameters and ME2's post-gamma white point. Preserve register-level swizzles for comparison with the
+// live CSOs. This body produces linear graded_hdr and native gamma sdr_gamma; the shared tail applies DICE.
+// ME3 analytic shader 0x225A8330 has a different cbuffer layout and no exponential curve.
+
+// clang-format off
+#include "Includes/Common.hlsl"
+#include "../Includes/Color.hlsl"
+#include "../Includes/DICE.hlsl"
+#include "../Includes/Reinhard.hlsl" // ReinhardScalable (max-channel compress)
+// clang-format on
+
+#define cmp -
+
+cbuffer _Globals : register(b0)
+{
+   float4 PackedParameters : packoffset(c0);
+   float4 InputTextureSize : packoffset(c1);
+   float4 MinMaxBlurClamp : packoffset(c2);
+   float4 DOFKernelParams : packoffset(c3);
+   float4 BloomTintAndScreenBlendThreshold : packoffset(c4);
+   float4 SceneShadowsAndDesaturation : packoffset(c5);
+   float4 SceneInverseHighLights : packoffset(c6);
+   float4 SceneMidTones : packoffset(c7);
+   float4 SceneScaledLuminanceWeights : packoffset(c8);
+   float4 GammaColorScaleAndInverse : packoffset(c9);
+   float4 GammaOverlayColor : packoffset(c10);
+}
+
+SamplerState SceneColorTextureSampler_s : register(s0);
+SamplerState DOFTextureSampler_s : register(s1);
+SamplerState DOFBlurredNearSampler_s : register(s2);
+SamplerState DOFBlurredFarSampler_s : register(s3);
+SamplerState BlurredImageSeperateBloomSampler_s : register(s4);
+Texture2D<float4> SceneColorTexture : register(t0);
+Texture2D<float4> DOFTexture : register(t1);
+Texture2D<float4> DOFBlurredNear : register(t2);
+Texture2D<float4> DOFBlurredFar : register(t3);
+Texture2D<float4> BlurredImageSeperateBloom : register(t4);
+
+// Native analytic SDR grade transcribed from the live CSOs, evaluated exactly once on the untouched per-channel
+// value in every Display Mode: SDR is its output and nothing else, HDR only scales it. Keep its register-level
+// swizzles and optional ME2 white point unchanged.
+float3 MELE_Analytic_GradeChain(float3 c)
+{
+   float4 r0, r1, r2;
+   r0.xyz = c;
+   // Native highlight desaturation.
+   r1.xyz = float3(0.98082906, 0.980000436, 0.993047416) * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.333000004, 0.333000004, 0.333000004));
+   r0.w = cmp(1.10000002 < r0.w);
+   r1.w = r0.w ? 1.000000 : 0;
+   r2.x = dot(r1.xyz, float3(0.300000012, 0.589999974, 0.109999999));
+   r2.xyz = -r0.xyz * float3(0.98082906, 0.980000436, 0.993047416) + r2.xxx;
+   r1.xyz = r2.xyz * float3(0.5, 0.5, 0.5) + r1.xyz;
+   r0.w = r0.w ? 0 : 1;
+   r0.xyz = r0.www * r0.xyz;
+   r0.xyz = r1.www * r1.xyz + r0.xyz;
+   // Native ImageAdjustments mix.
+   r0.w = dot(r0.xyz, float3(0.300000012, 0.589999974, 0.109999999));
+   r1.xyz = float3(0.400000006, 0.400000006, 0.400000006) * r0.xyz;
+   r1.xyz = r0.www * float3(0.600000024, 0.600000024, 0.600000024) + r1.xyz;
+   r1.xyz = r1.xyz * float3(0.00658500008, 0.0199180003, 1) + -r0.xyz;
+   r0.xyz = r1.xyz * float3(0.200000003, 0.200000003, 0.200000003) + r0.xyz;
+   // Native analytic Scene grade.
+   r0.xyz = saturate(-SceneShadowsAndDesaturation.xyz + r0.xyz);
+   r0.xyz = SceneInverseHighLights.xyz * r0.xyz;
+   r0.xyz = log2(r0.xyz);
+   r0.xyz = SceneMidTones.xyz * r0.xyz;
+   r0.xyz = exp2(r0.xyz);
+   r0.w = dot(r0.xyz, SceneScaledLuminanceWeights.xyz);
+   r0.xyz = r0.xyz * SceneShadowsAndDesaturation.www + GammaOverlayColor.xyz;
+   r0.xyz = r0.xyz + r0.www;
+   // Native SDR gamma curve.
+   r0.xyz = MELE_NativeGammaCurve(r0.xyz, GammaColorScaleAndInverse.xyz, GammaColorScaleAndInverse.w, false);
+
+#ifdef TM_ANALYTIC_WHITEPOINT
+   r0.xyz = TM_ANALYTIC_WHITEPOINT * r0.xyz; // ME2 blue-tinted white point; ME1 defines none.
+#endif
+   r0.xyz = min(float3(1, 1, 1), r0.xyz);
+   return r0.xyz;
+}
+
+// Included here, not with the headers: MELE_CompositeDOF reads the _Globals fields and DOF textures declared above.
+#include "Includes/Tonemap_MELE_Scene.hlsli"
+
+void main(
+    float4 v0 : TEXCOORD0,
+    float2 v1 : TEXCOORD1,
+    out float4 o0 : SV_Target0,
+    out float o1 : SV_Target1)
+{
+   float4 r0, r1, r2, r3, r4;
+
+   r0.xy = DynamicScale.xy * v0.zw;
+   r1.xyz = SceneColorTexture.Sample(SceneColorTextureSampler_s, r0.xy).xyz;
+   r0.zw = cmp(float2(0, 0) < MinMaxBlurClamp.xy);
+   r1.w = (int)r0.w | (int)r0.z;
+
+   // Native near/far depth-of-field composite.
+   if (r1.w != 0)
+   {
+      r1.xyz = MELE_CompositeDOF(r0.xy, r0.zw, r1.xyz);
+   }
+
+   // Scene-referred exposure before tonemapping.
+   r1.xyz = r1.xyz * LumaSettings.GameSettings.Exposure;
+
+   // Native screen-blend using Luma's rebound fp16 bloom; preserve unclamped linear scene+bloom for HDR.
+   r0.xyz = MELE_BloomScreenBlend(r0.xy, r1.xyz, r0.w);
+
+   float3 untonemapped = r0.xyz * r0.www + r1.xyz;
+
+   // Native per-channel SDR curve: 1 - exp2(-1.7 * scene).
+   r1.xyz = float3(-1.70000005, -1.70000005, -1.70000005) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = float3(1, 1, 1) + -r1.xyz;
+   r0.xyz = r0.xyz * r0.www + r1.xyz;
+   // The native per-channel value reaches the analytic grade untouched, so the vanilla white blowout survives into
+   // HDR: HDR only measures the reversible max-channel Reinhard ratio that expands the grade output below. Its
+   // 0.18 -> 0.1911 anchor matches the native exponential curve at mid-gray.
+   float mele_scale = 1.0;
+   if (LumaSettings.DisplayMode == 1)
+   {
+      float mele_mch = max(max3(untonemapped), 1e-6);
+      // 1-exp2(-1.7*0.18) = 0.1911.
+      mele_scale = Reinhard::ReinhardScalable(mele_mch, 1.0, 0.0, 0.18, 0.1911) / mele_mch;
+   }
+
+   // Apply the same native grade function to the working value and, below, to the SDR reference.
+   float3 sdr_gamma = MELE_Analytic_GradeChain(r0.xyz);
+
+   // Undo compression only where scale < 1, preserving the native diffuse/shadow grade while expanding HDR
+   // highlights. SDR leaves mele_scale at 1.
+   float3 graded_hdr = gamma_to_linear(sdr_gamma, GCT_MIRROR) / min(1.0, mele_scale);
+
+   // Entry point supplies vignette macros. Analytic ME1/ME2 permutations have no grain and write zero alpha.
+#include "Includes/Tonemap_MELE_Output.hlsli"
+}

--- a/Shaders/Mass Effect Legendary Edition/Video_0x7B5C59DF.ps_5_0.hlsl
+++ b/Shaders/Mass Effect Legendary Edition/Video_0x7B5C59DF.ps_5_0.hlsl
@@ -1,0 +1,90 @@
+// Trilogy-wide Bink YUV-to-RGB pass with optional HDR highlight expansion. The YUV matrix is transcribed from
+// 0x7B5C59DF; the native 8-bit clamp is restored before decoding because fp16 targets do not clamp YUV overshoot.
+//
+// Intermediate draws stay gamma for stage 2. Direct swapchain draws emit linear scRGB once stage 2 has
+// established a linear frame, and otherwise stay gamma for the final composition decode; C++ supplies both
+// states. Bypassing stage 2 makes the linear path the other pass that applies Game Paper White itself.
+
+// clang-format off
+#include "Includes/Common.hlsl"   // Defines game settings; keep first.
+#include "../Includes/Color.hlsl" // Gamma transfer helpers and reference white.
+// clang-format on
+
+// Keep the peak conservative because stronger expansion exposes Bink compression. Relative to UI white,
+// boost 0, 0.5, and 1 target 1x, 2.0625x, and 3.125x before scene/display peak containment.
+#ifndef ENABLE_VIDEO_AUTO_HDR
+#define ENABLE_VIDEO_AUTO_HDR 1
+#endif
+#ifndef VIDEO_AUTO_HDR_PEAK_NITS
+#define VIDEO_AUTO_HDR_PEAK_NITS 250.0
+#endif
+
+Texture2D<float4> tex0 : register(t0); // Y plane
+Texture2D<float4> tex1 : register(t1); // Cr plane
+Texture2D<float4> tex2 : register(t2); // Cb plane
+
+SamplerState tex0Sampler_s : register(s0);
+SamplerState tex1Sampler_s : register(s1);
+SamplerState tex2Sampler_s : register(s2);
+
+cbuffer _Globals : register(b0)
+{
+   float4 crc;    // Cr coefficients
+   float4 cbc;    // Cb coefficients
+   float4 adj;    // chroma re-centering offset
+   float4 yscale; // Y (luma) scale
+   float4 consts; // .w = alpha
+}
+
+void main(
+    float2 v0 : TEXCOORD0,
+    out float4 o0 : SV_Target0)
+{
+   // YUV-to-RGB matrix from 0x7B5C59DF.
+   float y = tex0.Sample(tex0Sampler_s, v0.xy).x;
+   float cr = tex1.Sample(tex1Sampler_s, v0.xy).x;
+   float cb = tex2.Sample(tex2Sampler_s, v0.xy).x;
+   float3 rgb = cr * crc.xyz + y * yscale.xyz + cb * cbc.xyz + adj.xyz;
+   o0.w = consts.w; // Preserve alpha for in-world video surfaces.
+
+   const bool hdr = LumaSettings.DisplayMode == 1;
+   const bool on_swapchain = LumaSettings.GameSettings.VideoOnSwapchain > 0.5;
+   const bool swapchain_gamma_encoded = LumaData.GameData.SwapchainGammaEncoded > 0.5;
+
+   // Restore the native clamp in every mode. Whether the decode is observable depends on the target.
+   const float3 clamped = saturate(rgb);
+
+   // Intermediate video and a native-SDR swapchain stay gamma for the remaining final decode.
+   const bool emit_linear = on_swapchain && !swapchain_gamma_encoded;
+#if ENABLE_VIDEO_AUTO_HDR
+   const bool auto_hdr = hdr && LumaSettings.GameSettings.VideoAutoHDREnable > 0.5; // Exact HDR mode only.
+#else
+   const bool auto_hdr = false;
+#endif
+
+   // Both selectors are cbuffer-uniform, so this branch is free. Skipping the decode/re-encode round trip on a
+   // gamma target is an exact identity and avoids the transcendental error the two paths would otherwise differ by.
+   [branch] if (!auto_hdr && !emit_linear)
+   {
+      o0.xyz = clamped;
+   }
+   else
+   {
+      // Decode exactly once; the target below decides how it is re-encoded.
+      float3 lin = gamma_to_linear(clamped, GCT_MIRROR);
+
+#if ENABLE_VIDEO_AUTO_HDR
+      [branch] if (auto_hdr)
+      {
+         // Linear 1 lands at UI Paper White after relative transport and final composition.
+         const float peakNits = lerp(sRGB_WhiteLevelNits, VIDEO_AUTO_HDR_PEAK_NITS, saturate(LumaSettings.GameSettings.VideoAutoHDRBoost));
+         lin = PumboAutoHDR(lin, peakNits, LumaSettings.UIPaperWhiteNits);
+      }
+#endif
+
+      // The linear branch writes the swapchain directly, so it carries both the transport ratio and Game Paper
+      // White, exactly as stage 2 does; video white then lands at UI Paper White.
+      const float directScale = MELE_GetUIPaperWhiteRelativeToGame() * MELE_GetGamePaperWhiteScale();
+      o0.xyz = emit_linear ? (lin * directScale) : linear_to_gamma(lin, GCT_MIRROR);
+   }
+}

--- a/Source/Games/Mass Effect Legendary Edition/Mass Effect Legendary Edition.vcxproj
+++ b/Source/Games/Mass Effect Legendary Edition/Mass Effect Legendary Edition.vcxproj
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Development-Debug|x64">
+      <Configuration>Development-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Release|x64">
+      <Configuration>Development-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Publishing-Release|x64">
+      <Configuration>Publishing-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Test-Release|x64">
+      <Configuration>Test-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7d3e1c92-5a64-4b18-9f2a-1e8c4d6b0a37}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Platform>x64</Platform>
+    <ProjectName>Mass Effect Legendary Edition</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">true</GenerateManifest>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>false</VcpkgEnableManifest>
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_DEBUG;_WINDOWS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_ME1_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME1_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME3_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME3_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_ME1_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME1_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME3_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME3_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;NDEBUG;TEST=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_ME1_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME1_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME3_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME3_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;NDEBUG;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_ME1_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME1_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME2_BIN_PATH%" || exit /B 0 )
+IF DEFINED LUMA_ME3_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_ME3_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Games/Mass Effect Legendary Edition/Mass Effect Legendary Edition.vcxproj.filters
+++ b/Source/Games/Mass Effect Legendary Edition/Mass Effect Legendary Edition.vcxproj.filters
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+  </ItemGroup>
+</Project>

--- a/Source/Games/Mass Effect Legendary Edition/main.cpp
+++ b/Source/Games/Mass Effect Legendary Edition/main.cpp
@@ -1,0 +1,1332 @@
+// Mass Effect Legendary Edition trilogy Luma mod (Unreal Engine 3, native DX11, x64). One addon, three games:
+// stage-1 hashes and bloom slots are per game, the FXAA/HBAO+/DoF/bloom/present chains are shared.
+//
+// Stage 1 replaces the SDR-clamping uber-post tonemap with an HDR reconstruction and DICE rolloff; stage 2
+// (0x0765601C) decodes the gamma intermediate and applies Game Paper White. SMAA replaces compute FXAA, fp16
+// pyramidal bloom replaces the UNORM bloom, XeGTAO writes the native AO target; native fp16 DoF is unchanged.
+//
+// Sub-native borderless is best-effort: the game allocates desktop-sized targets but renders a top-left
+// sub-rectangle through cb2 DynamicScale, so injected in-place passes process the full allocation.
+
+#define DISABLE_AUTO_DEBUGGER 1 // The DEVELOPMENT attach prompt is hidden by fullscreen and blocks the loader.
+
+#define ENABLE_NGX 0 // UE3 LE exposes only an 8-bit SoftEdge mask, not usable motion vectors for DLSS/DLAA.
+#define ENABLE_FIDELITY_SK 0
+#define GEOMETRY_SHADER_SUPPORT 0
+#define ENABLE_SMAA 1  // replaces the game's compute FXAA
+#define ENABLE_BLOOM 1 // fp16 pyramidal bloom replaces the game's clamped bloom
+
+#include "..\..\Core\core.hpp"
+#include <shellapi.h> // ShellExecuteA for About links (system() hangs the render thread in exclusive fullscreen)
+#include <vector>
+#include <unordered_set>
+#include <cmath>
+#include <array>
+#include <memory>
+#include <optional>
+#include <span>
+
+// Selects the per-game tonemap table used by injected resource-slot handling; replacement stays CSO-hash keyed.
+enum class MEGame
+{
+   Unknown = 0,
+   ME1,
+   ME2,
+   ME3,
+};
+static MEGame g_me_game = MEGame::ME1;
+
+static MEGame DetectMEGame()
+{
+   char path[MAX_PATH] = {};
+   GetModuleFileNameA(nullptr, path, MAX_PATH);
+   std::string exe(path);
+   for (auto& c : exe)
+      c = (char)tolower((unsigned char)c);
+   if (exe.find("masseffect3") != std::string::npos)
+      return MEGame::ME3;
+   if (exe.find("masseffect2") != std::string::npos)
+      return MEGame::ME2;
+   if (exe.find("masseffect1") != std::string::npos)
+      return MEGame::ME1;
+   return MEGame::ME1; // Treat an unknown executable as ME1.
+}
+
+// SMAA replaces the shared MiniEngine FXAA resolve on the fp16 gamma post buffer. The prepass and indirect-
+// argument dispatches touch only work queues and remain native.
+static constexpr uint32_t kFXAAResolveHHash = 0xB53BB634; // Horizontal resolve: replaced with SMAA.
+static constexpr uint32_t kFXAAResolveVHash = 0xF43DBFFD; // Vertical in-place refine: skipped after SMAA.
+
+// Stage-1 tonemap permutations (MB = motion blur, FG = film grain). Slots are stored per permutation because
+// MB binds depth at t0 and pushes everything up one, and ME3 additionally binds velocity at t2. They mirror
+// R_SCENE and R_BLOOM in the matching HLSL body with no compile-time cross-check, so a re-captured permutation
+// must move both sides. Unlisted permutations stay vanilla; this table drives only bloom and SMAA depth capture.
+struct TonemapPermDesc
+{
+   uint32_t hash;
+   uint8_t scene_slot; // 1 on motion-blur permutations, where t0 is depth instead of scene color.
+   uint8_t bloom_slot;
+};
+static constexpr TonemapPermDesc kTonemapPermsME1[] = {
+   {0x151FE4CA, 1, 5}, // MB+FG, LUT grade
+   {0x69F03340, 1, 5}, // MB, LUT grade
+   {0x109F3B6E, 0, 4}, // FG, LUT grade
+   {0x8C8E8CA2, 0, 4}, // LUT grade
+   {0xAAE8755A, 0, 4}, // analytic grade (no LUT)
+};
+static constexpr TonemapPermDesc kTonemapPermsME2[] = {
+   {0x2754F750, 1, 5}, // MB, LUT grade
+   {0x1536C5B5, 1, 5}, // MB+FG, LUT grade
+   {0x940979D8, 1, 5}, // MB, Filmic+LUT grade
+   {0x75BFAFBC, 1, 5}, // MB+FG, Filmic+LUT grade
+   {0xCC76075F, 0, 4}, // analytic grade (no LUT)
+   {0xD077D06B, 0, 4}, // LUT grade
+   {0x8E0C0DBB, 0, 4}, // FG, LUT grade
+   {0x222186F8, 0, 4}, // Filmic+LUT grade
+   {0xEC890842, 0, 4}, // FG, Filmic+LUT grade
+};
+static constexpr TonemapPermDesc kTonemapPermsME3[] = {
+   {0x36B90B12, 1, 6}, // MB(depth)+Filmic+LUT grade
+   {0x49BD5A95, 1, 6}, // MB(depth)+FG, Filmic+LUT grade
+   {0x00944C2E, 0, 4}, // Filmic+LUT grade
+   {0x5AA0BD09, 0, 4}, // FG, Filmic+LUT grade
+   {0x225A8330, 0, 4}, // analytic grade (no LUT)
+};
+// Selected once in DllMain.
+static std::span<const TonemapPermDesc> g_tonemap_perms = kTonemapPermsME1;
+
+// Everything that differs between the three games. ME2/ME3 share the native HBAO+ radius of 48 uu against ME1's
+// 30 uu; GTAO visibility power is 1 everywhere, so it stays at its global default instead of living here.
+struct MEGameProfile
+{
+   std::span<const TonemapPermDesc> tonemap_perms;
+   float gtao_radius_override; // Native radius (uu) / DepthScale; 0 keeps the shader's own radius.
+   float bloom_scale_ref;      // Energy match; the native bright-pass scale alone over-blooms the pyramid.
+};
+static constexpr MEGameProfile ProfileFor(MEGame game)
+{
+   switch (game)
+   {
+   case MEGame::ME2:
+      return {kTonemapPermsME2, 0.96f, 0.69f};
+   case MEGame::ME3:
+      // Native scale 0.5 matches ME3 bloom energy despite sharing ME2's bright-pass parameters.
+      return {kTonemapPermsME3, 0.96f, 0.5f};
+   default:
+      return {kTonemapPermsME1, 0.f, 1.01f};
+   }
+}
+// Quarter-resolution bloom bright-pass; cb0.xy = (BloomScale, Threshold).
+static constexpr uint32_t kBloomBrightPassHash = 0xF8942FF1;
+
+// User-facing AA settings persisted through ReShade.
+static bool g_smaa_enable = true;
+static float g_rcas_sharpness = 0.f; // RCAS sharpen on the SMAA output (0 = off, opt-in)
+
+// SMAA predication, uploaded as SmaaPredication.xyz. Not exposed: tuned to this engine's non-reverse hyperbolic
+// R24 depth, whose small far-silhouette deltas need 0.001 rather than SMAA's generic 0.01.
+static constexpr float kPredScale = 2.0f;       // [1,5] off-edge threshold multiplier.
+static constexpr float kPredThreshold = 0.001f; // Depth delta that identifies an edge.
+static constexpr float kPredStrength = 0.4f;    // [0,1] edge influence on the color threshold.
+
+// fp16 pyramidal bloom built from the stage-1 linear scene and rebound at the native bloom slot, keeping the
+// game's tint and screen blend. Mip count is fixed: DrawBloom resizes its static mip cache only in DEVELOPMENT.
+static bool g_bloom_enable = true;
+// One sigma per mip, so the two counts cannot drift apart.
+static constexpr std::array<float, 6> kBloomSigmas = {1.5f, 2.f, 2.f, 2.f, 2.f, 1.f};
+static float g_bloom_intensity = 1.0f;
+// Artist-authored per-scene cb0.x, read two frames late through a no-stall ring. Per-game divisor at which
+// slider 1 matches native energy; DllMain overrides it for ME2/ME3.
+static float g_bloom_scale_ref = 1.01f;
+
+// Bink targets the intermediate gamma buffer or the swapchain directly; GameSettings.VideoOnSwapchain reports
+// which, so the replacement applies the UI/Game scale exactly once.
+static constexpr uint32_t kVideoBinkHash = 0x7B5C59DF;
+// Shared stage 2 decodes the gamma scene/HUD composite into Game-relative linear scRGB. Native SDR omits it.
+static constexpr uint32_t kOutputStage2Hash = 0x0765601C;
+
+// XeGTAO replaces the half-resolution GFSDK HBAO+ chain, writing the game's R8_UNORM AO target at the blur
+// dispatch; the native apply blit still composites. No TAA, so noise is frozen and two spatial denoisers run.
+static constexpr uint32_t kAODeinterleaveHash = 0x497830D8; // Depth deinterleave: skipped after capture.
+static constexpr uint32_t kAOHorizonHash = 0x80212FD6;      // Horizon march: skipped after normal capture.
+static constexpr uint32_t kAOBlurHash = 0x06D92B08;         // Blur: replaced with XeGTAO.
+
+static bool g_gtao_enable = true;
+static bool g_video_auto_hdr_enable = true; // Expand Bink highlights in HDR; off preserves vanilla SDR video.
+static bool g_hide_ui = false;              // Session-only HUD suppression for clean captures.
+// Runtime XeGTAO parameters in b11. HBAO+ PowExponent does not transfer numerically (different visibility
+// curve), so FinalValuePower is calibrated against the native AO histogram.
+static float g_gtao_final_value_power = 1.0f;
+// Converts UE3 view-Z units (approximately 2 cm per uu) to the scale expected by XeGTAO.
+static float g_gtao_depth_scale = 50.f;
+// A positive value overrides EFFECT_RADIUS; native radius is sqrt(-1 / NegInvR2) / DepthScale.
+static float g_gtao_radius_override = 0.f;
+#if DEVELOPMENT || TEST
+static int g_gtao_debug_view = 0; // 0=off, 1=depth, 2=normals, 3=AO x8, 4=edges.
+#endif
+
+// Native DoF is retained: its fp16 near/far chain has no SDR clamp, and stage 1 composites those buffers.
+
+// Per-device SMAA resources. The gamma snapshot feeds both DrawSMAA color inputs; no linear copy is needed.
+struct MassEffectGameDeviceData final : public GameDeviceData
+{
+   // Handles already processed by SMAA this frame; later in-place FXAA resolves must be skipped.
+   std::unordered_set<uint64_t> smaa_applied_handles;
+
+   // R24 scene depth captured from motion-blur tonemap permutations for SMAA predication.
+   ComPtr<ID3D11ShaderResourceView> srv_depth;
+
+   // SMAA b1: target metrics followed by predication scale, threshold, and strength.
+   ComPtr<ID3D11Buffer> cb_smaa_metrics;
+   uint32_t smaa_metrics_w = 0, smaa_metrics_h = 0;
+   bool smaa_metrics_predicated = false; // Whether the cached metrics carry the depth-edge term or plain ULTRA.
+
+   // Size DrawSMAA built its core-managed intermediates at (rebuild on resolution change).
+   uint32_t smaa_core_w = 0, smaa_core_h = 0;
+
+   // SRV-readable snapshot of the in-place gamma post buffer.
+   ComPtr<ID3D11Texture2D> tex_input;
+   ComPtr<ID3D11ShaderResourceView> srv_input;
+   uint32_t smaa_temps_w = 0, smaa_temps_h = 0;
+
+   // fp16 SMAA output, copied back directly or through RCAS.
+   ComPtr<ID3D11Texture2D> tex_smaa_out;
+   ComPtr<ID3D11RenderTargetView> tex_smaa_out_rtv;
+   ComPtr<ID3D11ShaderResourceView> tex_smaa_out_srv;
+   uint32_t smaa_out_w = 0, smaa_out_h = 0;
+
+   // RCAS b0 = (width, height, sharpness, 0).
+   ComPtr<ID3D11Buffer> cb_sharpen;
+   uint32_t sharpen_w = 0, sharpen_h = 0;
+   float sharpen_amount = -1.f;
+   ComPtr<ID3D11Texture2D> tex_rcas_out;
+   ComPtr<ID3D11RenderTargetView> tex_rcas_out_rtv;
+   uint32_t rcas_out_w = 0, rcas_out_h = 0;
+
+   // XeGTAO scratch at half-res AO size: R24 depth from deinterleave t0, packed R8G8 view normals from horizon t0.
+   ComPtr<ID3D11ShaderResourceView> srv_gtao_depth;
+   ComPtr<ID3D11ShaderResourceView> srv_gtao_normals;
+   // Set only after a complete takeover at deinterleave; otherwise the native chain remains intact.
+   bool gtao_active_this_frame = false;
+
+   // Five-level R32F view-space-depth pyramid.
+   ComPtr<ID3D11Texture2D> tex_gtao_depth_mips;
+   ComPtr<ID3D11UnorderedAccessView> gtao_depth_mip_uavs[5];
+   ComPtr<ID3D11ShaderResourceView> srv_gtao_depth_mips;
+   // R8G8_UNORM AO/edge ping-pong; the second denoiser writes the game's u0.
+   ComPtr<ID3D11Texture2D> tex_gtao_working[2];
+   ComPtr<ID3D11UnorderedAccessView> uav_gtao_working[2];
+   ComPtr<ID3D11ShaderResourceView> srv_gtao_working[2];
+   uint32_t gtao_w = 0, gtao_h = 0;
+
+   // Immutable b11 = (FinalValuePower, DepthScale, RadiusOverride, DebugView).
+   ComPtr<ID3D11Buffer> cb_gtao;
+   float gtao_cb_fvp = -1.f, gtao_cb_depth_scale = -1.f, gtao_cb_radius = -1.f, gtao_cb_debug = -1.f;
+
+   // Bright-pass cb0 staging ring for no-stall per-scene BloomScale and threshold capture.
+   ComPtr<ID3D11Buffer> bloom_scale_ring[3];
+   int bloom_scale_ring_wr = 0;
+   int bloom_scale_ring_filled = 0;              // Do not map until every slot contains real data.
+   bool bloom_scale_captured_this_frame = false; // Once-per-frame capture gate.
+   bool scene_post_done_this_frame = false;      // Arms HUD suppression after the FXAA resolve.
+   bool stage2_seen_this_frame = false;          // False means final composition must decode the gamma swapchain.
+   float bloom_scale_live = -1.f;                // Negative until the first successful readback.
+   float bloom_threshold_live = -1.f;            // Negative selects the 1.2 fallback.
+#if DEVELOPMENT
+   int bloom_bright_pass_hits = 0; // Bright-pass captures this frame.
+#endif
+};
+
+class MassEffectLE final : public Game
+{
+   static MassEffectGameDeviceData& GetGameDeviceData(DeviceData& device_data)
+   {
+      return *static_cast<MassEffectGameDeviceData*>(device_data.game);
+   }
+
+   // Registered shader names, hashed once so registration, readiness probes and dispatch cannot drift apart.
+   static constexpr uint32_t kNameBloomVS = CompileTimeStringHash("Bloom VS");
+   static constexpr uint32_t kNameBloomPrefilterPS = CompileTimeStringHash("Bloom Prefilter PS");
+   static constexpr uint32_t kNameBloomDownsamplePS = CompileTimeStringHash("Bloom Downsample PS");
+   static constexpr uint32_t kNameBloomUpsamplePS = CompileTimeStringHash("Bloom Upsample PS");
+   static constexpr uint32_t kNameGTAOPrefilterCS = CompileTimeStringHash("MELE XeGTAO Prefilter Depths CS");
+   static constexpr uint32_t kNameGTAOMainPassCS = CompileTimeStringHash("MELE XeGTAO Main Pass CS");
+   static constexpr uint32_t kNameGTAODenoise1CS = CompileTimeStringHash("MELE XeGTAO Denoise Pass 1 CS");
+   static constexpr uint32_t kNameGTAODenoise2CS = CompileTimeStringHash("MELE XeGTAO Denoise Pass 2 CS");
+   static constexpr uint32_t kNameSMAAEdgeVS = CompileTimeStringHash("SMAA Edge Detection VS");
+   static constexpr uint32_t kNameSMAAEdgePS = CompileTimeStringHash("SMAA Edge Detection PS");
+   static constexpr uint32_t kNameSMAAWeightVS = CompileTimeStringHash("SMAA Blending Weight Calculation VS");
+   static constexpr uint32_t kNameSMAAWeightPS = CompileTimeStringHash("SMAA Blending Weight Calculation PS");
+   static constexpr uint32_t kNameSMAABlendVS = CompileTimeStringHash("SMAA Neighborhood Blending VS");
+   static constexpr uint32_t kNameSMAABlendPS = CompileTimeStringHash("SMAA Neighborhood Blending PS");
+   static constexpr uint32_t kNameCopyVS = CompileTimeStringHash("Copy VS");
+   static constexpr uint32_t kNameSharpenPS = CompileTimeStringHash("MELE Sharpen PS");
+
+   // operator[] default-inserts on a miss, which would mutate a map the render thread otherwise only reads.
+   template <typename ShaderMap>
+   static auto FindShader(const ShaderMap& shaders, uint32_t name)
+   {
+      const auto it = shaders.find(name);
+      return it != shaders.end() ? it->second.get() : nullptr;
+   }
+   template <typename ShaderMap>
+   static bool AllShadersReady(const ShaderMap& shaders, std::initializer_list<uint32_t> names)
+   {
+      for (const uint32_t name : names)
+      {
+         if (FindShader(shaders, name) == nullptr)
+            return false;
+      }
+      return true;
+   }
+
+   static bool CreateImmutableCB(ID3D11Device* device, const void* data, UINT size, ComPtr<ID3D11Buffer>& out)
+   {
+      out.reset();
+      D3D11_BUFFER_DESC bd = {};
+      bd.ByteWidth = size;
+      bd.Usage = D3D11_USAGE_IMMUTABLE;
+      bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+      D3D11_SUBRESOURCE_DATA sd = {};
+      sd.pSysMem = data;
+      return SUCCEEDED(device->CreateBuffer(&bd, &sd, out.put()));
+   }
+
+   static bool CreateDefaultRGBA16FTex(ID3D11Device* device, uint32_t w, uint32_t h, UINT bind_flags, ComPtr<ID3D11Texture2D>& out)
+   {
+      out.reset();
+      D3D11_TEXTURE2D_DESC td = {};
+      td.Width = w;
+      td.Height = h;
+      td.MipLevels = 1;
+      td.ArraySize = 1;
+      td.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+      td.SampleDesc.Count = 1;
+      td.Usage = D3D11_USAGE_DEFAULT;
+      td.BindFlags = bind_flags;
+      return SUCCEEDED(device->CreateTexture2D(&td, nullptr, out.put()));
+   }
+
+   // (Re)create an fp16 scratch target and its views on resolution change. Pass nullptr for a view the target does
+   // not use: bind flags follow the requested views, so an unused one cannot leave a stale flag behind.
+   static bool EnsureRGBA16FTarget(ID3D11Device* device, uint32_t w, uint32_t h, ComPtr<ID3D11Texture2D>& tex,
+      ComPtr<ID3D11RenderTargetView>* rtv, ComPtr<ID3D11ShaderResourceView>* srv, uint32_t& cached_w, uint32_t& cached_h)
+   {
+      if (!tex || cached_w != w || cached_h != h)
+      {
+         if (rtv != nullptr)
+            rtv->reset();
+         if (srv != nullptr)
+            srv->reset();
+         tex.reset();
+         const UINT bind_flags = (srv != nullptr ? D3D11_BIND_SHADER_RESOURCE : 0u) | (rtv != nullptr ? D3D11_BIND_RENDER_TARGET : 0u);
+         if (CreateDefaultRGBA16FTex(device, w, h, bind_flags, tex))
+         {
+            if (rtv != nullptr)
+               device->CreateRenderTargetView(tex.get(), nullptr, rtv->put());
+            if (srv != nullptr)
+               device->CreateShaderResourceView(tex.get(), nullptr, srv->put());
+            cached_w = w;
+            cached_h = h;
+         }
+      }
+      return (rtv == nullptr || *rtv) && (srv == nullptr || *srv);
+   }
+
+   static void ReleaseGTAOScratch(MassEffectGameDeviceData& gd)
+   {
+      gd.tex_gtao_depth_mips.reset();
+      for (auto& uav : gd.gtao_depth_mip_uavs)
+         uav.reset();
+      gd.srv_gtao_depth_mips.reset();
+      for (int i = 0; i < 2; i++)
+      {
+         gd.tex_gtao_working[i].reset();
+         gd.uav_gtao_working[i].reset();
+         gd.srv_gtao_working[i].reset();
+      }
+      gd.gtao_w = gd.gtao_h = 0;
+   }
+
+public:
+   void OnInit(bool async) override
+   {
+      // The game follows Windows HDR. Native HDR runs stage 2, so the frame reaches the swapchain linear and this
+      // game owns Game Paper White; native SDR has no stage 2, so it stays gamma and Core's composition owns the
+      // decode and the scale. Decided here because the shader compiler starts right after OnInit, with a null
+      // window because no swapchain exists yet (Display falls back to the primary monitor).
+      bool hdr_supported = false, hdr_enabled = false;
+      Display::IsHDRSupportedAndEnabled(0, hdr_supported, hdr_enabled);
+      const char native_hdr = hdr_enabled ? '1' : '0';
+
+      auto& post_process_space = GetShaderDefineData(POST_PROCESS_SPACE_TYPE_HASH);
+      post_process_space.SetDefaultValue(native_hdr);
+      post_process_space.SetValueFixed(true);
+      auto& early_display_encoding = GetShaderDefineData(EARLY_DISPLAY_ENCODING_HASH); // Inert unless the above is 1.
+      early_display_encoding.SetDefaultValue(native_hdr);
+      early_display_encoding.SetValueFixed(true);
+      GetShaderDefineData(VANILLA_ENCODING_TYPE_HASH).SetDefaultValue('0');
+      // The stage-1/stage-2 chain already carries gamma 2.2, so 1 would apply the sRGB mismatch a second time and
+      // crush shadows. On the native-SDR topology Core still corrects sRGB against 2.2 on its own, through the
+      // display-mode term of its composition pass.
+      GetShaderDefineData(GAMMA_CORRECTION_TYPE_HASH).SetDefaultValue('0');
+      // Exposes UI Paper White without renormalizing the already combined scene/HUD buffer; type 2 would
+      // double-apply the transport ratio.
+      GetShaderDefineData(UI_DRAW_TYPE_HASH).SetDefaultValue('1');
+
+      use_os_reference_white_level = false; // Explicit Scene and UI Paper White controls.
+
+      // Native post passes use b0-b3; inject Luma cbuffers at the high slots.
+      luma_settings_cbuffer_index = 13;
+      luma_data_cbuffer_index = 12;
+
+      // Core registers SMAA through ENABLE_SMAA; no input linearization is needed because the post buffer stays
+      // gamma encoded. RCAS runs afterwards through Copy VS and DrawCustomPixelShader.
+      native_shaders_definitions.emplace(kNameSharpenPS,
+         ShaderDefinition{"Luma_MELE_Sharpen", reshade::api::pipeline_subobject_type::pixel_shader, nullptr, "sharpen_ps"});
+
+      // Four XeGTAO compute entries share one source; XE_GTAO_FINAL_APPLY selects the game's R8_UNORM target.
+      native_shaders_definitions.emplace(kNameGTAOPrefilterCS,
+         ShaderDefinition{"Luma_MELE_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "prefilter_depths16x16_cs"});
+      native_shaders_definitions.emplace(kNameGTAOMainPassCS,
+         ShaderDefinition{"Luma_MELE_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "main_pass_cs"});
+      native_shaders_definitions.emplace(kNameGTAODenoise1CS,
+         ShaderDefinition{"Luma_MELE_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "denoise_pass_cs", {{"XE_GTAO_FINAL_APPLY", "0"}}});
+      native_shaders_definitions.emplace(kNameGTAODenoise2CS,
+         ShaderDefinition{"Luma_MELE_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "denoise_pass_cs", {{"XE_GTAO_FINAL_APPLY", "1"}}});
+
+      // With no TAA, Very High slice count and two denoise passes provide spatial stability.
+      std::vector<ShaderDefineData> game_shader_defines_data = {
+         {"XE_GTAO_QUALITY", '3', true, false, "XeGTAO quality (slice count)\n0 - Low\n1 - Medium\n2 - High\n3 - Very High\n4 - Ultra", 4},
+      };
+      shader_defines_data.append_range(game_shader_defines_data);
+
+      // Grade controls default to a vanilla no-op. Exposure affects SDR and HDR, the rest are HDR only.
+      default_luma_global_game_settings.Exposure = 1.f;
+      default_luma_global_game_settings.Saturation = 1.f;
+      default_luma_global_game_settings.HighlightDechroma = 0.f;
+      default_luma_global_game_settings.Contrast = 1.f;
+      default_luma_global_game_settings.VignetteIntensity = 1.f;
+      default_luma_global_game_settings.FilmGrainIntensity = 1.f;
+      default_luma_global_game_settings.BloomIntensity = g_bloom_intensity; // Per-game gain lives in g_bloom_scale_ref.
+      default_luma_global_game_settings.BloomThreshold = 1.2f;              // ME1 fallback until live capture succeeds.
+      default_luma_global_game_settings.Dithering = 1.f;                    // Output anti-banding.
+      default_luma_global_game_settings.VideoAutoHDREnable = 1.f;           // Off preserves vanilla SDR video.
+      default_luma_global_game_settings.VideoAutoHDRBoost = 0.5f;           // 0=1x, 0.5=2.0625x, 1=3.125x UI white.
+      default_luma_global_game_settings.VideoOnSwapchain = 0.f;             // Set per Bink draw.
+      cb_luma_global_settings.GameSettings = default_luma_global_game_settings;
+   }
+
+   void OnCreateDevice(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+      device_data.game = new MassEffectGameDeviceData;
+   }
+
+   void OnDestroyDeviceData(DeviceData& device_data) override
+   {
+      // GameDeviceData lacks a virtual destructor; delete through the concrete type to release derived members.
+      delete static_cast<MassEffectGameDeviceData*>(device_data.game);
+      device_data.game = nullptr;
+   }
+
+   // Capture bright-pass cb0 into a staging ring and map the oldest entry with DO_NOT_WAIT, so the readback
+   // never stalls. OnPresent turns the live artist-authored BloomScale into the effective intensity.
+   void CaptureBloomScale(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, MassEffectGameDeviceData& gd, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes)
+   {
+      if (g_bloom_enable && original_shader_hashes.Contains(kBloomBrightPassHash, reshade::api::shader_stage::pixel) && !gd.bloom_scale_captured_this_frame)
+      {
+         gd.bloom_scale_captured_this_frame = true; // Do not advance the ring twice in one frame.
+#if DEVELOPMENT
+         gd.bloom_bright_pass_hits++;
+#endif
+         ComPtr<ID3D11Buffer> cb0;
+         native_device_context->PSGetConstantBuffers(0, 1, cb0.put());
+         if (cb0)
+         {
+            if (!gd.bloom_scale_ring[2]) // Gate on the last slot so partial allocation retries next frame.
+            {
+               D3D11_BUFFER_DESC bd{};
+               cb0->GetDesc(&bd);
+               bd.Usage = D3D11_USAGE_STAGING;
+               bd.BindFlags = 0;
+               bd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+               bd.MiscFlags = 0;
+               for (auto& b : gd.bloom_scale_ring)
+                  b = nullptr; // com_ptr::put() requires null and this discards prior partial allocation.
+               for (auto& b : gd.bloom_scale_ring)
+               {
+                  if (FAILED(native_device->CreateBuffer(&bd, nullptr, b.put())))
+                  {
+                     for (auto& r : gd.bloom_scale_ring)
+                        r = nullptr;
+                     break;
+                  }
+               }
+            }
+            if (gd.bloom_scale_ring[2])
+            {
+               native_device_context->CopyResource(gd.bloom_scale_ring[gd.bloom_scale_ring_wr].get(), cb0.get());
+               if (gd.bloom_scale_ring_filled < 3)
+                  gd.bloom_scale_ring_filled++;
+               if (gd.bloom_scale_ring_filled >= 3)
+               {
+                  const int oldest = (gd.bloom_scale_ring_wr + 1) % 3; // Written two frames ago and expected idle.
+                  D3D11_MAPPED_SUBRESOURCE ms{};
+                  if (SUCCEEDED(native_device_context->Map(gd.bloom_scale_ring[oldest].get(), 0, D3D11_MAP_READ, D3D11_MAP_FLAG_DO_NOT_WAIT, &ms)))
+                  {
+                     const float* f = reinterpret_cast<const float*>(ms.pData);
+                     const float bscale = f[0];     // BloomScaleAndThreshold.x.
+                     const float bthreshold = f[1]; // BloomScaleAndThreshold.y, per-scene artist dial.
+                     native_device_context->Unmap(gd.bloom_scale_ring[oldest].get(), 0);
+                     if (bscale >= 0.f && bscale < 100.f) // Reject implausible readback data.
+                     {
+                        gd.bloom_scale_live = bscale;
+                     }
+                     if (bthreshold > 0.f && bthreshold < 100.f)
+                     {
+                        gd.bloom_threshold_live = bthreshold;
+                     }
+                  }
+               }
+               gd.bloom_scale_ring_wr = (gd.bloom_scale_ring_wr + 1) % 3; // Map failure skips only this update.
+            }
+         }
+      }
+   }
+
+   // Core uploads a dirty settings cbuffer before the replaced pass runs, so the flag applies to the same draw.
+   void TagVideoTarget(ID3D11DeviceContext* native_device_context, DeviceData& device_data, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes)
+   {
+      if (original_shader_hashes.Contains(kVideoBinkHash, reshade::api::shader_stage::pixel))
+      {
+         ComPtr<ID3D11RenderTargetView> rtv;
+         native_device_context->OMGetRenderTargets(1, rtv.put(), nullptr);
+         ComPtr<ID3D11Resource> rt_res;
+         if (rtv)
+            rtv->GetResource(rt_res.put());
+         if (rt_res)
+         {
+            const uint64_t rt_handle = reinterpret_cast<uint64_t>(rt_res.get());
+            bool on_swapchain;
+            {
+               // Swapchain recreation mutates back_buffers under unique_lock; draw hooks must take a shared lock.
+               std::shared_lock lock(device_data.mutex);
+               on_swapchain = device_data.back_buffers.contains(rt_handle);
+            }
+            auto& gs = cb_luma_global_settings.GameSettings;
+            const float flag = on_swapchain ? 1.f : 0.f;
+            if (gs.VideoOnSwapchain != flag)
+            {
+               gs.VideoOnSwapchain = flag;
+               device_data.cb_luma_global_settings_dirty = true;
+            }
+         }
+      }
+   }
+
+   // Stage 1 supplies motion-blur depth for SMAA and the scene/bloom slots for fp16 bloom injection.
+   void InjectBloomAndDepth(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, DeviceData& device_data, MassEffectGameDeviceData& gd, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes)
+   {
+      const TonemapPermDesc* perm = nullptr;
+      for (const TonemapPermDesc& candidate : g_tonemap_perms)
+      {
+         if (original_shader_hashes.Contains(candidate.hash, reshade::api::shader_stage::pixel))
+         {
+            perm = &candidate;
+            break;
+         }
+      }
+      if (perm == nullptr)
+         return;
+
+      if (g_smaa_enable)
+      {
+         if (perm->scene_slot != 0)
+         {
+            // Only motion-blur permutations bind depth at t0; non-MB t0 is scene color.
+            ComPtr<ID3D11ShaderResourceView> srv_d;
+            native_device_context->PSGetShaderResources(0, 1, srv_d.put());
+            if (srv_d)
+               gd.srv_depth = srv_d;
+         }
+         else
+         {
+            gd.srv_depth.reset(); // Disable predication instead of reusing stale depth.
+         }
+      }
+
+      // Build fp16 bloom from the tonemap's linear scene and rebind its native bloom slot.
+      const bool bloom_ready =
+         AllShadersReady(device_data.native_vertex_shaders, {kNameBloomVS}) &&
+         AllShadersReady(device_data.native_pixel_shaders, {kNameBloomPrefilterPS, kNameBloomDownsamplePS, kNameBloomUpsamplePS});
+      if (g_bloom_enable && bloom_ready)
+      {
+         ComPtr<ID3D11ShaderResourceView> srv_scene;
+         native_device_context->PSGetShaderResources(perm->scene_slot, 1, srv_scene.put());
+         if (srv_scene)
+         {
+            // Bloom prefilter reads GameSettings.BloomThreshold from b13; DrawBloom binds only b11.
+            if (luma_settings_cbuffer_index < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT)
+            {
+               ID3D11Buffer* settings_cb = device_data.luma_global_settings.get();
+               native_device_context->PSSetConstantBuffers(luma_settings_cbuffer_index, 1, &settings_cb);
+            }
+            ComPtr<ID3D11ShaderResourceView> srv_bloom;
+            DrawBloom(native_device, native_device_context, device_data, srv_scene.get(), (int)kBloomSigmas.size(), kBloomSigmas.data(), srv_bloom.put());
+            if (srv_bloom)
+            {
+               ID3D11ShaderResourceView* p = srv_bloom.get();
+               native_device_context->PSSetShaderResources(perm->bloom_slot, 1, &p);
+            }
+         }
+      }
+   }
+
+   // Take over HBAO+ only when every XeGTAO shader and resource is ready at the first dispatch, otherwise the
+   // whole native deinterleave -> horizon -> blur -> apply chain stays active. A returned value is terminal for
+   // the callback; nullopt means no AO hash matched and the caller continues.
+   std::optional<DrawOrDispatchOverrideType> RunXeGTAO(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, DeviceData& device_data, MassEffectGameDeviceData& gd, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes)
+   {
+      if (g_gtao_enable)
+      {
+         // Deinterleave: capture half-resolution R24 depth, prepare all scratch resources, then skip native work.
+         if (original_shader_hashes.Contains(kAODeinterleaveHash, reshade::api::shader_stage::compute))
+         {
+            const bool gtao_shaders_ready =
+               AllShadersReady(device_data.native_compute_shaders, {kNameGTAOPrefilterCS, kNameGTAOMainPassCS, kNameGTAODenoise1CS, kNameGTAODenoise2CS});
+            if (!gtao_shaders_ready)
+               return DrawOrDispatchOverrideType::None;
+
+            ComPtr<ID3D11ShaderResourceView> srv_d;
+            native_device_context->CSGetShaderResources(0, 1, srv_d.put());
+            if (!srv_d)
+               return DrawOrDispatchOverrideType::None;
+            uint4 dinfo{};
+            DXGI_FORMAT dfmt = DXGI_FORMAT_UNKNOWN;
+            GetResourceInfo(srv_d.get(), dinfo, dfmt);
+            if (dinfo.x == 0 || dinfo.y == 0)
+               return DrawOrDispatchOverrideType::None;
+            // Native cb0 stays content-dimensioned, so pixel/UV mapping holds even when the allocation is larger.
+            uint32_t w = dinfo.x, h = dinfo.y;
+
+            if (gd.gtao_w != w || gd.gtao_h != h || !gd.tex_gtao_depth_mips || !gd.tex_gtao_working[1])
+            {
+               ReleaseGTAOScratch(gd);
+
+               D3D11_TEXTURE2D_DESC td = {};
+               td.Width = w;
+               td.Height = h;
+               td.MipLevels = 5; // XE_GTAO_DEPTH_MIP_LEVELS.
+               td.ArraySize = 1;
+               td.Format = DXGI_FORMAT_R32_FLOAT;
+               td.SampleDesc.Count = 1;
+               td.Usage = D3D11_USAGE_DEFAULT;
+               td.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+               bool ok = SUCCEEDED(native_device->CreateTexture2D(&td, nullptr, gd.tex_gtao_depth_mips.put()));
+               D3D11_UNORDERED_ACCESS_VIEW_DESC ud = {};
+               ud.Format = td.Format;
+               ud.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+               for (int i = 0; ok && i < 5; i++)
+               {
+                  ud.Texture2D.MipSlice = i;
+                  ok = SUCCEEDED(native_device->CreateUnorderedAccessView(gd.tex_gtao_depth_mips.get(), &ud, gd.gtao_depth_mip_uavs[i].put()));
+               }
+               ok = ok && SUCCEEDED(native_device->CreateShaderResourceView(gd.tex_gtao_depth_mips.get(), nullptr, gd.srv_gtao_depth_mips.put()));
+
+               td.MipLevels = 1;
+               td.Format = DXGI_FORMAT_R8G8_UNORM;
+               for (int i = 0; ok && i < 2; i++)
+               {
+                  ok = ok && SUCCEEDED(native_device->CreateTexture2D(&td, nullptr, gd.tex_gtao_working[i].put()));
+                  ok = ok && SUCCEEDED(native_device->CreateUnorderedAccessView(gd.tex_gtao_working[i].get(), nullptr, gd.uav_gtao_working[i].put()));
+                  ok = ok && SUCCEEDED(native_device->CreateShaderResourceView(gd.tex_gtao_working[i].get(), nullptr, gd.srv_gtao_working[i].put()));
+               }
+               if (!ok)
+               {
+                  ReleaseGTAOScratch(gd);                  // All or nothing; retry clean next frame.
+                  return DrawOrDispatchOverrideType::None; // Leaves the native chain active.
+               }
+               gd.gtao_w = w;
+               gd.gtao_h = h;
+            }
+
+#if DEVELOPMENT || TEST
+            const float dbg = (float)g_gtao_debug_view;
+#else
+            const float dbg = 0.f;
+#endif
+            if (!gd.cb_gtao || gd.gtao_cb_fvp != g_gtao_final_value_power || gd.gtao_cb_depth_scale != g_gtao_depth_scale ||
+                gd.gtao_cb_radius != g_gtao_radius_override || gd.gtao_cb_debug != dbg)
+            {
+               const float knobs[4] = {g_gtao_final_value_power, g_gtao_depth_scale, g_gtao_radius_override, dbg};
+               if (CreateImmutableCB(native_device, knobs, sizeof(knobs), gd.cb_gtao))
+               {
+                  gd.gtao_cb_fvp = g_gtao_final_value_power;
+                  gd.gtao_cb_depth_scale = g_gtao_depth_scale;
+                  gd.gtao_cb_radius = g_gtao_radius_override;
+                  gd.gtao_cb_debug = dbg;
+               }
+            }
+            if (!gd.cb_gtao)
+               return DrawOrDispatchOverrideType::None;
+
+            gd.srv_gtao_depth = srv_d;
+            gd.gtao_active_this_frame = true;
+            return DrawOrDispatchOverrideType::Replaced;
+         }
+
+         // Horizon march: capture packed view normals and skip native work only after a successful takeover.
+         if (original_shader_hashes.Contains(kAOHorizonHash, reshade::api::shader_stage::compute))
+         {
+            if (!gd.gtao_active_this_frame)
+               return DrawOrDispatchOverrideType::None;
+            ComPtr<ID3D11ShaderResourceView> srv_n;
+            native_device_context->CSGetShaderResources(0, 1, srv_n.put());
+            if (srv_n)
+               gd.srv_gtao_normals = srv_n;
+
+            return DrawOrDispatchOverrideType::Replaced;
+         }
+
+         // Blur: run all XeGTAO passes and write the game's final R8_UNORM u0; native apply performs composition.
+         if (original_shader_hashes.Contains(kAOBlurHash, reshade::api::shader_stage::compute))
+         {
+            if (!gd.gtao_active_this_frame)
+               return DrawOrDispatchOverrideType::None;
+
+            ComPtr<ID3D11UnorderedAccessView> uav_final;
+            native_device_context->CSGetUnorderedAccessViews(0, 1, uav_final.put());
+            if (!uav_final)
+               return DrawOrDispatchOverrideType::Replaced; // Earlier native stages were already skipped.
+            if (!gd.srv_gtao_depth || !gd.srv_gtao_normals)
+            {
+               // Missing fixed-order inputs: write neutral AO instead of applying stale data.
+               const FLOAT ones[4] = {1.f, 1.f, 1.f, 1.f};
+               native_device_context->ClearUnorderedAccessViewFloat(uav_final.get(), ones);
+               return DrawOrDispatchOverrideType::Replaced;
+            }
+
+            // Dispatch dimensions follow the captured content size; native apply ignores any larger stale region.
+            const uint32_t w = gd.gtao_w, h = gd.gtao_h;
+            DrawStateStack<DrawStateStackType::Compute> st;
+            st.Cache(native_device_context, device_data.uav_max_count);
+
+            ID3D11Buffer* kcb = gd.cb_gtao.get();
+            native_device_context->CSSetConstantBuffers(11, 1, &kcb);
+            ID3D11SamplerState* smp = device_data.sampler_state_point.get();
+            native_device_context->CSSetSamplers(0, 1, &smp);
+            // XeGTAO deliberately inherits native b0 ($Globals/ProjInfo) and b2 (MinZ_MaxZRatioCS): the immediate
+            // context runs a fixed contiguous AO chain with no ClearState, so the horizon-pass bindings persist.
+
+            static constexpr std::array<ID3D11UnorderedAccessView*, 5> uav_nulls5 = {};
+            static constexpr std::array<ID3D11ShaderResourceView*, 2> srv_nulls2 = {};
+
+            // Prefilter game depth into the R32F mip pyramid; each thread covers 2x2 pixels.
+            {
+               native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+               ID3D11ShaderResourceView* srv = gd.srv_gtao_depth.get();
+               ID3D11UnorderedAccessView* uavs[5] = {gd.gtao_depth_mip_uavs[0].get(), gd.gtao_depth_mip_uavs[1].get(),
+                  gd.gtao_depth_mip_uavs[2].get(), gd.gtao_depth_mip_uavs[3].get(), gd.gtao_depth_mip_uavs[4].get()};
+               native_device_context->CSSetUnorderedAccessViews(0, 5, uavs, nullptr);
+               native_device_context->CSSetShaderResources(0, 1, &srv);
+               native_device_context->CSSetShader(FindShader(device_data.native_compute_shaders, kNameGTAOPrefilterCS), nullptr, 0);
+               native_device_context->Dispatch((w + 15) / 16, (h + 15) / 16, 1);
+               native_device_context->CSSetUnorderedAccessViews(0, 5, uav_nulls5.data(), nullptr);
+            }
+            // Bind each destination UAV before its source SRVs: D3D11 otherwise keeps the previous UAV hazard and
+            // silently nulls the conflicting SRV. Main pass writes AO and edges to working0.
+            {
+               native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+               ID3D11ShaderResourceView* srvs[2] = {gd.srv_gtao_depth_mips.get(), gd.srv_gtao_normals.get()};
+               ID3D11UnorderedAccessView* uav = gd.uav_gtao_working[0].get();
+               native_device_context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+               native_device_context->CSSetShaderResources(0, 2, srvs);
+               native_device_context->CSSetShader(FindShader(device_data.native_compute_shaders, kNameGTAOMainPassCS), nullptr, 0);
+               native_device_context->Dispatch((w + 7) / 8, (h + 7) / 8, 1);
+            }
+            // First denoiser writes working1, two horizontal pixels per thread.
+            {
+               native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+               ID3D11ShaderResourceView* srv = gd.srv_gtao_working[0].get();
+               ID3D11UnorderedAccessView* uav = gd.uav_gtao_working[1].get();
+               native_device_context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+               native_device_context->CSSetShaderResources(0, 1, &srv);
+               native_device_context->CSSetShader(FindShader(device_data.native_compute_shaders, kNameGTAODenoise1CS), nullptr, 0);
+               native_device_context->Dispatch((w + 15) / 16, (h + 7) / 8, 1);
+            }
+            // Final denoiser writes the game's R8_UNORM AO target.
+            {
+               native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+               ID3D11ShaderResourceView* srv = gd.srv_gtao_working[1].get();
+               ID3D11UnorderedAccessView* uav = uav_final.get();
+               native_device_context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+               native_device_context->CSSetShaderResources(0, 1, &srv);
+               native_device_context->CSSetShader(FindShader(device_data.native_compute_shaders, kNameGTAODenoise2CS), nullptr, 0);
+               native_device_context->Dispatch((w + 15) / 16, (h + 7) / 8, 1);
+            }
+
+            st.Restore(native_device_context);
+            return DrawOrDispatchOverrideType::Replaced;
+         }
+      }
+
+      return {};
+   }
+
+   // Replace the in-place FXAA resolve with SMAA by taking color from u0. Disabled SMAA leaves FXAA native.
+   DrawOrDispatchOverrideType RunSMAAResolve(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, DeviceData& device_data, MassEffectGameDeviceData& gd, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass)
+   {
+      const bool is_resolve_h = original_shader_hashes.Contains(kFXAAResolveHHash, reshade::api::shader_stage::compute);
+      const bool is_resolve_v = original_shader_hashes.Contains(kFXAAResolveVHash, reshade::api::shader_stage::compute);
+      // The resolve is the final scene-post step and arms HUD suppression for subsequent draws regardless of AA.
+      if (is_resolve_h || is_resolve_v)
+         gd.scene_post_done_this_frame = true;
+      if (!g_smaa_enable)
+         return DrawOrDispatchOverrideType::None;
+      if (!is_custom_pass && (is_resolve_h || is_resolve_v))
+      {
+         ComPtr<ID3D11UnorderedAccessView> uav_color;
+         native_device_context->CSGetUnorderedAccessViews(0, 1, uav_color.put());
+         if (!uav_color)
+            return DrawOrDispatchOverrideType::None;
+         ComPtr<ID3D11Resource> color_res;
+         uav_color->GetResource(color_res.put());
+         if (!color_res)
+            return DrawOrDispatchOverrideType::None;
+         const uint64_t color_handle = reinterpret_cast<uint64_t>(color_res.get());
+
+         // Skip later resolves for an already processed resource; rerunning in-place FXAA would corrupt SMAA.
+         if (gd.smaa_applied_handles.count(color_handle) != 0)
+            return DrawOrDispatchOverrideType::Replaced;
+         // Only horizontal resolve triggers SMAA; an unexpected vertical-only resolve remains native.
+         if (!is_resolve_h)
+            return DrawOrDispatchOverrideType::None;
+
+         uint4 cinfo{};
+         DXGI_FORMAT cfmt = DXGI_FORMAT_UNKNOWN;
+         GetResourceInfo(color_res.get(), cinfo, cfmt);
+         const uint32_t w = cinfo.x, h = cinfo.y;
+         if (w == 0 || h == 0)
+            return DrawOrDispatchOverrideType::None;
+         // SMAA temporaries are RGBA16F; CopyResource silently fails across formats, so fall back to FXAA on mismatch.
+         if (cfmt != DXGI_FORMAT_R16G16B16A16_FLOAT)
+            return DrawOrDispatchOverrideType::None;
+
+         // Predication requires current, same-sized depth; otherwise a null texture and scale 1 select plain ULTRA.
+         bool depth_ok = false;
+         if (gd.srv_depth)
+         {
+            uint4 dinfo{};
+            DXGI_FORMAT dfmt = DXGI_FORMAT_UNKNOWN;
+            GetResourceInfo(gd.srv_depth.get(), dinfo, dfmt);
+            depth_ok = (dinfo.x == w && dinfo.y == h);
+         }
+         // Threshold and strength are inert without the depth-edge term.
+         const float pred_scale = depth_ok ? kPredScale : 1.f;
+
+         // Async loading and live reload may temporarily require native FXAA fallback.
+         const bool smaa_ready =
+            AllShadersReady(device_data.native_pixel_shaders, {kNameSMAAEdgePS, kNameSMAAWeightPS, kNameSMAABlendPS}) &&
+            AllShadersReady(device_data.native_vertex_shaders, {kNameSMAAEdgeVS, kNameSMAAWeightVS, kNameSMAABlendVS});
+         if (!smaa_ready)
+            return DrawOrDispatchOverrideType::None;
+
+         // DrawSMAA rebuilds managed views only on swapchain init; drop them explicitly on resolution changes.
+         if (gd.smaa_core_w != w || gd.smaa_core_h != h)
+         {
+            auto& mr = device_data.managed_resources;
+            mr.depth_stencil_views[CompileTimeStringHash("smaa_dsv")].reset();
+            mr.render_target_views[CompileTimeStringHash("smaa_edge_detection")].reset();
+            mr.render_target_views[CompileTimeStringHash("smaa_blending_weight_calculation")].reset();
+            gd.smaa_core_w = w;
+            gd.smaa_core_h = h;
+         }
+
+         if (!gd.cb_smaa_metrics || gd.smaa_metrics_w != w || gd.smaa_metrics_h != h || gd.smaa_metrics_predicated != depth_ok)
+         {
+            const float metrics[8] = {1.f / (float)w, 1.f / (float)h, (float)w, (float)h, pred_scale, kPredThreshold, kPredStrength, 0.f};
+            if (CreateImmutableCB(native_device, metrics, sizeof(metrics), gd.cb_smaa_metrics))
+            {
+               gd.smaa_metrics_w = w;
+               gd.smaa_metrics_h = h;
+               gd.smaa_metrics_predicated = depth_ok;
+            }
+         }
+         if (!gd.cb_smaa_metrics)
+            return DrawOrDispatchOverrideType::None;
+
+         // The fp16 SMAA output is both a render target and an SRV for the optional sharpen pass.
+         if (!EnsureRGBA16FTarget(native_device, w, h, gd.tex_smaa_out, std::addressof(gd.tex_smaa_out_rtv), std::addressof(gd.tex_smaa_out_srv), gd.smaa_out_w, gd.smaa_out_h))
+            return DrawOrDispatchOverrideType::None;
+
+         // The gamma snapshot is only ever read.
+         if (!EnsureRGBA16FTarget(native_device, w, h, gd.tex_input, nullptr, std::addressof(gd.srv_input), gd.smaa_temps_w, gd.smaa_temps_h))
+            return DrawOrDispatchOverrideType::None;
+
+         native_device_context->CopyResource(gd.tex_input.get(), color_res.get());
+
+         // DrawSMAA restores shaders, resources, and targets, but not cbuffer slots; save VS/PS b1 explicitly.
+         ComPtr<ID3D11Buffer> vs_cb1_orig, ps_cb1_orig;
+         native_device_context->VSGetConstantBuffers(1, 1, vs_cb1_orig.put());
+         native_device_context->PSGetConstantBuffers(1, 1, ps_cb1_orig.put());
+         ID3D11Buffer* mcb = gd.cb_smaa_metrics.get();
+         native_device_context->VSSetConstantBuffers(1, 1, &mcb);
+         native_device_context->PSSetConstantBuffers(1, 1, &mcb);
+
+         DrawSMAA(native_device, native_device_context, device_data,
+            gd.tex_smaa_out_rtv.get(), gd.srv_input.get() /*edge color (gamma)*/, gd.srv_input.get() /*blend color (gamma)*/,
+            depth_ok ? gd.srv_depth.get() : nullptr /*predication*/);
+
+         // Apply optional RCAS, otherwise copy SMAA directly so the cancelled resolve always produces output.
+         const bool sharpen_shaders_ready =
+            AllShadersReady(device_data.native_vertex_shaders, {kNameCopyVS}) &&
+            AllShadersReady(device_data.native_pixel_shaders, {kNameSharpenPS});
+         bool do_sharpen = g_rcas_sharpness > 0.f && sharpen_shaders_ready;
+         if (do_sharpen)
+         {
+            if (!gd.cb_sharpen || gd.sharpen_w != w || gd.sharpen_h != h || gd.sharpen_amount != g_rcas_sharpness)
+            {
+               const float sp[4] = {(float)w, (float)h, g_rcas_sharpness, 0.f};
+               if (CreateImmutableCB(native_device, sp, sizeof(sp), gd.cb_sharpen))
+               {
+                  gd.sharpen_w = w;
+                  gd.sharpen_h = h;
+                  gd.sharpen_amount = g_rcas_sharpness;
+               }
+            }
+            // Written by the sharpen pass and then copied out, so it needs no SRV.
+            const bool rcas_target_ready =
+               EnsureRGBA16FTarget(native_device, w, h, gd.tex_rcas_out, std::addressof(gd.tex_rcas_out_rtv), nullptr, gd.rcas_out_w, gd.rcas_out_h);
+            if (!gd.cb_sharpen || !rcas_target_ready)
+               do_sharpen = false;
+         }
+
+         if (do_sharpen)
+         {
+            auto* sharpen_vs = FindShader(device_data.native_vertex_shaders, kNameCopyVS);
+            auto* sharpen_ps = FindShader(device_data.native_pixel_shaders, kNameSharpenPS);
+            // DrawCustomPixelShader does not restore state; FullGraphics also prevents RCAS b0 leaking into HUD draws.
+            DrawStateStack<DrawStateStackType::FullGraphics> sharpen_state;
+            sharpen_state.Cache(native_device_context, device_data.uav_max_count);
+
+            ID3D11Buffer* scb = gd.cb_sharpen.get();
+            native_device_context->PSSetConstantBuffers(0, 1, &scb);
+            DrawCustomPixelShader(native_device_context, device_data.default_depth_stencil_state.get(), device_data.default_blend_state.get(), nullptr,
+               sharpen_vs, sharpen_ps, gd.tex_smaa_out_srv.get(), gd.tex_rcas_out_rtv.get(), w, h, false);
+
+            sharpen_state.Restore(native_device_context);
+
+            native_device_context->CopyResource(color_res.get(), gd.tex_rcas_out.get());
+         }
+         else
+         {
+            native_device_context->CopyResource(color_res.get(), gd.tex_smaa_out.get());
+         }
+
+         // Restore native VS/PS b1; no compute state was changed.
+         ID3D11Buffer* vcb = vs_cb1_orig.get();
+         ID3D11Buffer* pcb = ps_cb1_orig.get();
+         native_device_context->VSSetConstantBuffers(1, 1, &vcb);
+         native_device_context->PSSetConstantBuffers(1, 1, &pcb);
+
+         gd.smaa_applied_handles.insert(color_handle);
+         device_data.has_drawn_main_post_processing = true;
+         return DrawOrDispatchOverrideType::Replaced;
+      }
+
+      return DrawOrDispatchOverrideType::None;
+   }
+
+   // Captures inputs for SMAA/bloom/XeGTAO/video and replaces their native dispatches; stage-1 HDR replacement
+   // stays hash-driven by Core.
+   DrawOrDispatchOverrideType OnDrawOrDispatch(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, CommandListData& cmd_list_data, DeviceData& device_data, reshade::api::shader_stage stages, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass, bool& updated_cbuffers, std::function<void()>* original_draw_dispatch_func) override
+   {
+      auto& gd = GetGameDeviceData(device_data);
+
+      const bool is_immediate = cmd_list_data.is_primary; // Cached by Core; avoids a per-draw virtual query.
+      // Do not reject custom passes globally: the hash-replaced stage-1 tonemap still supplies SMAA depth and the
+      // bloom slot. Individual native-only branches apply !is_custom_pass where required.
+      if (!is_immediate)
+         return DrawOrDispatchOverrideType::None;
+
+      // Core uploads LumaData after this callback for replaced shaders, so stage 2 and any later direct Bink draw
+      // receive the updated encoding state in the same frame.
+      if (original_shader_hashes.Contains(kOutputStage2Hash, reshade::api::shader_stage::pixel))
+         gd.stage2_seen_this_frame = true;
+
+      // HUD draws occur after the FXAA resolve. Suppress only plain game draws in that window so stage 1, stage 2,
+      // movies without a scene resolve, and pre-scene menus remain intact.
+      if (g_hide_ui && !is_custom_pass && gd.scene_post_done_this_frame)
+         return DrawOrDispatchOverrideType::Replaced;
+
+      CaptureBloomScale(native_device, native_device_context, gd, original_shader_hashes);
+
+      TagVideoTarget(native_device_context, device_data, original_shader_hashes);
+
+      InjectBloomAndDepth(native_device, native_device_context, device_data, gd, original_shader_hashes);
+
+      if (const auto gtao_result = RunXeGTAO(native_device, native_device_context, device_data, gd, original_shader_hashes))
+         return *gtao_result;
+
+      return RunSMAAResolve(native_device, native_device_context, device_data, gd, original_shader_hashes, is_custom_pass);
+   }
+
+   void UpdateLumaInstanceDataCB(CB::LumaInstanceDataPadded& data, CommandListData&, DeviceData& device_data) override
+   {
+      // Read by the Bink replacement to decide whether a direct swapchain draw may emit linear scRGB.
+      const auto& gd = GetGameDeviceData(device_data);
+      data.GameData.SwapchainGammaEncoded = gd.stage2_seen_this_frame ? 0.f : 1.f;
+   }
+
+   void OnPresent(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+      auto& gd = GetGameDeviceData(device_data);
+      gd.stage2_seen_this_frame = false;
+      // Clear per-frame SMAA state so menus and transitions cannot reuse stale predication depth.
+      gd.smaa_applied_handles.clear();
+      gd.srv_depth.reset();
+      // Drop XeGTAO inputs and ownership so failed or absent AO chains cannot reuse stale resources.
+      gd.srv_gtao_depth.reset();
+      gd.srv_gtao_normals.reset();
+      gd.gtao_active_this_frame = false;
+      gd.bloom_scale_captured_this_frame = false; // Re-arm BloomScale capture.
+      gd.scene_post_done_this_frame = false;      // Re-armed by the FXAA resolve.
+#if DEVELOPMENT
+      gd.bloom_bright_pass_hits = 0;
+#endif
+
+      // This is the sole writer of effective BloomIntensity. UI code edits only the raw slider and enable state,
+      // preventing raw/derived values from oscillating while dragging. Native bloom keeps multiplier 1.
+      {
+         auto& gs = cb_luma_global_settings.GameSettings;
+         float eff = 1.f;
+         if (g_bloom_enable)
+         {
+            float scale = 1.f;
+            if (gd.bloom_scale_live >= 0.f && g_bloom_scale_ref > 1e-4f)
+            {
+               scale = gd.bloom_scale_live / g_bloom_scale_ref;
+               scale = scale < 0.f ? 0.f : (scale > 4.f ? 4.f : scale); // Avoid Windows min/max macros.
+            }
+            eff = g_bloom_intensity * scale;
+         }
+         if (fabsf(gs.BloomIntensity - eff) > 1e-4f)
+         {
+            gs.BloomIntensity = eff;
+            device_data.cb_luma_global_settings_dirty = true;
+         }
+
+         // Follow native per-scene cb0.y; use ME1's 1.2 default until the first readback.
+         const float thr = gd.bloom_threshold_live >= 0.f ? gd.bloom_threshold_live : 1.2f;
+         if (fabsf(gs.BloomThreshold - thr) > 1e-4f)
+         {
+            gs.BloomThreshold = thr;
+            device_data.cb_luma_global_settings_dirty = true;
+         }
+      }
+   }
+
+   void LoadConfigs() override
+   {
+      reshade::get_config_value(nullptr, PROJECT_NAME, "SMAAEnable", g_smaa_enable);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "RCASSharpness", g_rcas_sharpness);
+      auto& gs = cb_luma_global_settings.GameSettings;
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Exposure", gs.Exposure);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Saturation", gs.Saturation);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "HighlightDechroma", gs.HighlightDechroma);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Contrast", gs.Contrast);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "VignetteIntensity", gs.VignetteIntensity);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "FilmGrainIntensity", gs.FilmGrainIntensity);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "BloomEnable", g_bloom_enable);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "BloomIntensity", g_bloom_intensity);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "Dithering", gs.Dithering);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "VideoAutoHDREnable", g_video_auto_hdr_enable);
+      gs.VideoAutoHDREnable = g_video_auto_hdr_enable ? 1.f : 0.f;
+      reshade::get_config_value(nullptr, PROJECT_NAME, "VideoAutoHDRBoost", gs.VideoAutoHDRBoost);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "GTAOEnable", g_gtao_enable);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "GTAOFinalValuePower", g_gtao_final_value_power);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "GTAODepthScale", g_gtao_depth_scale);
+      reshade::get_config_value(nullptr, PROJECT_NAME, "GTAORadiusOverride", g_gtao_radius_override);
+   }
+
+   void DrawImGuiSettings(DeviceData& device_data) override
+   {
+      ImGui::SeparatorText("Anti-Aliasing");
+      if (ImGui::Checkbox("SMAA Enable", &g_smaa_enable))
+         reshade::set_config_value(nullptr, PROJECT_NAME, "SMAAEnable", g_smaa_enable);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's FXAA with SMAA (requires AA enabled in the game's video settings).");
+      ImGui::BeginDisabled(!g_smaa_enable);
+      ImGui::SliderFloat("RCAS Sharpness", &g_rcas_sharpness, 0.f, 1.f);
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "RCASSharpness", g_rcas_sharpness);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Sharpening applied on top of SMAA (0 = off).");
+      ImGui::EndDisabled();
+
+      ImGui::SeparatorText("Grade");
+      auto& gs = cb_luma_global_settings.GameSettings;
+      auto& gd_def = default_luma_global_game_settings;
+
+      if (ImGui::SliderFloat("Exposure", &gs.Exposure, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Exposure", gs.Exposure);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Overall image brightness (1 = vanilla).");
+      if (DrawResetButton<float, false>(gs.Exposure, gd_def.Exposure, "Exposure"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Exposure", gs.Exposure); // LoadConfigs reads PROJECT_NAME, not [Luma].
+      }
+
+      if (cb_luma_global_settings.DisplayMode == DisplayModeType::HDR)
+      {
+         if (ImGui::SliderFloat("Contrast", &gs.Contrast, 0.f, 2.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, PROJECT_NAME, "Contrast", gs.Contrast);
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Overall image contrast, HDR only (1 = vanilla).");
+         if (DrawResetButton<float, false>(gs.Contrast, gd_def.Contrast, "Contrast"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, PROJECT_NAME, "Contrast", gs.Contrast);
+         }
+
+         if (ImGui::SliderFloat("Saturation", &gs.Saturation, 0.f, 2.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, PROJECT_NAME, "Saturation", gs.Saturation);
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Color saturation, HDR only (1 = vanilla).");
+         if (DrawResetButton<float, false>(gs.Saturation, gd_def.Saturation, "Saturation"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, PROJECT_NAME, "Saturation", gs.Saturation);
+         }
+
+         if (ImGui::SliderFloat("Highlights Desaturation", &gs.HighlightDechroma, 0.f, 1.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, PROJECT_NAME, "HighlightDechroma", gs.HighlightDechroma);
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("How soon bright sources fade to neutral white, HDR only (0 = keep color at any brightness).");
+         if (DrawResetButton<float, false>(gs.HighlightDechroma, gd_def.HighlightDechroma, "HighlightDechroma"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, PROJECT_NAME, "HighlightDechroma", gs.HighlightDechroma);
+         }
+      }
+
+      ImGui::SeparatorText("Bloom");
+      if (ImGui::Checkbox("Luma Bloom Enable", &g_bloom_enable))
+      {
+         reshade::set_config_value(nullptr, PROJECT_NAME, "BloomEnable", g_bloom_enable);
+         device_data.cb_luma_global_settings_dirty = true;
+      }
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's bloom with a wider, softer HDR bloom.");
+      ImGui::BeginDisabled(!g_bloom_enable);
+      if (ImGui::SliderFloat("Bloom Intensity", &g_bloom_intensity, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "BloomIntensity", g_bloom_intensity);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Bloom strength (1 = vanilla, 0 = none).");
+      if (DrawResetButton<float, false>(g_bloom_intensity, gd_def.BloomIntensity, "BloomIntensity"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "BloomIntensity", g_bloom_intensity);
+      }
+      ImGui::EndDisabled();
+
+      ImGui::SeparatorText("Ambient Occlusion");
+      if (ImGui::Checkbox("XeGTAO Enable", &g_gtao_enable))
+         reshade::set_config_value(nullptr, PROJECT_NAME, "GTAOEnable", g_gtao_enable);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's HBAO+ with XeGTAO (cleaner, more accurate ambient occlusion).");
+#if DEVELOPMENT || TEST
+      ImGui::BeginDisabled(!g_gtao_enable);
+      ImGui::SliderFloat("GTAO Final Value Power", &g_gtao_final_value_power, 0.3f, 4.5f, "%.2f");
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "GTAOFinalValuePower", g_gtao_final_value_power);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Primary darkness dial (higher = darker AO). Calibrate to match vanilla's overall darkening.");
+      ImGui::SliderFloat("GTAO Depth Scale", &g_gtao_depth_scale, 10.f, 200.f, "%.0f", ImGuiSliderFlags_Logarithmic);
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "GTAODepthScale", g_gtao_depth_scale);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("viewZ divisor (UE3 units -> ~meters). FIRST dial if AO shows broad depth-correlated over-occlusion.");
+      ImGui::SliderFloat("GTAO Radius Override", &g_gtao_radius_override, 0.f, 3.f, "%.3f");
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "GTAORadiusOverride", g_gtao_radius_override);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("0 = shader EFFECT_RADIUS define; > 0 overrides it to match the vanilla HBAO+ radius (uu / DepthScale).");
+      ImGui::Combo("GTAO Debug View", &g_gtao_debug_view, "Off\0Depth gradient\0Normals\0AO x8\0Edges\0");
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Draws diagnostics through the game's AO apply (multiplied into the scene). Depth gradient dead/flat or normals blocky = wrong input; AO x8 = spot broad over-occlusion.");
+      ImGui::EndDisabled();
+#endif
+
+      ImGui::SeparatorText("Effects");
+      if (ImGui::SliderFloat("Vignette Intensity", &gs.VignetteIntensity, 0.f, 1.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "VignetteIntensity", gs.VignetteIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Scales the game's vignette darkening (1 = vanilla, 0 = none).");
+      if (DrawResetButton<float, false>(gs.VignetteIntensity, gd_def.VignetteIntensity, "VignetteIntensity"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "VignetteIntensity", gs.VignetteIntensity);
+      }
+
+      if (ImGui::SliderFloat("Film Grain Intensity", &gs.FilmGrainIntensity, 0.f, 1.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, PROJECT_NAME, "FilmGrainIntensity", gs.FilmGrainIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Scales the game's film grain (1 = vanilla, 0 = off).");
+      if (DrawResetButton<float, false>(gs.FilmGrainIntensity, gd_def.FilmGrainIntensity, "FilmGrainIntensity"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "FilmGrainIntensity", gs.FilmGrainIntensity);
+      }
+
+      if (cb_luma_global_settings.DisplayMode == DisplayModeType::HDR)
+      {
+         if (ImGui::Checkbox("Video AutoHDR", &g_video_auto_hdr_enable))
+         {
+            reshade::set_config_value(nullptr, PROJECT_NAME, "VideoAutoHDREnable", g_video_auto_hdr_enable);
+            gs.VideoAutoHDREnable = g_video_auto_hdr_enable ? 1.f : 0.f;
+            device_data.cb_luma_global_settings_dirty = true;
+         }
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Adds HDR highlights to pre-rendered videos (HDR only).");
+         ImGui::BeginDisabled(!g_video_auto_hdr_enable);
+         if (ImGui::SliderFloat("Video HDR Boost", &gs.VideoAutoHDRBoost, 0.f, 1.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, PROJECT_NAME, "VideoAutoHDRBoost", gs.VideoAutoHDRBoost);
+         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+            ImGui::SetTooltip("Video highlight strength (0 = off).");
+         if (DrawResetButton<float, false>(gs.VideoAutoHDRBoost, gd_def.VideoAutoHDRBoost, "VideoAutoHDRBoost"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, PROJECT_NAME, "VideoAutoHDRBoost", gs.VideoAutoHDRBoost);
+         }
+         ImGui::EndDisabled();
+      }
+
+      bool dithering = gs.Dithering > 0.5f;
+      if (ImGui::Checkbox("Dithering", &dithering))
+      {
+         gs.Dithering = dithering ? 1.f : 0.f;
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, PROJECT_NAME, "Dithering", gs.Dithering);
+      }
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Reduces gradient banding (HDR output).");
+
+      ImGui::SeparatorText("UI");
+      ImGui::Checkbox("Hide Gameplay UI", &g_hide_ui); // Session-only to avoid a confusing HUD-less restart.
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Disables the in-game UI.");
+
+#if DEVELOPMENT
+      {
+         auto& gd = GetGameDeviceData(device_data);
+         const char* gname = g_me_game == MEGame::ME1 ? "ME1" : (g_me_game == MEGame::ME2 ? "ME2" : "ME3");
+         const float eff_thr = gd.bloom_threshold_live >= 0.f ? gd.bloom_threshold_live : 1.2f;
+         ImGui::SeparatorText("Bloom DEV readout");
+         ImGui::Text("game=%s  bright-pass hits/frame=%d  (0 = capture hook never fired)", gname, gd.bloom_bright_pass_hits);
+         ImGui::Text("threshold_live=%.4f  scale_live=%.4f  (-1 = not captured yet)", gd.bloom_threshold_live, gd.bloom_scale_live);
+         ImGui::Text("scale_ref=%.4f  eff threshold=%.4f  eff intensity=%.4f", g_bloom_scale_ref, eff_thr, cb_luma_global_settings.GameSettings.BloomIntensity);
+      }
+#endif
+   }
+
+   void PrintImGuiAbout() override
+   {
+      ImGui::PushTextWrapPos(0.f);
+      ImGui::Text(
+         "Luma for \"Mass Effect Legendary Edition\" is developed by DristoforColumb and is open source and free.\n"
+         "It replaces the game's FXAA with SMAA, its bloom with a wider HDR bloom, and its HBAO+ with XeGTAO, plus 16x anisotropic filtering.\n"
+         "With the game's HDR enabled it also replaces the native HDR tonemap with a higher quality one.\n"
+         "Enable Anti-Aliasing and Ambient Occlusion in the game's video settings for SMAA and XeGTAO to apply.\n"
+         "Do NOT run another HDR mod (e.g. RenoDX) alongside it.\n"
+         "Thanks to the Luma team and contributors.\n"
+         "If you enjoy it, consider donating.");
+      ImGui::PopTextWrapPos();
+
+      ImGui::NewLine();
+      ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(70, 134, 0, 255));
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(70 + 9, 134 + 9, 0, 255));
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(70 + 18, 134 + 18, 0, 255));
+      static const std::string donation_link = std::string("Buy DristoforColumb a Coffee on ko-fi ") + std::string(ICON_FK_OK);
+      if (ImGui::Button(donation_link.c_str()))
+         ShellExecuteA(nullptr, "open", "https://ko-fi.com/dristoforcolumb", nullptr, nullptr, SW_SHOWNORMAL);
+      ImGui::PopStyleColor(3);
+
+      ImGui::NewLine();
+      static const std::string social_link = std::string("Join our \"HDR Den\" Discord ") + std::string(ICON_FK_SEARCH);
+      if (ImGui::Button(social_link.c_str()))
+      {
+         // Unique link for Luma's HDR Den (tracks the origin of people joining); do not share for other purposes.
+         static const std::string discord_link = std::string("https://discord.gg/J9fM") + std::string("3EVuEZ");
+         ShellExecuteA(nullptr, "open", discord_link.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+      }
+      static const std::string contributing_link = std::string("Contribute on Github ") + std::string(ICON_FK_FILE_CODE);
+      if (ImGui::Button(contributing_link.c_str()))
+         ShellExecuteA(nullptr, "open", "https://github.com/Filoppi/Luma-Framework", nullptr, nullptr, SW_SHOWNORMAL);
+
+      ImGui::NewLine();
+      ImGui::Text("Build Date: %s %s", __DATE__, __TIME__);
+
+      ImGui::NewLine();
+      ImGui::Text("Credits:"
+                  "\n\nMain:"
+                  "\nDristoforColumb"
+                  "\n\nThird Party:"
+                  "\nReShade"
+                  "\nImGui"
+                  "\nSMAA (Iryoku)"
+                  "\nXeGTAO (Intel)"
+                  "\nAMD FidelityFX (RCAS)"
+                  "\nDICE (HDR tonemapper)"
+                  "\n3Dmigoto"
+                  "\nRenoDX (HDR tonemap method)");
+   }
+};
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+   {
+      g_me_game = DetectMEGame();
+      // Per-game defaults; LoadConfigs may override the persisted ones afterwards.
+      const MEGameProfile profile = ProfileFor(g_me_game);
+      g_tonemap_perms = profile.tonemap_perms;
+      g_gtao_radius_override = profile.gtao_radius_override;
+      g_bloom_scale_ref = profile.bloom_scale_ref;
+
+      Globals::SetGlobals(PROJECT_NAME, "Mass Effect Legendary Edition Luma mod", "", 3);
+
+      // Native in-game HDR is required; it already supplies the fp16 scRGB swapchain and RGBA16F stage-1/2
+      // transport. A general texture upgrade would also catch R8G8B8A8 velocity and UI, breaking their contracts.
+      swapchain_format_upgrade_type = TextureFormatUpgradesType::AllowedEnabled; // Enables scRGB and linear composition.
+      swapchain_upgrade_type = SwapchainUpgradeType::scRGB;
+      texture_format_upgrades_type = TextureFormatUpgradesType::None; // HDR buffers are already fp16.
+
+      // Mode 4 sets MaxAnisotropy=16. Keep zero LOD bias because there is no TAA to suppress shimmer.
+      enable_samplers_upgrade = true; // Boot-time only.
+      samplers_upgrade_mode = 4;
+
+      game = new MassEffectLE();
+   }
+
+   CoreMain(hModule, ul_reason_for_call, lpReserved);
+
+   return TRUE;
+}


### PR DESCRIPTION
Luma addon for the Mass Effect Legendary Edition trilogy
- Native HDR: replaces AutoHDR with native HDR presentation
- AA: replaces FXAA with SMAA + optional RCAS sharpen
- HDR bloom: replaces the game's clamped bloom with a wider pyramidal HDR bloom
- AO: replaces the native HBAO+ with XeGTAO
- Forces 16x anisotropic filtering
- AutoHDR for the videos
- Grade controls (exposure, contrast, saturation, highlight desaturation, bloom, vignette, film grain, dithering) + Hide Gameplay UI toggle