### PR TITLE
Dishonored 2: don't paint the world red when in-game brightness leaves the default (17)

### DIFF
--- a/Shaders/Dishonored 2/PostProcess_Tonemap_0xA6F33860_0xD2F50617.ps_5_0.hlsl
+++ b/Shaders/Dishonored 2/PostProcess_Tonemap_0xA6F33860_0xD2F50617.ps_5_0.hlsl
@@ -435,6 +435,10 @@ void main(
   o0.xyz = safePow(r0.xyz, cb_env_tonemapping_gamma_brightness.x); //TODO: apply this b4 TM?
   o0.w = 1;
 
+#if 0 // Debug: identity check for the brightness/gamma CB.
+  // At the in-game default brightness (17) these components are 1 and the
+  // tonemapper works. Moving brightness off default makes them != 1, so these
+  // fills painted the whole 3D frame solid green/red (intro video was fine).
   if (cb_env_tonemapping_gamma_brightness.y != 1)
   {
     o0.xyz = float3(0, 1, 0);
@@ -443,6 +447,7 @@ void main(
   {
     o0.xyz = float3(1, 0, 0);
   }
+#endif
 #if !FIX_RAISED_BLACKS && 0 // Test raised blacks. Happens always
   if (cb_postfx_tonemapping_tonemappingcoeffs0.z != 0)
   {

--- a/Shaders/Dishonored 2/PostProcess_Tonemap_0xA6F33860_0xD2F50617.ps_5_0.hlsl
+++ b/Shaders/Dishonored 2/PostProcess_Tonemap_0xA6F33860_0xD2F50617.ps_5_0.hlsl
@@ -435,7 +435,7 @@ void main(
   o0.xyz = safePow(r0.xyz, cb_env_tonemapping_gamma_brightness.x); //TODO: apply this b4 TM?
   o0.w = 1;
 
-#if 0 // Debug: identity check for the brightness/gamma CB.
+#if DEVELOPMENT && 0 // Debug: identity check for the brightness/gamma CB.
   // At the in-game default brightness (17) these components are 1 and the
   // tonemapper works. Moving brightness off default makes them != 1, so these
   // fills painted the whole 3D frame solid green/red (intro video was fine).
@@ -448,7 +448,7 @@ void main(
     o0.xyz = float3(1, 0, 0);
   }
 #endif
-#if !FIX_RAISED_BLACKS && 0 // Test raised blacks. Happens always
+#if DEVELOPMENT && !FIX_RAISED_BLACKS && 0 // Test raised blacks. Happens always
   if (cb_postfx_tonemapping_tonemappingcoeffs0.z != 0)
   {
     o0.xyz = float3(1, 0, 1);


### PR DESCRIPTION
## What happens

The replaced Dishonored 2 tonemapper applies `cb_env_tonemapping_gamma_brightness` as a real scale/gamma, then immediately overwrites the result:

```hlsl
if (cb_env_tonemapping_gamma_brightness.y != 1) o0.xyz = float3(0, 1, 0); // green
if (cb_env_tonemapping_gamma_brightness.x != 1) o0.xyz = float3(1, 0, 0); // red
```

At the **in-game default brightness (17)** those components are identity `1`. Moving the brightness slider off 17 makes them `!= 1`, so the whole 3D frame becomes solid red (the second fill wins). HUD / ReShade / the Luma overlay still work because they do not go through this pass. The intro is a Bink video, so it also looks fine until you are in the world and change brightness.

Luma already tells you to leave brightness at default for best results. That advice is still fair for tonemapping, but leaving this probe **ungated** means any player who touches the slider gets a bricked image instead of a worse grade.

The magenta raised-blacks probe a few lines below is already wrapped in `#if !FIX_RAISED_BLACKS && 0`. These two fills were the same kind of CB identity check and were left live.

Related: https://github.com/Filoppi/Luma-Framework/issues/74

## Change

Wrap the green/red fills in `#if 0` (same style as the other tests in this file). The actual `safePow` / brightness scale is unchanged.

Tested on SDR, 3440x1440, RTX 5070 Ti: default brightness 17 is fine; moving the slider off 17 was solid red before this, and is a normal picture after.