### PR TITLE
The Witcher 2: Add Luma mod

### DIFF
--- a/Luma.sln
+++ b/Luma.sln
@@ -117,6 +117,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mass Effect Legendary Editi
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Middle-earth Shadow of War", "Source\Games\Middle-earth Shadow of War\Middle-earth Shadow of War.vcxproj", "{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "The Witcher 2", "Source\Games\The Witcher 2\The Witcher 2.vcxproj", "{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Development-Debug|Win32 = Development-Debug|Win32
@@ -861,6 +863,18 @@ Global
 		{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18}.Test-Release|Win32.Build.0 = Test-Release|x64
 		{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18}.Test-Release|x64.ActiveCfg = Test-Release|x64
 		{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18}.Test-Release|x64.Build.0 = Test-Release|x64
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Development-Debug|Win32.ActiveCfg = Development-Debug|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Development-Debug|Win32.Build.0 = Development-Debug|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Development-Debug|x64.ActiveCfg = Development-Debug|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Development-Release|Win32.ActiveCfg = Development-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Development-Release|Win32.Build.0 = Development-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Development-Release|x64.ActiveCfg = Development-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Publishing-Release|Win32.ActiveCfg = Publishing-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Publishing-Release|Win32.Build.0 = Publishing-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Publishing-Release|x64.ActiveCfg = Publishing-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Test-Release|Win32.ActiveCfg = Test-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Test-Release|Win32.Build.0 = Test-Release|Win32
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}.Test-Release|x64.ActiveCfg = Test-Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -920,6 +934,7 @@ Global
 		{1180032D-8EEB-4A60-B120-E838393947DF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{B0DE12A4-5C7A-4E91-9F3B-08891303C0DE} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{17FBB4FD-8E4E-4E61-AC32-BBEBA09B8D18} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B799422-BA66-3174-B21F-B9FA07C4B2E3}

--- a/Shaders/The Witcher 2/FinalGradeNoAA_0xBBFEC706.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGradeNoAA_0xBBFEC706.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Final grade, NO-FXAA permutation as translated by dgVoodoo 2.81.3. Same signature and slot map as
+// 0xCF3B72A9, so the whole pass comes from that file.
+#include "FinalGradeNoAA_0xCF3B72A9.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/FinalGradeNoAA_0xCF3B72A9.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGradeNoAA_0xCF3B72A9.ps_5_0.hlsl
@@ -1,0 +1,12 @@
+// The Witcher 2 final grade, NO-FXAA permutation (dgVoodoo -> ps_5_0, hash 0xCF3B72A9): what the engine runs
+// with the game's Anti-aliasing setting turned off. Identical to 0xDE5CF9CD from
+// the desaturation onward (desat cb4[62], gamma-slider log2/pow/exp2 cb4[61], scale cb4[60], highlight and
+// shadow tint lerps cb4[68..71], vignette t2 + cb4[66..67]); the FXAA neighbourhood is replaced by a single
+// scene tap at v5.xy, and the output alpha carries the scene alpha instead of 0.
+//
+// Both differences are gated on LUMA_TW2_NO_FXAA_PERM inside the main file, so the vanilla grade tail and the
+// Luma HDR output block have exactly one implementation. Users can now turn the in-game AA off and keep both
+// HDR and Luma SMAA.
+
+#define LUMA_TW2_NO_FXAA_PERM 1
+#include "FinalGrade_0xDE5CF9CD.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/FinalGradeNoVignette_0x2CA0631E.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGradeNoVignette_0x2CA0631E.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Final grade, NO-FXAA + NO-VIGNETTE permutation as translated by dgVoodoo 2.81.3. Same signature and slot map
+// as 0xBABBFFAD, so the whole pass comes from that file.
+#include "FinalGradeNoVignette_0xBABBFFAD.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/FinalGradeNoVignette_0xBABBFFAD.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGradeNoVignette_0xBABBFFAD.ps_5_0.hlsl
@@ -1,0 +1,15 @@
+// The Witcher 2 final grade, NO-FXAA + NO-VIGNETTE permutation (dgVoodoo -> ps_5_0, hash 0xBABBFFAD): the
+// engine drops the vignette stage entirely in this variant. Identical by disassembly diff
+// vs 0xCF3B72A9: byte-for-byte the same shader minus the t2/s2 mask sample, cb3[48..49] fixup and the
+// cb4[66..67] weight/color lerp — everything from the desaturation through the tint lerps is identical, and
+// the output alpha likewise carries the scene alpha.
+//
+// Without this file the pass fell through unreplaced, which silently costs the whole Luma tail on any frame
+// that uses it: no HDR block, no SMAA (the post-draw callback keys on the grade hash) and no Hide UI gate.
+//
+// Both differences are gated inside the main file (LUMA_TW2_NO_FXAA_PERM + LUMA_TW2_NO_VIGNETTE_PERM), so the
+// vanilla grade tail and the Luma HDR output block still have exactly one implementation.
+
+#define LUMA_TW2_NO_FXAA_PERM     1
+#define LUMA_TW2_NO_VIGNETTE_PERM 1
+#include "FinalGrade_0xDE5CF9CD.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/FinalGrade_0x517DC6D5.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGrade_0x517DC6D5.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Final grade as translated by dgVoodoo 2.81.3. Same signature and slot map as 0xDE5CF9CD (it also declares an
+// unused cb5, which needs no counterpart here), so the whole pass comes from that file.
+#include "FinalGrade_0xDE5CF9CD.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/FinalGrade_0xDE5CF9CD.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGrade_0xDE5CF9CD.ps_5_0.hlsl
@@ -1,0 +1,367 @@
+// clang-format off
+// ORDER MATTERS — see Luma_TW2_Tonemap.hlsl (game-local Common.hlsl defines LumaGameSettings first).
+#include "Includes/Common.hlsl" // game-local: LumaGameSettings — keep FIRST
+#include "../Includes/Color.hlsl"
+#include "../Includes/ColorGradingLUT.hlsl" // RestoreHueAndChrominance (vanilla clip hue/chroma emulation)
+#include "../Includes/DICE.hlsl"
+// clang-format on
+
+// The Witcher 2 FINAL GRADE pass (dgVoodoo -> ps_5_0, hash 0xDE5CF9CD): FXAA + the in-game Gamma slider +
+// highlight/shadow tint lerps + vignette, on the full-res fp16 canvas right before the UI draws.
+// Vanilla body transcribed VERBATIM (register-level, constants cb4[N] = DX9 c(N-8)). This is also where the
+// Luma HDR output block lives (expansion + DICE + UI paper-white pre-scale): the vanilla tint lerps weight by
+// SATURATED luma and soft-clip everything above 1.0, so the HDR range dies here unless it is rebuilt after
+// them. The tonemap replacements stay vanilla-only.
+//
+// Three permutations, and the only ones that exist: this file (FXAA + vignette), 0xCF3B72A9 with the game's
+// Anti-aliasing off (no FXAA block, scene alpha instead of 0) and 0xBABBFFAD with the vignette stage dropped
+// as well (no t2/s2 mask sample, no cb4[66..67]). The wrappers include this file and select with
+// LUMA_TW2_NO_FXAA_PERM / LUMA_TW2_NO_VIGNETTE_PERM, so the grade tail lives in one place.
+#ifndef LUMA_TW2_NO_FXAA_PERM
+#define LUMA_TW2_NO_FXAA_PERM 0
+#endif
+#ifndef LUMA_TW2_NO_VIGNETTE_PERM
+#define LUMA_TW2_NO_VIGNETTE_PERM 0
+#endif
+
+Texture2D<float4> t0 : register(t0); // scene canvas (full-res fp16, gamma-space, carries >1 Luma HDR range)
+#if !LUMA_TW2_NO_VIGNETTE_PERM
+Texture2D<float4> t2 : register(t2); // vignette mask
+#endif
+
+SamplerState s0_s : register(s0);
+#if !LUMA_TW2_NO_VIGNETTE_PERM
+SamplerState s2_s : register(s2);
+#endif
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+// dgVoodoo texture-format fixup + guarded ops — transcribed verbatim. Deliberately duplicated per replacement
+// rather than shared: each hash-replaced file stays self-contained for side-by-side comparison with its dump.
+// Names match Luma_TW2_Tonemap.hlsl's copies exactly, so identical bodies never read as different helpers.
+float4 DgVoodooTexFixup(float4 color, float4 mask_and, float4 mask_or)
+{
+   return asfloat((asuint(color) & asuint(mask_and)) | asuint(mask_or));
+}
+// 1e37 is the exact sentinel every dgVoodoo dump uses (l(9999999933815812510711506376257961984.0)); it must
+// not be rounded up to 1e38, or "hiTarget * DgVoodooRcp(0)" below overflows to inf ten times sooner and the
+// zero-weight lerp around it turns into 0 * inf = NaN (which the guard at the end paints black).
+#define DGVOODOO_BIG 1e37
+float DgVoodooRcp(float x)
+{
+   return (abs(x) > 0.0) ? (1.0 / x) : DGVOODOO_BIG;
+}
+float DgVoodooLog2(float x)
+{
+   float l = log2(abs(x));
+   // dgVoodoo: log(0) = -inf -> -BIG (so exp2 later yields 0). It tests the -inf BIT PATTERN, not isinf(), so
+   // a +inf input keeps propagating as vanilla does instead of being flipped to ~0 (a white pixel gone black).
+   return (asuint(l) == 0xff800000u) ? -DGVOODOO_BIG : l;
+}
+
+// FXAA luma approximation the pass uses everywhere: R + 1.963211 * G
+float FxaaLuma(float4 c)
+{
+   return c.y * 1.963211 + c.x;
+}
+
+float4 SampleScene(float2 uv)
+{
+   return DgVoodooTexFixup(t0.SampleLevel(s0_s, uv, 0.0), cb3[44], cb3[45]);
+}
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0,
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   float4 sampleM = SampleScene(v5.xy);
+   float3 aaColor = sampleM.rgb; // the no-AA permutation stops here; the FXAA one may replace it below
+
+#if !LUMA_TW2_NO_FXAA_PERM
+   // CustomData2 == 1: Luma SMAA runs right after this pass, so skip the vanilla FXAA instead of double-AAing.
+   // The neighbour taps sit INSIDE the branch on purpose: with SMAA on they would be 4 dead full-res fetches.
+   [branch] if (LumaData.CustomData2 != 1)
+   {
+      const float2 rcpFrame = cb4[72].xy; // c64 vInvSurfaceSize
+
+      // ---- vanilla FXAA (verbatim transcription) ----
+      float4 sampleN = SampleScene(v5.xy + rcpFrame * float2(0.0, -1.0));
+      float4 sampleW = SampleScene(v5.xy + rcpFrame * float2(-1.0, 0.0));
+      float4 sampleE = SampleScene(v5.xy + rcpFrame * float2(1.0, 0.0));
+      float4 sampleS = SampleScene(float2(v5.x, v5.y + rcpFrame.y));
+
+      float lumaN = FxaaLuma(sampleN);
+      float lumaW = FxaaLuma(sampleW);
+      float lumaM = FxaaLuma(sampleM);
+      float lumaE = FxaaLuma(sampleE);
+      float lumaS = FxaaLuma(sampleS);
+
+      float rangeMin = min(min(min(lumaW, lumaN), min(lumaE, lumaS)), lumaM);
+      float rangeMax = max(max(max(lumaN, lumaW), max(lumaS, lumaE)), lumaM);
+      float range = rangeMax - rangeMin;
+
+      [branch] if (range >= max(0.0625, rangeMax * 0.125))
+      {
+         float3 sum5 = sampleN.rgb + sampleW.rgb + sampleM.rgb + sampleE.rgb + sampleS.rgb;
+
+         float lumaSum4 = lumaN + lumaW + lumaE + lumaS;
+         float blend = abs(lumaSum4 * 0.25 - lumaM) * DgVoodooRcp(range) - 0.5;
+         float subpix = min(max(blend, 0.0) * 2.0, 2.0 / 3.0);
+
+         float4 sampleNW = SampleScene(v5.xy - rcpFrame);
+         float4 sampleNE = SampleScene(v5.xy + rcpFrame * float2(1.0, -1.0));
+         float4 sampleSW = SampleScene(v5.xy + rcpFrame * float2(-1.0, 1.0));
+         float4 sampleSE = SampleScene(v5.xy + rcpFrame);
+
+         float3 sum9 = sum5 + sampleNW.rgb + sampleNE.rgb + sampleSW.rgb + sampleSE.rgb;
+
+         float lumaNW = FxaaLuma(sampleNW);
+         float lumaNE = FxaaLuma(sampleNE);
+         float lumaSW = FxaaLuma(sampleSW);
+         float lumaSE = FxaaLuma(sampleSE);
+
+         // Edge orientation (vanilla operand order kept)
+         float edgeHorz = abs(lumaN * -0.5 + lumaNW * 0.25 + lumaNE * 0.25) + abs(lumaW * 0.5 - lumaM + lumaE * 0.5) // |(W+E)*0.5 - M| written as vanilla mads
+                          + abs(lumaS * -0.5 + lumaSW * 0.25 + lumaSE * 0.25);
+         float edgeVert = abs(lumaNW * 0.25 + lumaW * -0.5 + lumaSW * 0.25) + abs(lumaN * 0.5 - lumaM + lumaS * 0.5) + abs(lumaNE * 0.25 + lumaE * -0.5 + lumaSE * 0.25);
+         bool horzSpan = (edgeVert - edgeHorz) >= 0.0;
+
+         float stepLength = horzSpan ? -rcpFrame.y : -rcpFrame.x;
+         float luma1 = horzSpan ? lumaN : lumaW;
+         float luma2 = horzSpan ? lumaS : lumaE;
+         float grad1 = luma1 - lumaM;
+         float grad2 = luma2 - lumaM;
+         float lumaEnd1 = (lumaM + luma1) * 0.5;
+         float lumaEnd2 = (lumaM + luma2) * 0.5;
+         bool pair1 = (abs(grad1) - abs(grad2)) >= 0.0;
+         float lumaLocalAvg = pair1 ? lumaEnd1 : lumaEnd2;
+         float gradScaled = max(abs(grad1), abs(grad2));
+         stepLength = pair1 ? stepLength : -stepLength;
+
+         float halfStep = stepLength * 0.5;
+         float2 posCenter;
+         posCenter.x = v5.x + (horzSpan ? 0.0 : halfStep);
+         posCenter.y = v5.y + (horzSpan ? halfStep : 0.0);
+
+         float2 edgeStep = horzSpan ? float2(rcpFrame.x, 0.0) : float2(0.0, rcpFrame.y);
+         float2 posN = posCenter - edgeStep;
+         float2 posP = posCenter + edgeStep;
+         float lumaEndN = lumaLocalAvg;
+         float lumaEndP = lumaLocalAvg;
+         float doneN = 0.0;
+         float doneP = 0.0;
+
+         [loop] for (int i = 8; i > 0; i--)
+         {
+            if (doneN == 0.0)
+               lumaEndN = FxaaLuma(SampleScene(posN));
+            if (doneP == 0.0)
+               lumaEndP = FxaaLuma(SampleScene(posP));
+            float hitN = (abs(lumaEndN - lumaLocalAvg) - gradScaled * 0.25 >= 0.0) ? 1.0 : 0.0;
+            hitN += doneN;
+            doneN = (-hitN >= 0.0) ? 0.0 : 1.0;
+            float hitP = (abs(lumaEndP - lumaLocalAvg) - gradScaled * 0.25 >= 0.0) ? 1.0 : 0.0;
+            hitP += doneP;
+            doneP = (-hitP >= 0.0) ? 0.0 : 1.0;
+            if (doneN * doneP != 0.0)
+               break;
+            if (-hitN >= 0.0)
+               posN -= edgeStep;
+            if (-hitP >= 0.0)
+               posP += edgeStep;
+         }
+
+         float dstN = horzSpan ? (v5.x - posN.x) : (v5.y - posN.y);
+         float dstP = horzSpan ? (posP.x - v5.x) : (posP.y - v5.y);
+         float lumaEndNear = (dstN - dstP >= 0.0) ? lumaEndP : lumaEndN;
+         float mBelow = (lumaM - lumaLocalAvg >= 0.0) ? 0.0 : 1.0;
+         float endBelow = (lumaEndNear - lumaLocalAvg >= 0.0) ? -0.0 : -1.0;
+         float goodSpan = mBelow + endBelow;
+         float finalStep = (-abs(goodSpan) >= 0.0) ? 0.0 : stepLength;
+         float spanLength = dstN + dstP;
+         float pixelOffset = min(dstP, dstN) * -DgVoodooRcp(spanLength) + 0.5;
+         pixelOffset *= finalStep;
+
+         float2 posFinal;
+         posFinal.x = v5.x + (horzSpan ? 0.0 : pixelOffset);
+         posFinal.y = v5.y + (horzSpan ? pixelOffset : 0.0);
+         float4 sampleEnd = SampleScene(posFinal);
+
+         aaColor = subpix * sum9 * 0.111111 + sampleEnd.rgb;
+         aaColor = -subpix * sampleEnd.rgb + aaColor; // = lerp(endColor, avg9, subpix), vanilla op order
+      }
+   }
+#endif // !LUMA_TW2_NO_FXAA_PERM
+
+   // ---- vanilla grade tail (verbatim): desat, gamma slider (log2/exp2 pow), tints, vignette ----
+   float lumaAA = dot(aaColor, float3(0.299, 0.587, 0.114));
+   float3 color = saturate(lumaAA * cb4[62].w) * -cb4[62].rgb + aaColor;
+
+   float3 clamped = max(color, 0.0);
+   color.r = DgVoodooLog2(clamped.r);
+   color.g = DgVoodooLog2(clamped.g);
+   color.b = DgVoodooLog2(clamped.b);
+   color *= cb4[61].rgb; // in-game Gamma slider exponent
+   color = exp2(color);
+   color *= cb4[60].rgb; // scale
+
+   float lum = dot(color, float3(0.299, 0.587, 0.114));
+
+   // Highlight tint branch: lerp toward lum * cb4[68].rgb / cb4[70].y, weight sat((1.3 - lum) * cb4[71].x * 4) * cb4[68].w
+   float3 hiTarget = lum * cb4[68].rgb;
+   float hiWeight = saturate((1.3 - lum) * cb4[71].x * 4.0) * cb4[68].w;
+   float3 hiBranch = hiWeight * (hiTarget * DgVoodooRcp(cb4[70].y) - color) + color;
+
+   // Shadow tint branch: lerp toward SATURATED lum * cb4[69].rgb / cb4[70].z — the vanilla >1 soft-clip lives here
+   float3 loTarget = saturate(lum) * cb4[69].rgb;
+   float loWeight = saturate((lum + 0.3) * cb4[71].y * 4.0) * cb4[69].w;
+   float3 loBranch = loWeight * (loTarget * DgVoodooRcp(cb4[70].z) - color) + color;
+
+   // Vanilla: final = lerp(hiBranch, loBranch, sat(lum * cb4[70].x * 5))
+   float mixWeight = saturate(lum * cb4[70].x * 5.0);
+   float3 graded = mixWeight * (loBranch - hiBranch) + hiBranch;
+
+   // User Color Grading Intensity fades the two tint lerps back toward the untinted grade (the game's
+   // yellow-sepia cast); "color" is already the exact untinted reference, so nothing is recomputed. In the
+   // vanilla tail on purpose, so it applies in SDR too. Side effect: the shadow-tint branch carries vanilla's
+   // saturate(lum) soft-clip, so below 1.0 highlights above white reach a little further in HDR.
+   [branch] if (LumaSettings.GameSettings.ColorGradingIntensity != 1.0)
+       graded = lerp(color, graded, LumaSettings.GameSettings.ColorGradingIntensity);
+
+#if LUMA_TW2_NO_VIGNETTE_PERM
+   // This permutation has no vignette stage at all (see FinalGradeNoVignette_0xBABBFFAD.ps_5_0.hlsl): the
+   // engine compiles the mask sample and cb4[66..67] out, so the grade result IS the vanilla output and the
+   // Vignette Intensity slider has nothing to scale here.
+   float3 vanillaColor = graded;
+#else
+   // Vignette
+   float4 vignette = DgVoodooTexFixup(t2.Sample(s2_s, v7.xy), cb3[48], cb3[49]);
+   float vigWeight = saturate(dot(cb4[66], vignette));
+   float3 vanillaColor = vigWeight * (cb4[67].rgb - graded) + graded;
+   // User Vignette Intensity: lerp between the pre-vignette grade and the vignetted result (1 = vanilla,
+   // bit-exact; 0 = no vignette). Sits in the vanilla tail on purpose, so it applies in SDR as well.
+   vanillaColor = lerp(graded, vanillaColor, LumaSettings.GameSettings.VignetteIntensity);
+#endif
+
+#if TONEMAP_TYPE == 1
+   // ---- Luma HDR output (BL2-shape tail; this pass runs once per frame, full-res, scene only) ----
+   {
+      float3 lin = gamma_to_linear(vanillaColor, GCT_MIRROR); // VANILLA_ENCODING_TYPE 1: gamma 2.2 buffers
+
+      float3 postProcessedColor;
+      if (LumaSettings.DisplayMode == 1) // HDR
+      {
+         const float paperWhite = LumaSettings.GamePaperWhiteNits / sRGB_WhiteLevelNits;
+         const float peakWhite = LumaSettings.PeakWhiteNits / sRGB_WhiteLevelNits;
+
+         // Vanilla highlight emulation (ALWAYS ON — part of the game's look, not a user knob). The vanilla SDR
+         // ceiling was a per-channel clamp at exactly 1.0, and it lived in the ROP, not in any shader: dgVoodoo's
+         // present blit (PS 0x2749AFD8) is a bare "sample_l -> o0" with zero math, and it wrote into an 8-bit
+         // r8g8b8a8 intermediate, so the output merger did the clamping. Luma upgrades that very intermediate to
+         // fp16 (texture_upgrade_formats in main.cpp), which is exactly why the clamp — and with it the vanilla
+         // look — disappears and has to be put back here, in the last pass before that blit. On a bright
+         // saturated source one channel reaches 1.0 first, which both skews the hue toward white (fire ->
+         // yellow-white) AND desaturates it; the shadow-tint branch above adds a partial soft clip of its own.
+         //
+         // REFERENCE = saturate(lin), the vanilla per-channel clip itself: this pass transcribes the whole
+         // vanilla grade, so the real vanilla SDR color is already here and needs no stand-in. A synthetic
+         // ReinhardPiecewise reference is only the fallback for passes with no vanilla SDR in hand, and it is a
+         // poor one here — a ceiling-5 reference recovers ~4% of the needed hue swing on a moderate highlight
+         // (G/R 0.347 where vanilla clips to 0.400), leaving fire red.
+         //
+         // Clip in BT.709: the artifact happened in the game's 8-bit sRGB buffer, so that is the faithful domain
+         // and both gamut matrices disappear with it. Clipping before or after the transfer function is
+         // equivalent, since a per-channel clamp at 1.0 commutes with any monotonic curve fixing 1 -> 1.
+         // The gate is exact, not conservative: below 1.0 saturate is the identity, so hueRef == lin and the
+         // restore provably does nothing, sparing two Oklab round trips on the ~96% of pixels that sit below.
+         [branch] if (max(lin.r, max(lin.g, lin.b)) > 1.0)
+         {
+            float3 hueRef = saturate(lin);
+            // Shipped 0.8 hue / 0.4 whitening, both from GameSettings. 0.8 is the catalog value for a clipped
+            // SDR reference; 0.4 reproduces part of the clip's own chroma loss without paying for path-to-white
+            // twice, since DICE desaturates again at the display peak and Highlights Desaturation adds more on
+            // request. A non-zero whitening is only defensible because the reference here IS the vanilla clip.
+            // Only the CHROMA argument can whiten: the helper transfers hue, then restores chrominance exactly.
+            //
+            // HAZARD: hue strength must stay BELOW 1.0. Once every channel clips, hueRef is (1,1,1) whose
+            // chrominance is 1.7e-4 rather than 0, so the helper misses its safe-division fallback and its
+            // renormalization goes near-singular — the hue runs away while chroma stays put. On (6,5,4) linear:
+            // +0.87 deg at 0.80, +2.02 at 0.90, +4.49 at 0.95, +36.9 at 0.99, +143.9 at 1.00, where a white-hot
+            // pixel comes out CYAN. 0.80 keeps 61-79% of the vanilla hue swing; 0.90 is the hard ceiling.
+            lin = RestoreHueAndChrominance(lin, hueRef, saturate(LumaSettings.GameSettings.HighlightsHueStrength), saturate(LumaSettings.GameSettings.HighlightsHueChroma));
+         }
+
+         DICESettings settings = DefaultDICESettings(DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE);
+         float3 hdr = DICETonemap(lin * paperWhite, peakWhite, settings) / paperWhite;
+
+         const float highlightDechroma = LumaSettings.GameSettings.HighlightDechroma;
+         if (highlightDechroma > 0.0)
+         {
+            float dcExp = lerp(1.0, 0.05, highlightDechroma);
+            float dcWeight = saturate(pow(saturate(GetLuminance(hdr) / peakWhite), dcExp));
+            hdr = Saturation(hdr, 1.0 - dcWeight);
+         }
+         hdr = Saturation(hdr, LumaSettings.GameSettings.Saturation);
+
+         // User contrast: slope around 18% mid-gray (linear, 1.0 = paper white), after DICE and saturation.
+         // Gated so the shipped 1.0 stays bit-exact rather than paying a subtract/multiply/add round trip.
+         // KNOWN, ACCEPTED: the pivot means black does not stay black below 1.0 — a fully faded frame lands on
+         // 0.18 * (1 - Contrast), so cutscene fade-to-blacks read dark grey. The fade is applied upstream in
+         // the tonemap pass, so it cannot be reordered after the pivot.
+         [branch] if (LumaSettings.GameSettings.Contrast != 1.0)
+         {
+            const float midGray = 0.18;
+            hdr = (hdr - midGray) * LumaSettings.GameSettings.Contrast + midGray;
+         }
+
+         postProcessedColor = hdr;
+      }
+      else // SDR (still presented through the scRGB swapchain)
+      {
+         postProcessedColor = lin;
+      }
+
+#if UI_DRAW_TYPE >= 2
+      // Pre-scale so the gamma-SDR HUD drawn on top lands at UIPaperWhite after composition.
+      postProcessedColor *= LumaSettings.GamePaperWhiteNits / max(LumaSettings.UIPaperWhiteNits, 1.0);
+#endif
+
+      postProcessedColor = (postProcessedColor == postProcessedColor) ? postProcessedColor : 0.0; // NaN -> 0
+      postProcessedColor = max(0.0, postProcessedColor);
+      postProcessedColor = linear_to_gamma(postProcessedColor, GCT_MIRROR);
+
+      // Animated triangular dither in the stored gamma space, HDR and SDR alike (MELE precedent): the core
+      // composition never dithers, and the 8-bit SDR output bands harder than the HDR one. Deliberately NOT
+      // vanilla — vanilla had no dither — hence the runtime toggle.
+      if (LumaSettings.GameSettings.Dithering > 0.5)
+         ApplyDithering(postProcessedColor, v5.xy, true, 1.0, DITHERING_BIT_DEPTH, LumaSettings.FrameIndex, true);
+
+      vanillaColor = postProcessedColor;
+   }
+#endif // TONEMAP_TYPE == 1
+
+#if LUMA_TW2_NO_FXAA_PERM
+   o0 = float4(vanillaColor, sampleM.a); // this permutation passes the scene alpha through
+#else
+   o0 = float4(vanillaColor, 0.0); // vanilla writes o0.w = 0
+#endif
+}

--- a/Shaders/The Witcher 2/Includes/Common.hlsl
+++ b/Shaders/The Witcher 2/Includes/Common.hlsl
@@ -1,0 +1,8 @@
+// Always include this instead of the global "Common.hlsl" if you made any changes to the game shaders/cbuffers
+
+// Define the game custom cbuffer structs
+#include "GameCBuffers.hlsl"
+// Global common
+#include "../../Includes/Common.hlsl"
+// Game specific settings
+#include "Settings.hlsl"

--- a/Shaders/The Witcher 2/Includes/GameCBuffers.hlsl
+++ b/Shaders/The Witcher 2/Includes/GameCBuffers.hlsl
@@ -1,0 +1,42 @@
+#ifndef LUMA_GAME_CB_STRUCTS
+#define LUMA_GAME_CB_STRUCTS
+
+#ifdef __cplusplus
+// This include is needed to allow reading shader types from c++.
+#include "../../../Source/Core/includes/shader_types.h"
+#endif
+
+// Mirrors c++ name spaces.
+namespace CB
+{
+// User grade settings, mirrored to c++ ("OnInit" defaults / ImGui in main.cpp) and read through
+// LumaSettings.GameSettings: Exposure in the tonemap replacement (Luma_TW2_Tonemap.hlsl), the video knobs in
+// Video_0x30BE6D87, everything else in the final grade. Defaults are vanilla no-ops.
+struct LumaGameSettings
+{
+   float Exposure;           // scene multiplier before the game grade (1 = vanilla). SDR + HDR
+   float Saturation;         // Oklab saturation (1 = vanilla). HDR display path only
+   float HighlightDechroma;  // bright sources fade to white approaching peak (0 = off). HDR display path only
+   float Dithering;          // 1 = animated triangular output dither (HDR, anti-banding)
+   float VideoAutoHDREnable; // 0/1. 1 = light PumboAutoHDR on pre-rendered videos (HDR only); 0 = flat SDR at paper white
+   float VideoAutoHDRBoost;  // 0..1. Highlight-expansion strength; peak = lerp(sRGB white, 250 nits, boost). 0 = off
+   float VignetteIntensity;  // 1 = vanilla vignette darkening, 0 = none. Applies in SDR and HDR (the vignette lives in the vanilla grade tail)
+   // chrominanceStrength / hueStrength of the vanilla highlight emulation (RestoreHueAndChrominance) in the
+   // final grade; HDR path only. DEV sliders, never persisted, so the C++ defaults ARE the shipped values.
+   // Calibration and the hard "keep strength below 1.0" limit are documented at the call site:
+   // FinalGrade_0xDE5CF9CD.ps_5_0.hlsl.
+   float HighlightsHueChroma;   // 0.4 shipped
+   float HighlightsHueStrength; // 0.8 shipped
+   float Contrast;              // 1 = vanilla. Slope contrast around 18% mid-gray on the final HDR color. HDR display path only
+   float BloomIntensity;        // 1 = vanilla, 0 = none. Scales the engine's glow where it enters the screen blend (SDR + HDR)
+   float ColorGradingIntensity; // 1 = vanilla, 0 = no tint. Fades the vanilla highlight/shadow tint lerps out of the grade (SDR + HDR)
+};
+
+// Define the game specific cbuffer (instance/pass) data here
+struct LumaGameData
+{
+   float Dummy; // hlsl doesn't support empty structs
+};
+} // namespace CB
+
+#endif // LUMA_GAME_CB_STRUCTS

--- a/Shaders/The Witcher 2/Includes/Settings.hlsl
+++ b/Shaders/The Witcher 2/Includes/Settings.hlsl
@@ -1,0 +1,11 @@
+#ifndef SRC_GAME_SETTINGS_HLSL
+#define SRC_GAME_SETTINGS_HLSL
+
+// Include this after the global "Settings.hlsl" file
+
+/////////////////////////////////////////
+// The Witcher 2 LUMA advanced settings
+// (note that the defaults might be mirrored in c++, the shader values will be overridden anyway)
+/////////////////////////////////////////
+
+#endif // SRC_GAME_SETTINGS_HLSL

--- a/Shaders/The Witcher 2/LightShaftBlend2_0xB1E64DB0.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/LightShaftBlend2_0xB1E64DB0.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Second light-shaft blend as translated by dgVoodoo 2.81.3. Same signature and slot map as 0xCB06362E, so the
+// whole pass comes from that file.
+#include "LightShaftBlend2_0xCB06362E.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/LightShaftBlend2_0xCB06362E.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/LightShaftBlend2_0xCB06362E.ps_5_0.hlsl
@@ -1,0 +1,80 @@
+// The Witcher 2 light-shaft screen blend, permutation 2 (dgVoodoo -> ps_5_0, hash 0xCB06362E).
+// Vanilla: o0 = 1 - (1 - canvas) * (1 - saturate(shafts * tint * saturate(exp2(-3 * lum(canvas)) * fade)))
+// — a screen blend whose shaft contribution is attenuated where the canvas is already bright. Unlike the
+// sibling glow blend (0x12931281) the canvas itself is NOT saturated here, but the screen formula still damps
+// any canvas value above 1 by (1 - shaftPart): HDR highlights sink up to ~30% wherever god rays overlap them.
+// Replacement: vanilla math verbatim (bit-exact at any range), then, in HDR only, undo that damping on the
+// above-1 part of the canvas (identity <= 1), matching how the glow blend is treated.
+//
+// A third permutation of this same source exists and is deliberately NOT replaced: 0x262CAE95, identical
+// instruction for instruction except that it combines ADDITIVELY (o0.xyz = canvas + shaftPart) instead of
+// screen-blending. Additive never damps the canvas, so the above-1 restore below would be a no-op there and
+// vanilla is already correct in HDR. Found by a full fingerprint sweep of the 592-shader dump; that sweep
+// also confirmed there is no fourth grade permutation and no SSAO-generator permutation.
+
+#include "Includes/Common.hlsl" // game-local: LumaSettings (DisplayMode gates the HDR-only excess restore)
+
+Texture2D<float4> t0 : register(t0); // light-shaft / glow source
+Texture2D<float4> t1 : register(t1); // scene canvas (fp16, gamma-space; carries Luma HDR range > 1)
+
+SamplerState s0_s : register(s0);
+SamplerState s1_s : register(s1);
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+// dgVoodoo texture-format fixup masks (see Luma_TW2_Tonemap.hlsl) — transcribed verbatim.
+float4 DgVoodooTexFixup(float4 color, float4 mask_and, float4 mask_or)
+{
+   return asfloat((asuint(color) & asuint(mask_and)) | asuint(mask_or));
+}
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0,
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   float4 canvas = DgVoodooTexFixup(t1.Sample(s1_s, v6.xy), cb3[46], cb3[47]);
+   float lum = dot(canvas.rgb, float3(0.30, 0.59, 0.11));
+   // DXBC "exp" is base-2 (the vanilla disasm multiplies by exactly -3, with no folded log2(e) factor), so
+   // this must be exp2: HLSL exp() would attenuate the shafts up to 60% too hard on a bright canvas.
+   float atten = saturate(exp2(lum * -3.0) * cb4[62].w);
+
+   float4 shafts = DgVoodooTexFixup(t0.Sample(s0_s, v5.xy), cb3[44], cb3[45]);
+   float3 shaftPart = saturate(atten * (shafts.rgb * cb4[62].xyz));
+
+   // Vanilla screen blend on the RAW canvas (this permutation does not saturate it, unlike 0x12931281), so
+   // this line alone is bit-exact vanilla for any input, in range or above it.
+   float3 blended = 1.0 - (1.0 - canvas.rgb) * (1.0 - shaftPart);
+
+#if TONEMAP_TYPE == 1
+   // Undo the (1 - shaftPart) damping on the part of the canvas that sits above 1: vanilla sinks HDR
+   // highlights by up to ~30% wherever god rays overlap them. Identity for any canvas <= 1.
+   // HDR display path only. The SDR one has to see what vanilla produced, and not because the composition
+   // clips later anyway: this pass runs BEFORE the final grade, whose saturated-luma tint weights and
+   // per-channel gamma pow react non-linearly to an above-1 input, so the excess would move graded values
+   // that end up BELOW 1 as well. "== 1" also keeps the dev "SDR on HDR" mode honest — composition only
+   // clamps for DisplayMode 0, so there the excess would never be clipped downstream either.
+   [branch] if (LumaSettings.DisplayMode == 1)
+       blended += shaftPart * max(canvas.rgb - 1.0, 0.0);
+#endif
+
+   o0 = float4(blended, 1.0); // vanilla alpha: 1
+}

--- a/Shaders/The Witcher 2/LightShaftBlend_0x12931281.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/LightShaftBlend_0x12931281.ps_5_0.hlsl
@@ -1,0 +1,86 @@
+// The Witcher 2 glow screen blend (dgVoodoo -> ps_5_0, hash 0x12931281). This is the pass that gives candles
+// and torches their halo: it screen-blends the engine's blurred, THRESHOLDLESS copy of the scene onto the
+// scene itself, weighted toward dark pixels by the blend's own shape.
+// Vanilla: o0 = 1 - (1 - sat(glow)) * (1 - sat(scene)) — a classic screen blend that SATURATES both inputs,
+// hard-clipping the whole frame to 0-1. It runs right after the tonemap every frame, so it was the pass
+// eating the Luma HDR range.
+// Replacement: bit-exact vanilla math on the saturated values (SDR look preserved), then re-add the
+// clipped HDR excess on top (identity for any input <= 1). Screen blend of a source at/above 1 saturates
+// toward 1 in vanilla anyway, so the excess re-add keeps the blend monotonic and hue-stable.
+
+// Slot mapping is disasm-confirmed, and it is the opposite way round from the sibling light-shaft blend
+// (0xCB06362E): here t0 is the GLOW and t1 is the SCENE. t0 is clamped by cb4[60], whose half-texel inset and
+// 0..0.5 extent describe the glow buffer — a half-res texture holding its image in a quarter of itself
+// (at 3840x2160 output: a 1920x1080 buffer with the image at 960x540) — while t1 is clamped by
+// cb4[61], the full 0..1 rect of the scene.
+// This pass also forwards the GLOW's alpha to its output, and that alpha is live data (mean 2.3),
+// so anything that replaces the glow colour here has to leave t0's alpha alone.
+#include "Includes/Common.hlsl" // game-local: LumaSettings (DisplayMode gates the HDR-only excess restore)
+
+Texture2D<float4> t0 : register(t0); // engine glow
+Texture2D<float4> t1 : register(t1); // scene (fp16, gamma-space; carries Luma HDR range > 1)
+
+SamplerState s0_s : register(s0);
+SamplerState s1_s : register(s1);
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+// dgVoodoo texture-format fixup masks (see Luma_TW2_Tonemap.hlsl) — transcribed verbatim.
+float4 DgVoodooTexFixup(float4 color, float4 mask_and, float4 mask_or)
+{
+   return asfloat((asuint(color) & asuint(mask_and)) | asuint(mask_or));
+}
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0,
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   // Vanilla UV clamp rects (cb4[60] glow, cb4[61] scene: .xy min, .zw max)
+   float2 uv0 = min(cb4[60].zw, max(v5.xy, cb4[60].xy));
+   float4 glow = DgVoodooTexFixup(t0.Sample(s0_s, uv0), cb3[44], cb3[45]);
+   float2 uv1 = min(cb4[61].zw, max(v6.xy, cb4[61].xy));
+   float4 scene = DgVoodooTexFixup(t1.Sample(s1_s, uv1), cb3[46], cb3[47]);
+
+   // User Bloom Intensity (1 = vanilla, 0 = no halo): scale the engine's glow where it enters the blend, so
+   // everything downstream — the screen blend, and the HDR excess restore below, which derives from this same
+   // value — follows. Only the glow COLOR is scaled: .a is forwarded to o0.w as live engine data (
+   // mean 2.3), and the screen blend is not additive, so at 0 the scene is left exactly as it arrived rather
+   // than brightened. Applies in SDR too: this weakens a vanilla effect, it does not shape HDR.
+   glow.rgb *= LumaSettings.GameSettings.BloomIntensity;
+
+   float3 glowSat = saturate(glow.rgb);
+   float3 sceneSat = saturate(scene.rgb);
+   float3 blended = 1.0 - (1.0 - glowSat) * (1.0 - sceneSat); // vanilla screen blend
+
+#if TONEMAP_TYPE == 1
+   // Re-add the range the vanilla saturates clipped (0 for any SDR input -> bit-exact vanilla).
+   // HDR display path only: vanilla saturates BOTH inputs here, so its output is provably <= 1 and the SDR
+   // path must see exactly that. Not redundant with the composition's SDR clamp — this pass runs BEFORE the
+   // final grade, whose saturated-luma tint weights and per-channel gamma pow react non-linearly to an
+   // above-1 input, so the excess would move graded values that end up BELOW 1 too. "== 1" also keeps the
+   // dev "SDR on HDR" mode honest (composition only clamps for DisplayMode 0).
+   [branch] if (LumaSettings.DisplayMode == 1)
+       blended += max(glow.rgb - glowSat, 0.0) + max(scene.rgb - sceneSat, 0.0);
+#endif
+
+   o0 = float4(blended, glow.a); // vanilla alpha: raw t0 sample .a
+}

--- a/Shaders/The Witcher 2/LightShaftBlend_0x42D88D41.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/LightShaftBlend_0x42D88D41.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Light-shaft blend as translated by dgVoodoo 2.81.3. Same signature and slot map as 0x12931281, so the whole
+// pass comes from that file.
+#include "LightShaftBlend_0x12931281.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/Luma_SMAA_impl.hlsl
+++ b/Shaders/The Witcher 2/Luma_SMAA_impl.hlsl
@@ -1,0 +1,107 @@
+// SMAA implementation for The Witcher 2. Reference: https://github.com/iryoku/smaa
+// ULTRA preset + color edge detection, run POST-final-grade on the graded gamma canvas: main.cpp uses the
+// post-draw callback on FinalGrade 0xDE5CF9CD to run the grade, then SMAA on its output, before the UI draws
+// on the same canvas. The grade skips its built-in FXAA while SMAA is active (LumaData.CustomData2), so this
+// is a strict replacement rather than double AA.
+// The canvas is GAMMA (POST_PROCESS_SPACE_TYPE=0) and carries display-mapped HDR values, so >1 is possible;
+// both edge detection and neighborhood blending work in gamma, which keeps 1px-thin dark features alive
+// against a bright sky. No HDR/tonemap tail here, core Display Composition runs downstream.
+// Predication uses the game's full-res r32_float depth, turned into an edge-ness signal by the Depth Extract
+// CS; null-predication + scale 1.0 is the no-depth fallback.
+
+#include "../Includes/Common.hlsl"
+
+// (1/W, 1/H, W, H) at output resolution — filled by the mod (see main.cpp RunPostFinalGradeSMAA).
+cbuffer SmaaMetricsCB : register(b1)
+{
+   float4 SmaaRtMetrics;
+   // x = predication threshold scale: 2.0 when predication is active (normalized depth bound) -> frame-wide
+   // threshold 0.10 on flats; 1.0 with a null predication texture (fallback) -> plain ULTRA threshold 0.05. yzw unused.
+   float4 SmaaPredication;
+}
+
+#define SMAA_RT_METRICS SmaaRtMetrics
+#define SMAA_PRESET_ULTRA
+#define SMAA_PREDICATION       1
+#define SMAA_PREDICATION_SCALE SmaaPredication.x
+// Calibrated against the signal the Depth Extract CS produces from TW2's depth (linear view-space
+// metres, p50 ~7.3) — see Luma_TW2_DepthExtract.hlsl:
+//  - flat threshold  = SCALE * SMAA_THRESHOLD            = 2.0 * 0.05      = 0.10 (rejects texture color-noise —
+//    TW2 stone/foliage is one big color-noise field — so SMAA doesn't over-AA flat detail)
+//  - silhouette thr  = SCALE * SMAA_THRESHOLD * (1-STR)  = 2.0 * 0.05 *0.5 = 0.05 (= plain ULTRA base; predication
+//    only relaxes geometric edges back to normal sensitivity, never below). Keep this identity when retuning.
+//  - PREDICATION_THRESHOLD is 0.5 and needs no per-scene tuning: the Depth Extract CS hands SMAA an EDGE-NESS
+//    signal in [0,1], not a depth, so 0.5 is just its midpoint and is independent of scene scale, camera
+//    height, FOV and resolution. Tune the CS tolerance instead. Tripping the gate is graceful either way:
+//    it only restores the base 0.05 threshold, never lowers it.
+#define SMAA_PREDICATION_STRENGTH  0.5
+#define SMAA_PREDICATION_THRESHOLD 0.5
+#define SMAA_CUSTOM_SL
+SamplerState LinearSampler : register(s0);
+SamplerState PointSampler : register(s1);
+#define SMAATexture2D(tex)                            Texture2D tex
+#define SMAATexturePass2D(tex)                        tex
+#define SMAASampleLevelZero(tex, coord)               tex.SampleLevel(LinearSampler, coord, 0)
+#define SMAASampleLevelZeroPoint(tex, coord)          tex.SampleLevel(PointSampler, coord, 0)
+#define SMAASampleLevelZeroOffset(tex, coord, offset) tex.SampleLevel(LinearSampler, coord, 0, offset)
+#define SMAASample(tex, coord)                        tex.Sample(LinearSampler, coord)
+#define SMAASamplePoint(tex, coord)                   tex.Sample(PointSampler, coord)
+#define SMAASampleOffset(tex, coord, offset)          tex.Sample(LinearSampler, coord, offset)
+#define SMAA_FLATTEN                                  [flatten]
+#define SMAA_BRANCH                                   [branch]
+#define SMAATexture2DMS2(tex)                         Texture2DMS<float4, 2> tex
+#define SMAALoad(tex, pos, sample)                    tex.Load(pos, sample)
+#define SMAAGather(tex, coord)                        tex.Gather(LinearSampler, coord, 0)
+#include "../Includes/SMAA.hlsl"
+
+Texture2D tex0 : register(t0);
+Texture2D tex1 : register(t1);
+Texture2D tex2 : register(t2);
+
+void fullscreen_triangle(uint id, out float4 position, out float2 texcoord)
+{
+   texcoord = float2((id << 1) & 2, id & 2);
+   position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}
+
+// SMAAEdgeDetection
+void smaa_edge_detection_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float4 offset[3] : TEXCOORD1)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAAEdgeDetectionVS(texcoord, offset);
+}
+
+float2 smaa_edge_detection_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float4 offset[3] : TEXCOORD1) : SV_Target
+{
+   // tex0 = colorTexGamma (gamma-encoded graded canvas)
+   // tex1 = predicationTex (edge-ness in [0,1]; null fallback -> reads 0, scale 1.0 = plain ULTRA threshold)
+   return SMAAColorEdgeDetectionPS(texcoord, offset, tex0, tex1);
+}
+
+// SMAABlendingWeightCalculation
+void smaa_blending_weight_calculation_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float2 pixcoord : TEXCOORD1, out float4 offset[3] : TEXCOORD2)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAABlendingWeightCalculationVS(texcoord, pixcoord, offset);
+}
+
+float4 smaa_blending_weight_calculation_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float2 pixcoord : TEXCOORD1, float4 offset[3] : TEXCOORD2) : SV_Target
+{
+   // tex0 = edgesTex, tex1 = areaTex, tex2 = searchTex
+   return SMAABlendingWeightCalculationPS(texcoord, pixcoord, offset, tex0, tex1, tex2, 0);
+}
+
+// SMAANeighborhoodBlending
+void smaa_neighborhood_blending_vs(uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD0, out float4 offset : TEXCOORD1)
+{
+   fullscreen_triangle(id, position, texcoord);
+   SMAANeighborhoodBlendingVS(texcoord, offset);
+}
+
+float4 smaa_neighborhood_blending_ps(float4 position : SV_Position, float2 texcoord : TEXCOORD0, float4 offset : TEXCOORD1) : SV_Target
+{
+   // tex0 = colorTex (gamma copy), tex1 = blendTex. Blend in gamma (the buffer's space): keeps the bright HDR sky
+   // compressed so 1px-thin dark features survive the average (linear blend erodes them). No HDR tail / re-encode:
+   // output stays in the gamma canvas's space, mid-pipeline before the UI and the composition.
+   return SMAANeighborhoodBlendingPS(texcoord, offset, tex0, tex1);
+}

--- a/Shaders/The Witcher 2/Luma_TW2_DepthExtract.hlsl
+++ b/Shaders/The Witcher 2/Luma_TW2_DepthExtract.hlsl
@@ -1,0 +1,52 @@
+// The Witcher 2 — build the SMAA predication signal from the game's depth.
+//
+// Input is the game's full-res r32_float depth, captured in main.cpp at the TINT tonemap draw (t1) or the AO
+// pack pass. LINEAR VIEW-SPACE metres, not device Z (min 1.77, p50 7.3, max 686).
+//
+// Not a rescale, on purpose. SMAA predicates on a plain first difference between adjacent pixels, and on
+// LINEAR depth that cannot separate a silhouette from a surface seen edge-on: a plane's own per-pixel change
+// grows as z², so at 50 m a floor legitimately moves ~0.6 m per pixel while a 1 m silhouette is only ~1.5x
+// above it. No monotonic remap of z and no threshold fixes that ratio.
+// Instead this measures deviation from the local tangent plane — a slope-adjusted second difference with a
+// depth-proportional tolerance, the same math as XeGTAO_CalculateEdges in Luma_TW2_XeGTAO.hlsl.
+//
+// Output is edge-ness in [0,1] against the LEFT and TOP neighbours only: SMAA compares centre-vs-left on one
+// axis and centre-vs-top on the other, so a one-sided measure jumps 0 -> 1 exactly ACROSS a silhouette, while
+// a symmetric mask would read 1 on both sides and difference to 0 where predication must fire. Single-channel
+// because the predication Gather reads only R. With this signal SMAA_PREDICATION_THRESHOLD is simply 0.5.
+
+Texture2D<float> depth : register(t0); // game r32_float depth (LINEAR view-space metres)
+RWTexture2D<float> uav : register(u0); // R16_FLOAT predication signal (0 = on the local plane, 1 = edge)
+
+cbuffer PredCB : register(b0)
+{
+   float4 P; // P.x = relative tolerance: plane deviation counted as a full edge, as a fraction of view depth
+}
+
+[numthreads(8, 8, 1)] void main(uint3 id : SV_DispatchThreadID) {
+   const int3 p = int3(id.xy, 0);
+   const float centerZ = depth.Load(p);
+   // Out-of-bounds Loads return 0 (D3D11-defined); mirroring the centre there keeps the border flat instead of
+   // reporting a false edge along the screen edges.
+   const float leftZ = (id.x > 0) ? depth.Load(p - int3(1, 0, 0)) : centerZ;
+   const float rightZ = depth.Load(p + int3(1, 0, 0));
+   const float topZ = (id.y > 0) ? depth.Load(p - int3(0, 1, 0)) : centerZ;
+   const float bottomZ = depth.Load(p + int3(0, 1, 0));
+
+   // Deviation from the local plane: compare each one-sided delta against the slope implied by the opposite
+   // neighbour, and keep whichever is smaller. On a plane (any orientation) the two agree and this cancels to
+   // ~0; at a depth discontinuity neither cancels.
+   float4 edgesLRTB = float4(leftZ, rightZ, topZ, bottomZ) - centerZ;
+   const float slopeLR = (edgesLRTB.y - edgesLRTB.x) * 0.5;
+   const float slopeTB = (edgesLRTB.w - edgesLRTB.z) * 0.5;
+   const float4 edgesLRTBSlopeAdjusted = edgesLRTB + float4(slopeLR, -slopeLR, slopeTB, -slopeTB);
+   edgesLRTB = min(abs(edgesLRTB), abs(edgesLRTBSlopeAdjusted));
+
+   // Depth-proportional tolerance: the deviation that matters scales with distance (a 10 cm step is a
+   // silhouette at 2 m and noise at 200 m). Both terms are required — the slope adjustment alone still
+   // degrades toward the vanishing point, and a depth-proportional threshold alone cannot reject a grazing
+   // plane at all.
+   const float tolerance = max(centerZ, 1e-3) * max(P.x, 1e-4);
+   // Left and top only (see the header): this is the axis pairing SMAA's predication actually compares.
+   uav[id.xy] = saturate(max(edgesLRTB.x, edgesLRTB.z) / tolerance);
+}

--- a/Shaders/The Witcher 2/Luma_TW2_Sharpen.hlsl
+++ b/Shaders/The Witcher 2/Luma_TW2_Sharpen.hlsl
@@ -1,0 +1,22 @@
+// RCAS sharpening for the SMAA output (The Witcher 2; same shape as the shipped BL2/TPS pass).
+// Runs after the SMAA neighborhood-blend pass, on the gamma canvas color (the same gamma buffer SMAA
+// consumed), before the result is copied back into the canvas (the UI then draws on it and the core Display
+// Composition does paper-white + scRGB downstream). paperWhite=1.0; the sharpness slider is the tuning knob.
+// RCAS_LIMIT bounds the lobe so bright pixels don't over-sharpen.
+
+#include "../Includes/RCAS.hlsl"
+
+cbuffer SharpenCB : register(b0)
+{
+   float4 SharpenParams; // (width, height, sharpness[0..1], unused)
+}
+
+Texture2D<float4> tex0 : register(t0);    // SMAA output (gamma canvas)
+Texture2D<float2> dummyMV : register(t1); // unused (dynamicSharpening = false)
+
+float4 sharpen_ps(float4 pos : SV_Position) : SV_Target
+{
+   int2 p = int2(pos.xy);
+   int2 maxPixel = int2((int)SharpenParams.x - 1, (int)SharpenParams.y - 1);
+   return RCAS(p, int2(0, 0), maxPixel, SharpenParams.z, tex0, dummyMV, 1.0, false, (float4)0, false);
+}

--- a/Shaders/The Witcher 2/Luma_TW2_Tonemap.hlsl
+++ b/Shaders/The Witcher 2/Luma_TW2_Tonemap.hlsl
@@ -1,0 +1,122 @@
+// clang-format off
+// ORDER MATTERS — do NOT let clang-format sort these. The game-local Common.hlsl MUST come first: it defines
+// LumaGameSettings (via GameCBuffers.hlsl) BEFORE the shared Settings.hlsl (pulled in by Color.hlsl below)
+// declares the LumaSettings cbuffer. If sorted after Color.hlsl, GameSettings becomes the empty fallback struct
+// and every LumaSettings.GameSettings.* reference fails to compile (invalid subscript).
+#include "Includes/Common.hlsl" // game-local: LumaGameSettings (grade sliders) — keep FIRST
+#include "../Includes/Color.hlsl"
+// clang-format on
+
+// The Witcher 2 EE — tonemap ("exposure") pass SHARED IMPLEMENTATION (REDengine, DX9 via dgVoodoo D3D9->11).
+// Holds the pass body as RunTonemap(); the per-hash wrapper files (Tonemap_0x<HASH>.ps_5_0.hlsl, one per
+// permutation × dgVoodoo build) declare the full dgVoodoo interpolator set + main() and forward to it. No hash
+// in this filename -> not matched/replaced directly; it is #included by the wrappers.
+//
+// Vanilla body transcribed VERBATIM (register-level) from the dgVoodoo-translated CSOs (0x91348C0F no-tint,
+// 0x00E31BF9 tint; DX9 origins 0xC5ADBC35/0xF01A691E), constants remapped DX9 cN -> cb4[N+8].
+// The game's "tone map" is only an adaptive exposure multiply — NO curve, NO clamp; auto-exposure fits the
+// brightest pixel to ~1.0, so the SDR ceiling is set by the exposure itself, not by a clip. The whole post
+// chain is fp16 and the UI blends src-alpha onto this buffer, so the HDR output stays GAMMA encoded.
+// This pass stays bit-exact vanilla apart from the user Exposure; the Luma HDR output block runs at the end
+// of the FINAL GRADE replacement instead, and fp16 keeps this pass's small overshoot alive for it.
+//
+// The SAME shader runs two roles per frame: a MAIN grade (RT == swapchain resolution, feeds post/UI/present)
+// and an AUX draw (smaller RT, DoF/flare source). Both are vanilla here; main.cpp detects the role from the
+// bound RT size, for the main-post-processing flag and to scope the exposure readback to one draw per frame.
+
+// ---- Permutation map (set by the wrappers) -----------------------------------------------------------
+// TM_HAS_TINT 0 -> DX9 0xC5ADBC35: exposure + post-scale only, alpha passthrough, adaptation at t1/s1.
+// TM_HAS_TINT 1 -> DX9 0xF01A691E: + fade ramp, saturation, color tint; writes alpha 1, adaptation at t2/s2.
+// Future static perms (DX9 0xA7D76FB1/0xEC6F063B, DX11 hashes unknown) read the exposure from
+// PSC_LumRanges constants instead of the adaptation texture — add TM_STATIC here when they are dumped.
+#if TM_HAS_TINT
+#define TM_T_ADAPT        t2
+#define TM_S_ADAPT        s2
+#define TM_ADAPT_MASK_AND cb3[48]
+#define TM_ADAPT_MASK_OR  cb3[49]
+#else
+#define TM_T_ADAPT        t1
+#define TM_S_ADAPT        s1
+#define TM_ADAPT_MASK_AND cb3[46]
+#define TM_ADAPT_MASK_OR  cb3[47]
+#endif
+
+Texture2D<float4> t0 : register(t0);              // scene (fp16, gamma-space, unclamped — vanilla max ~1.07)
+Texture2D<float4> t_adapt : register(TM_T_ADAPT); // 1x1 fp16 adaptation (.x black level, .z gain)
+
+SamplerState s0_s : register(s0);
+SamplerState s_adapt_s : register(TM_S_ADAPT);
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+#define LumWeights  cb4[58] // c50 PSC_LumWeights — luminance dot (dp4: folds scene alpha in)
+#define LumRanges2  cb4[59] // c51 PSC_LumRanges2 — .x exposure cap, .y post-scale
+#define FadeWeights cb4[60] // c52 vWeights — fade luminance dot (dp4 folds alpha)
+#define FadeParams  cb4[61] // c53 vParams — .x saturation, .y fade offset, .z fade range
+#define TintColor   cb4[62] // c54 vColor
+
+// dgVoodoo texture-format fixup: every game texture read goes through (value & maskAnd) | maskOr (e.g. forcing
+// alpha to 1 on X8 formats). The masks are dgVoodoo-internal state in cb3 — transcribed verbatim, do not simplify.
+float4 DgVoodooTexFixup(float4 color, float4 mask_and, float4 mask_or)
+{
+   return asfloat((asuint(color) & asuint(mask_and)) | asuint(mask_or));
+}
+
+// dgVoodoo's guarded reciprocal: rcp with a huge-constant fallback at exactly 0 (movc in the translated CSO).
+// The constant is 1e37 in every dump (l(9999999933815812510711506376257961984.0)) — keep it exact, since it is
+// multiplied downstream and 1e38 overflows to inf ten times sooner.
+float DgVoodooRcp(float x)
+{
+   return (abs(x) > 0.0) ? (1.0 / x) : 1e37;
+}
+
+// The tonemap body. v5 = TEXCOORD0 (scene UV in .xy — the only interpolator the pass uses).
+// Returns the final gamma-space color (alpha: scene passthrough on the no-tint perm, 1 on the tint perm).
+float4 RunTonemap(float4 v5)
+{
+   // --- vanilla body (verbatim transcription) ---
+   float4 adaptation = t_adapt.SampleLevel(s_adapt_s, float2(0.0, 0.0), 0.0);
+   adaptation = DgVoodooTexFixup(adaptation, TM_ADAPT_MASK_AND, TM_ADAPT_MASK_OR);
+   float4 scene = t0.Sample(s0_s, v5.xy);
+   scene = DgVoodooTexFixup(scene, cb3[44], cb3[45]);
+
+#if TONEMAP_TYPE == 1
+   // User exposure (1 = vanilla): a real scene multiplier before the adaptive exposure reads it, so the
+   // fade/tint terms keep tracking the same relative levels as vanilla.
+   scene.rgb *= LumaSettings.GameSettings.Exposure;
+#endif
+
+   // exposure = min(gain * max(lum - black, 0) / max(lum, 1e-6), cap)
+   float lum = dot(LumWeights, scene);
+   float inv_lum = DgVoodooRcp(max(1e-6, lum));
+   float exposure = min(adaptation.z * max(lum - adaptation.x, 0.0) * inv_lum, LumRanges2.x);
+
+   float3 scaled = scene.rgb * exposure * LumRanges2.y;
+
+#if TM_HAS_TINT
+   // Fade-in ramp + saturation around the scaled luminance + color tint (cutscene/environment grade terms).
+   float fade = saturate((dot(FadeWeights, float4(scaled, scene.a)) - FadeParams.y) * DgVoodooRcp(FadeParams.z));
+   float lum_scaled = dot(FadeWeights.xyz, scaled);
+   float3 saturated = (scaled - lum_scaled) * FadeParams.x + lum_scaled;
+   float3 vanillaColor = max(saturated, 0.0) * fade * TintColor.rgb;
+   const float vanillaAlpha = 1.0;
+#else
+   float3 vanillaColor = scaled;
+   const float vanillaAlpha = scene.a;
+#endif
+
+   // NOTE: the Luma HDR output block (expansion + DICE + UI pre-scale + dither) does NOT live here:
+   // the game runs a FINAL GRADE pass after this one (FXAA + gamma slider + tints + vignette,
+   // FinalGrade_0xDE5CF9CD.ps_5_0.hlsl) whose saturated-luma tint lerps would crush anything above 1.
+   // This pass therefore stays bit-exact vanilla (fp16 keeps the small unclamped overshoot alive),
+   // plus the user Exposure above; the HDR block runs at the end of the final grade replacement.
+
+   return float4(vanillaColor, vanillaAlpha);
+}

--- a/Shaders/The Witcher 2/Luma_TW2_XeGTAO.hlsl
+++ b/Shaders/The Witcher 2/Luma_TW2_XeGTAO.hlsl
@@ -1,0 +1,747 @@
+// XeGTAO adapted for The Witcher 2 EE (REDengine DX9 -> dgVoodoo2 -> DX11) — replaces the game's HBAO.
+// Source: https://github.com/GameTechDev/XeGTAO
+//
+// TW2 specifics:
+// - Only the native generator draw (PS 0x3FEEC0F7 / VS 0x5D9D0449, half-res HBAO) is replaced, by the 4
+//   XeGTAO dispatches; the result is CopyResource'd into the game's AO target, which is created without a
+//   UAV bind, hence the copy through our own texture. Downstream stays vanilla and reads only .x:
+//   pack 0x953119B5 -> ping-pong 0xC131C40D x2 -> blur 0xD01CBD13 x2 -> apply 0x5C63E1C2.
+// - Depth input = the generator's own t0: r32_float half-res, ALREADY LINEAR view-space depth, so no
+//   unpack, only the DepthScaleRT unit rescale.
+// - Normals are generated from depth in-place (XE_GTAO_GENERATE_NORMALS) using the same NDC->view
+//   convention as the native HBAO, so the space stays self-consistent.
+// - NDC->view from the game's cb4 (copied PS->CS by main.cpp):
+//   viewRay.xy = (uv.x*2-1, 1-2*uv.y) * cb4[9].zw; viewPos = viewRay * depth, viewPos.z = +depth
+// - No TAA and no motion vectors here: NoiseIndex is FROZEN at 0 (a frame index would make the pattern
+//   boil) and denoise runs twice; all stability is spatial.
+// - Viewport size comes through the Luma knobs CB at b9, not from game constants.
+
+// --- Game constant buffer (bound by the game at the hooked draw; main.cpp copies PS b4 -> CS b4) ---
+
+cbuffer GameCB4 : register(b4)
+{
+   float4 cb4[236]; // [9].zw = tan-half-FOV NDC->view scale (see header); layout as captured, do not trim
+}
+
+// --- Luma runtime knobs (set from main.cpp; live-tunable via DEV sliders, no recompile) ---
+// b9, NOT b11 (which the sibling MELE/BL GOTY ports use): core's DrawBloom owns b11 for its own constants,
+// so keeping the AO knobs off that slot costs nothing and avoids a clash. Mirrored by kGTAOKnobsCBSlot.
+cbuffer LumaGTAO : register(b9)
+{
+   float FinalValuePowerRT;    // primary darkness dial, calibrated to the vanilla AO histogram
+   float DepthScaleRT;         // viewZ divisor (game units -> ~meters); THE dial against broad over-occlusion
+   float RadiusOverrideRT;     // > 0 overrides EFFECT_RADIUS (view units after DepthScale)
+   float DebugViewRT;          // DEVELOPMENT: 0=off 1=depth gradient 2=normals 3=AO x8 4=edges
+   float2 ViewportPixelSizeRT; // 1 / AO target resolution (half render res), set by main.cpp
+   float2 PaddingRT;
+}
+
+#if XE_GTAO_QUALITY == 0 // Low
+#define SLICE_COUNT 4.0
+#elif XE_GTAO_QUALITY == 1 // Medium
+#define SLICE_COUNT 7.0
+#elif XE_GTAO_QUALITY == 2 // High
+#define SLICE_COUNT 10.0
+#elif XE_GTAO_QUALITY == 3 // Very High
+#define SLICE_COUNT 13.0
+#elif XE_GTAO_QUALITY == 4 // Ultra
+#define SLICE_COUNT 16.0
+#endif
+
+// User configurable
+//
+
+#ifndef XE_GTAO_GENERATE_NORMALS
+#define XE_GTAO_GENERATE_NORMALS 1 // TW2: no normal buffer captured at this point of the frame; derive from depth (a real normal source exists later in the frame — see 0x53AB3429 — but not here)
+#endif
+
+#ifndef EFFECT_RADIUS
+#define EFFECT_RADIUS 0.81 // anchored to the game's own HBAO radius: probed cb4[11] = (R, R^2) = (1.1835, 1.4008) view units (meters — depth p50 ~7.3); 0.81 * RADIUS_MULTIPLIER 1.457 = 1.18 matches native R. RadiusOverrideRT > 0 wins.
+#endif
+
+#ifndef RADIUS_MULTIPLIER
+#define RADIUS_MULTIPLIER 1.457 // Default 1.457
+#endif
+
+#ifndef EFFECT_FALLOFF_RANGE
+#define EFFECT_FALLOFF_RANGE 0.005 // hard-edge falloff (full sample weight up to the radius edge) = crisp contact AO, repo-standard for HBAO-native games; Intel default 0.615 is softer
+#endif
+
+#ifndef SAMPLE_DISTRIBUTION_POWER
+#define SAMPLE_DISTRIBUTION_POWER 1.5 // Default 2.0
+#endif
+
+#ifndef THIN_OCCLUDER_COMPENSATION
+#define THIN_OCCLUDER_COMPENSATION 0.0 // Default 0.0; > 0 causes more mistakes than it fixes on big geometry
+#endif
+
+#ifndef FINAL_VALUE_POWER
+#define FINAL_VALUE_POWER 1.0 // Default 2.2; shadow default for FinalValuePowerRT (the CB value is what actually applies)
+#endif
+
+#ifndef DEPTH_MIP_SAMPLING_OFFSET
+#define DEPTH_MIP_SAMPLING_OFFSET 3.3 // Default 3.3
+#endif
+
+#ifndef SLICE_COUNT
+#define SLICE_COUNT 3.0 // Default 3.0
+#endif
+
+#ifndef STEPS_PER_SLICE
+#define STEPS_PER_SLICE 3.0 // Default 3.0
+#endif
+
+#ifndef DENOISE_BLUR_BETA
+#define DENOISE_BLUR_BETA 1.2 // Default 1.2
+#endif
+
+//
+
+#define VIEWPORT_PIXEL_SIZE ViewportPixelSizeRT
+
+// Transcribed from the native HBAO PS (0x3FEEC0F7): ndc = (uv.x*2-1, 1-2*uv.y), viewRay = ndc * cb4[9].zw.
+// Expressed as the XeGTAO mul/add pair over raw uv: viewPos.xy = (uv * MUL + ADD) * viewZ.
+#define NDC_TO_VIEW_MUL              (float2(2.0, -2.0) * cb4[9].zw)
+#define NDC_TO_VIEW_ADD              (float2(-1.0, 1.0) * cb4[9].zw)
+#define NDC_TO_VIEW_MUL_X_PIXEL_SIZE (NDC_TO_VIEW_MUL * VIEWPORT_PIXEL_SIZE)
+
+#define XE_GTAO_DEPTH_MIP_LEVELS     5.0
+#define XE_GTAO_OCCLUSION_TERM_SCALE 1.5
+
+#define XE_GTAO_PI                   3.1415926535897932384626433832795
+#define XE_GTAO_PI_HALF              1.5707963267948966192313216916398
+
+// TW2's depth texture is ALREADY linear view-space depth (the native HBAO scales its NDC ray by the raw
+// sample) — no projection unpack. DepthScaleRT only rescales the game units into the ~meter range XeGTAO's
+// Intel-tuned constants (radius/falloff/mip offsets) expect.
+float XeGTAO_ScreenSpaceToViewSpaceDepth(const float screenDepth)
+{
+   return max(0.0, screenDepth) / max(1e-3, DepthScaleRT);
+}
+
+// This is also a good place to do non-linear depth conversion for cases where one wants the 'radius' (effectively the threshold between near-field and far-field GI),
+// is required to be non-linear (i.e. very large outdoors environments).
+float XeGTAO_ClampDepth(float depth)
+{
+   return clamp(depth, 0.0, 3.402823466e+38);
+}
+
+float XeGTAO_EffectRadius()
+{
+   return (RadiusOverrideRT > 0.0 ? RadiusOverrideRT : EFFECT_RADIUS) * RADIUS_MULTIPLIER;
+}
+
+// weighted average depth filter
+float XeGTAO_DepthMIPFilter(float depth0, float depth1, float depth2, float depth3)
+{
+   float maxDepth = max(max(depth0, depth1), max(depth2, depth3));
+
+   const float depthRangeScaleFactor = 0.75; // found empirically :)
+   const float effectRadius = depthRangeScaleFactor * XeGTAO_EffectRadius();
+   const float falloffRange = EFFECT_FALLOFF_RANGE * effectRadius;
+   const float falloffFrom = effectRadius * (1.0 - EFFECT_FALLOFF_RANGE);
+
+   // fadeout precompute optimisation
+   const float falloffMul = -1.0 / falloffRange;
+   const float falloffAdd = falloffFrom / falloffRange + 1.0;
+
+   float weight0 = saturate((maxDepth - depth0) * falloffMul + falloffAdd);
+   float weight1 = saturate((maxDepth - depth1) * falloffMul + falloffAdd);
+   float weight2 = saturate((maxDepth - depth2) * falloffMul + falloffAdd);
+   float weight3 = saturate((maxDepth - depth3) * falloffMul + falloffAdd);
+
+   float weightSum = weight0 + weight1 + weight2 + weight3;
+   return (weight0 * depth0 + weight1 * depth1 + weight2 * depth2 + weight3 * depth3) * rcp(weightSum);
+}
+
+groupshared float g_scratchDepths[8][8];
+void XeGTAO_PrefilterDepths16x16(uint2 dispatchThreadID, uint2 groupThreadID, Texture2D sourceNDCDepth, RWTexture2D<float> outDepth0, RWTexture2D<float> outDepth1, RWTexture2D<float> outDepth2, RWTexture2D<float> outDepth3, RWTexture2D<float> outDepth4)
+{
+   // MIP 0
+   const uint2 baseCoord = dispatchThreadID;
+   const uint2 pixCoord = baseCoord * 2;
+   // Explicit integer Loads of the 2x2 instead of GatherRed — GatherRed on some dgVoodoo depth views
+   // returns 0 on some drivers (flat depth -> visibility 1 -> AO silently gone). Loads read real
+   // values. Out-of-bounds Loads return 0 (D3D11-defined), clamped depth.
+   float d00 = sourceNDCDepth.Load(int3(pixCoord + uint2(0, 0), 0)).x;
+   float d10 = sourceNDCDepth.Load(int3(pixCoord + uint2(1, 0), 0)).x;
+   float d01 = sourceNDCDepth.Load(int3(pixCoord + uint2(0, 1), 0)).x;
+   float d11 = sourceNDCDepth.Load(int3(pixCoord + uint2(1, 1), 0)).x;
+   float depth0 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d00));
+   float depth1 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d10));
+   float depth2 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d01));
+   float depth3 = XeGTAO_ClampDepth(XeGTAO_ScreenSpaceToViewSpaceDepth(d11));
+   outDepth0[pixCoord + uint2(0, 0)] = depth0;
+   outDepth0[pixCoord + uint2(1, 0)] = depth1;
+   outDepth0[pixCoord + uint2(0, 1)] = depth2;
+   outDepth0[pixCoord + uint2(1, 1)] = depth3;
+
+   // MIP 1
+   float dm1 = XeGTAO_DepthMIPFilter(depth0, depth1, depth2, depth3);
+   outDepth1[baseCoord] = dm1;
+   g_scratchDepths[groupThreadID.x][groupThreadID.y] = dm1;
+
+   GroupMemoryBarrierWithGroupSync();
+
+   // MIP 2
+   [branch] if (all((groupThreadID.xy % 2) == 0))
+   {
+      float inTL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 0];
+      float inTR = g_scratchDepths[groupThreadID.x + 1][groupThreadID.y + 0];
+      float inBL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 1];
+      float inBR = g_scratchDepths[groupThreadID.x + 1][groupThreadID.y + 1];
+
+      float dm2 = XeGTAO_DepthMIPFilter(inTL, inTR, inBL, inBR);
+      outDepth2[baseCoord / 2] = dm2;
+      g_scratchDepths[groupThreadID.x][groupThreadID.y] = dm2;
+   }
+
+   GroupMemoryBarrierWithGroupSync();
+
+   // MIP 3
+   [branch] if (all((groupThreadID.xy % 4) == 0))
+   {
+      float inTL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 0];
+      float inTR = g_scratchDepths[groupThreadID.x + 2][groupThreadID.y + 0];
+      float inBL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 2];
+      float inBR = g_scratchDepths[groupThreadID.x + 2][groupThreadID.y + 2];
+
+      float dm3 = XeGTAO_DepthMIPFilter(inTL, inTR, inBL, inBR);
+      outDepth3[baseCoord / 4] = dm3;
+      g_scratchDepths[groupThreadID.x][groupThreadID.y] = dm3;
+   }
+
+   GroupMemoryBarrierWithGroupSync();
+
+   // MIP 4
+   [branch] if (all((groupThreadID.xy % 8) == 0))
+   {
+      float inTL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 0];
+      float inTR = g_scratchDepths[groupThreadID.x + 4][groupThreadID.y + 0];
+      float inBL = g_scratchDepths[groupThreadID.x + 0][groupThreadID.y + 4];
+      float inBR = g_scratchDepths[groupThreadID.x + 4][groupThreadID.y + 4];
+
+      float dm4 = XeGTAO_DepthMIPFilter(inTL, inTR, inBL, inBR);
+      outDepth4[baseCoord / 8] = dm4;
+      // g_scratchDepths[ groupThreadID.x ][ groupThreadID.y ] = dm4;
+   }
+}
+
+float4 XeGTAO_CalculateEdges(float centerZ, float leftZ, float rightZ, float topZ, float bottomZ)
+{
+   float4 edgesLRTB = float4(leftZ, rightZ, topZ, bottomZ) - centerZ;
+
+   float slopeLR = (edgesLRTB.y - edgesLRTB.x) * 0.5;
+   float slopeTB = (edgesLRTB.w - edgesLRTB.z) * 0.5;
+   float4 edgesLRTBSlopeAdjusted = edgesLRTB + float4(slopeLR, -slopeLR, slopeTB, -slopeTB);
+   edgesLRTB = min(abs(edgesLRTB), abs(edgesLRTBSlopeAdjusted));
+   return saturate(1.25 - edgesLRTB * rcp(centerZ * 0.011));
+}
+
+// packing/unpacking for edges; 2 bits per edge mean 4 gradient values (0, 0.33, 0.66, 1) for smoother transitions!
+float XeGTAO_PackEdges(float4 edgesLRTB)
+{
+   edgesLRTB = round(saturate(edgesLRTB) * 2.9);
+   return dot(edgesLRTB, float4(64.0 / 255.0, 16.0 / 255.0, 4.0 / 255.0, 1.0 / 255.0));
+}
+
+// Inputs are screen XY and viewspace depth, output is viewspace position
+float3 XeGTAO_ComputeViewspacePosition(float2 screenPos, float viewspaceDepth)
+{
+   float3 ret;
+   ret.xy = (NDC_TO_VIEW_MUL * screenPos.xy + NDC_TO_VIEW_ADD) * viewspaceDepth;
+   ret.z = viewspaceDepth;
+   return ret;
+}
+
+#if XE_GTAO_GENERATE_NORMALS
+// Depth-derived view-space normal (from the Intel reference; same convention as ComputeViewspacePosition,
+// so the space is self-consistent with the positions the main loop uses).
+float3 XeGTAO_CalculateNormal(const float4 edgesLRTB, const float3 pixCenterPos, float3 pixLPos, float3 pixRPos, float3 pixTPos, float3 pixBPos)
+{
+   float4 acceptedNormals = saturate(float4(edgesLRTB.x * edgesLRTB.z, edgesLRTB.z * edgesLRTB.y, edgesLRTB.y * edgesLRTB.w, edgesLRTB.w * edgesLRTB.x) + 0.01);
+
+   pixLPos = normalize(pixLPos - pixCenterPos);
+   pixRPos = normalize(pixRPos - pixCenterPos);
+   pixTPos = normalize(pixTPos - pixCenterPos);
+   pixBPos = normalize(pixBPos - pixCenterPos);
+
+   float3 pixelNormal = acceptedNormals.x * cross(pixLPos, pixTPos) + acceptedNormals.y * cross(pixTPos, pixRPos) + acceptedNormals.z * cross(pixRPos, pixBPos) + acceptedNormals.w * cross(pixBPos, pixLPos);
+   return normalize(pixelNormal);
+}
+#endif
+
+// http://h14s.p5r.org/2012/09/0x5f3759df.html, [Drobot2014a] Low Level Optimizations for GCN, https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf slide 63
+float XeGTAO_FastSqrt(float x)
+{
+   return asfloat(0x1fbd1df5 + (asint(x) >> 1));
+}
+
+// input [-1, 1] and output [0, PI], from https://seblagarde.wordpress.com/2014/12/01/inverse-trigonometric-functions-gpu-optimization-for-amd-gcn-architecture/
+float XeGTAO_FastACos(float inX)
+{
+   float x = abs(inX);
+   float res = -0.156583 * x + 1.570796;
+   res *= XeGTAO_FastSqrt(1.0 - x);
+   return inX >= 0 ? res : 3.141593 - res;
+}
+
+void XeGTAO_MainPass(uint2 pixCoord, float2 localNoise, float3 viewspaceNormal, Texture2D sourceViewspaceDepth, SamplerState depthSampler, RWTexture2D<unorm float2> outWorkingAOTermAndEdges)
+{
+   float2 normalizedScreenPos = (pixCoord + 0.5) * VIEWPORT_PIXEL_SIZE;
+
+   // Center + cross depths from the prefiltered (already linearized + scaled) mip0. This texture is our
+   // own R32F, Gather is safe here (the dgVoodoo view quirk is only on the game's depth view).
+   float4 valuesUL = sourceViewspaceDepth.GatherRed(depthSampler, float2(pixCoord * VIEWPORT_PIXEL_SIZE));
+   float4 valuesBR = sourceViewspaceDepth.GatherRed(depthSampler, float2(pixCoord * VIEWPORT_PIXEL_SIZE), int2(1, 1));
+
+   // viewspace Z at the center
+   float viewspaceZ = valuesUL.y;
+
+   // viewspace Zs left top right bottom
+   const float pixLZ = valuesUL.x;
+   const float pixTZ = valuesUL.z;
+   const float pixRZ = valuesBR.z;
+   const float pixBZ = valuesBR.x;
+
+   float4 edgesLRTB = XeGTAO_CalculateEdges(viewspaceZ, pixLZ, pixRZ, pixTZ, pixBZ);
+   const float edges = XeGTAO_PackEdges(edgesLRTB);
+
+#if DEVELOPMENT
+   // Debug views (visible on screen through the game's own AO blur/apply chain; the final denoise passes
+   // raw values through when DebugViewRT > 0).
+   if (DebugViewRT > 0.5 && DebugViewRT < 1.5) // 1 = depth gradient (proves live depth + linearization/scale)
+   {
+      outWorkingAOTermAndEdges[pixCoord] = float2(saturate(frac(log2(max(viewspaceZ, 1e-6)))), 1.0);
+      return;
+   }
+   if (DebugViewRT >= 3.5 && DebugViewRT < 4.5) // 4 = edges
+   {
+      outWorkingAOTermAndEdges[pixCoord] = float2(dot(edgesLRTB, 0.25), 1.0);
+      return;
+   }
+#endif
+
+#if XE_GTAO_GENERATE_NORMALS
+   // TW2 has no normal buffer at this point of the frame: derive the view-space normal from the depth
+   // cross, edge-weighted (Intel reference path). Requires the R32F pyramid we already build.
+   {
+      float3 CENTER = XeGTAO_ComputeViewspacePosition(normalizedScreenPos, viewspaceZ);
+      float3 LEFT = XeGTAO_ComputeViewspacePosition(normalizedScreenPos + float2(-1.0, 0.0) * VIEWPORT_PIXEL_SIZE, pixLZ);
+      float3 RIGHT = XeGTAO_ComputeViewspacePosition(normalizedScreenPos + float2(1.0, 0.0) * VIEWPORT_PIXEL_SIZE, pixRZ);
+      float3 TOP = XeGTAO_ComputeViewspacePosition(normalizedScreenPos + float2(0.0, -1.0) * VIEWPORT_PIXEL_SIZE, pixTZ);
+      float3 BOTTOM = XeGTAO_ComputeViewspacePosition(normalizedScreenPos + float2(0.0, 1.0) * VIEWPORT_PIXEL_SIZE, pixBZ);
+      viewspaceNormal = XeGTAO_CalculateNormal(edgesLRTB, CENTER, LEFT, RIGHT, TOP, BOTTOM);
+   }
+#endif
+
+   // Move center pixel slightly towards camera to avoid imprecision artifacts due to depth buffer imprecision; offset depends on depth texture format used
+   viewspaceZ *= 0.99999; // this is good for FP32 depth buffer
+
+   const float3 pixCenterPos = XeGTAO_ComputeViewspacePosition(normalizedScreenPos, viewspaceZ);
+   const float3 viewVec = normalize(-pixCenterPos);
+
+   // prevents normals that are facing away from the view vector - xeGTAO struggles with extreme cases, but in Vanilla it seems rare so it's disabled by default
+   viewspaceNormal = normalize(viewspaceNormal + max(0, -dot(viewspaceNormal, viewVec)) * viewVec);
+
+#if DEVELOPMENT
+   if (DebugViewRT >= 1.5 && DebugViewRT < 2.5) // 2 = normals view-facing term (smooth per-surface shading = correct space/convention)
+   {
+      outWorkingAOTermAndEdges[pixCoord] = float2(saturate(abs(dot(viewspaceNormal, viewVec))), 1.0);
+      return;
+   }
+#endif
+
+   const float effectRadius = XeGTAO_EffectRadius();
+   const float sampleDistributionPower = SAMPLE_DISTRIBUTION_POWER;
+   const float thinOccluderCompensation = THIN_OCCLUDER_COMPENSATION;
+   const float falloffRange = EFFECT_FALLOFF_RANGE * effectRadius;
+   const float falloffFrom = effectRadius * (1.0 - EFFECT_FALLOFF_RANGE);
+
+   // fadeout precompute optimisation
+   const float falloffMul = -1.0 / falloffRange;
+   const float falloffAdd = falloffFrom / falloffRange + 1.0;
+
+   float visibility = 0.0;
+
+   // see "Algorithm 1" in https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf
+   {
+      const float noiseSlice = localNoise.x;
+      const float noiseSample = localNoise.y;
+
+      // quality settings / tweaks / hacks
+      const float pixelTooCloseThreshold = 1.3; // if the offset is under approx pixel size (pixelTooCloseThreshold), push it out to the minimum distance
+
+      // approx viewspace pixel size at pixCoord; approximation of NDCToViewspace( normalizedScreenPos.xy + consts.ViewportPixelSize.xy, pixCenterPos.z ).xy - pixCenterPos.xy;
+      const float2 pixelDirRBViewspaceSizeAtCenterZ = viewspaceZ.xx * NDC_TO_VIEW_MUL_X_PIXEL_SIZE;
+
+      float screenspaceRadius = effectRadius * rcp(abs(pixelDirRBViewspaceSizeAtCenterZ.x));
+
+      // fade out for small screen radii
+      visibility += saturate((10.0 - screenspaceRadius) / 100.0) * 0.5;
+
+      // this is the min distance to start sampling from to avoid sampling from the center pixel (no useful data obtained from sampling center pixel)
+      const float minS = pixelTooCloseThreshold * rcp(screenspaceRadius);
+
+      //[unroll]
+      for (float slice = 0.0; slice < SLICE_COUNT; slice++)
+      {
+         float sliceK = (slice + noiseSlice) / SLICE_COUNT;
+         // lines 5, 6 from the paper
+         float phi = sliceK * XE_GTAO_PI;
+         float cosPhi = cos(phi);
+         float sinPhi = sin(phi);
+         float2 omega = float2(cosPhi, -sinPhi); // lpfloat2 on omega causes issues with big radii
+
+         // convert to screen units (pixels) for later use
+         omega *= screenspaceRadius;
+
+         // line 8 from the paper
+         const float3 directionVec = float3(cosPhi, sinPhi, 0.0);
+
+         // line 9 from the paper
+         const float3 orthoDirectionVec = directionVec - (dot(directionVec, viewVec) * viewVec);
+
+         // line 10 from the paper
+         // axisVec is orthogonal to directionVec and viewVec, used to define projectedNormal
+         const float3 axisVec = normalize(cross(orthoDirectionVec, viewVec));
+
+         // line 11 from the paper
+         float3 projectedNormalVec = viewspaceNormal - axisVec * dot(viewspaceNormal, axisVec);
+
+         // line 13 from the paper
+         float signNorm = sign(dot(orthoDirectionVec, projectedNormalVec));
+
+         // line 14 from the paper
+         float projectedNormalVecLength = length(projectedNormalVec);
+         float cosNorm = saturate(dot(projectedNormalVec, viewVec) * rcp(projectedNormalVecLength));
+
+         // line 15 from the paper
+         float n = signNorm * XeGTAO_FastACos(cosNorm);
+
+         // this is a lower weight target; not using -1 as in the original paper because it is under horizon, so a 'weight' has different meaning based on the normal
+         const float lowHorizonCos0 = cos(n + XE_GTAO_PI_HALF);
+         const float lowHorizonCos1 = cos(n - XE_GTAO_PI_HALF);
+
+         // lines 17, 18 from the paper, manually unrolled the 'side' loop
+         float horizonCos0 = lowHorizonCos0; //-1;
+         float horizonCos1 = lowHorizonCos1; //-1;
+
+         [unroll] for (float step = 0.0; step < STEPS_PER_SLICE; step++)
+         {
+            // R1 sequence (http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/)
+            const float stepBaseNoise = (slice + step * STEPS_PER_SLICE) * 0.6180339887498948482; // <- this should unroll
+            float stepNoise = frac(noiseSample + stepBaseNoise);
+
+            // approx line 20 from the paper, with added noise
+            float s = (step + stepNoise) / STEPS_PER_SLICE; // + (lpfloat2)1e-6f);
+
+            // additional distribution modifier
+            s = pow(s, sampleDistributionPower);
+
+            // avoid sampling center pixel
+            s += minS;
+
+            // approx lines 21-22 from the paper, unrolled
+            float2 sampleOffset = s * omega;
+
+            float sampleOffsetLength = length(sampleOffset);
+
+            // note: when sampling, using point_point_point or point_point_linear sampler works, but linear_linear_linear will cause unwanted interpolation between neighbouring depth values on the same MIP level!
+            const float mipLevel = clamp(log2(sampleOffsetLength) - DEPTH_MIP_SAMPLING_OFFSET, 0.0, XE_GTAO_DEPTH_MIP_LEVELS);
+
+            // Snap to pixel center (more correct direction math, avoids artifacts due to sampling pos not matching depth texel center - messes up slope - but adds other
+            // artifacts due to them being pushed off the slice). Also use full precision for high res cases.
+            sampleOffset = round(sampleOffset) * VIEWPORT_PIXEL_SIZE;
+
+            float2 sampleScreenPos0 = normalizedScreenPos + sampleOffset;
+            float SZ0 = sourceViewspaceDepth.SampleLevel(depthSampler, sampleScreenPos0, mipLevel).x;
+            float3 samplePos0 = XeGTAO_ComputeViewspacePosition(sampleScreenPos0, SZ0);
+
+            float2 sampleScreenPos1 = normalizedScreenPos - sampleOffset;
+            float SZ1 = sourceViewspaceDepth.SampleLevel(depthSampler, sampleScreenPos1, mipLevel).x;
+            float3 samplePos1 = XeGTAO_ComputeViewspacePosition(sampleScreenPos1, SZ1);
+
+            float3 sampleDelta0 = samplePos0 - pixCenterPos; // using lpfloat for sampleDelta causes precision issues
+            float3 sampleDelta1 = samplePos1 - pixCenterPos; // using lpfloat for sampleDelta causes precision issues
+            float sampleDist0 = length(sampleDelta0);
+            float sampleDist1 = length(sampleDelta1);
+
+            // approx lines 23, 24 from the paper, unrolled
+            float3 sampleHorizonVec0 = sampleDelta0 * rcp(sampleDist0);
+            float3 sampleHorizonVec1 = sampleDelta1 * rcp(sampleDist1);
+
+            // any sample out of radius should be discarded - also use fallof range for smooth transitions; this is a modified idea from "4.3 Implementation details, Bounding the sampling area"
+            // this is our own thickness heuristic that relies on sooner discarding samples behind the center
+            float falloffBase0 = length(float3(sampleDelta0.x, sampleDelta0.y, sampleDelta0.z * (1.0 + thinOccluderCompensation)));
+            float falloffBase1 = length(float3(sampleDelta1.x, sampleDelta1.y, sampleDelta1.z * (1.0 + thinOccluderCompensation)));
+            float weight0 = saturate(falloffBase0 * falloffMul + falloffAdd);
+            float weight1 = saturate(falloffBase1 * falloffMul + falloffAdd);
+
+            // sample horizon cos
+            float shc0 = dot(sampleHorizonVec0, viewVec);
+            float shc1 = dot(sampleHorizonVec1, viewVec);
+
+            // discard unwanted samples
+            shc0 = lerp(lowHorizonCos0, shc0, weight0); // this would be more correct but too expensive: cos(lerp( acos(lowHorizonCos0), acos(shc0), weight0 ));
+            shc1 = lerp(lowHorizonCos1, shc1, weight1); // this would be more correct but too expensive: cos(lerp( acos(lowHorizonCos1), acos(shc1), weight1 ));
+
+            // thickness heuristic disabled (THIN_OCCLUDER_COMPENSATION == 0)
+            horizonCos0 = max(horizonCos0, shc0);
+            horizonCos1 = max(horizonCos1, shc1);
+         }
+
+#if 1 // I can't figure out the slight overdarkening on high slopes, so I'm adding this fudge - in the training set, 0.05 is close (PSNR 21.34) to disabled (PSNR 21.45)
+         projectedNormalVecLength = lerp(projectedNormalVecLength, 1.0, 0.05);
+#endif
+
+         // line ~27, unrolled
+         float h0 = -XeGTAO_FastACos(horizonCos1);
+         float h1 = XeGTAO_FastACos(horizonCos0);
+         float iarc0 = (cosNorm + 2.0 * h0 * sin(n) - cos(2.0 * h0 - n)) / 4.0;
+         float iarc1 = (cosNorm + 2.0 * h1 * sin(n) - cos(2.0 * h1 - n)) / 4.0;
+         float localVisibility = projectedNormalVecLength * (iarc0 + iarc1);
+         visibility += localVisibility;
+      }
+      visibility /= SLICE_COUNT;
+      visibility = pow(max(0.0, visibility), max(0.05, FinalValuePowerRT)); // runtime dial (calibrated to the vanilla AO histogram); max(0,) also satisfies fxc strict X3571
+      visibility = max(0.0, visibility);                                    // no occlusion floor: TW2's native HBAO crushes creases all the way to 0 (Intel's 0.03 floor exists for bent-normal packing, unused here)
+   }
+
+   visibility = saturate(visibility / XE_GTAO_OCCLUSION_TERM_SCALE);
+   outWorkingAOTermAndEdges[pixCoord] = float2(visibility, edges);
+}
+
+void XeGTAO_DecodeGatherPartial(float4 packedValue, out float outDecoded[4])
+{
+   for (int i = 0; i < 4; i++)
+   {
+      outDecoded[i] = packedValue[i];
+   }
+}
+
+float4 XeGTAO_UnpackEdges(float _packedVal)
+{
+   uint packedVal = uint(_packedVal * 255.5);
+   float4 edgesLRTB;
+   edgesLRTB.x = float((packedVal >> 6) & 0x03) / 3.0; // there's really no need for mask (as it's an 8 bit input) but I'll leave it in so it doesn't cause any trouble in the future
+   edgesLRTB.y = float((packedVal >> 4) & 0x03) / 3.0;
+   edgesLRTB.z = float((packedVal >> 2) & 0x03) / 3.0;
+   edgesLRTB.w = float((packedVal >> 0) & 0x03) / 3.0;
+
+   return saturate(edgesLRTB);
+}
+
+void XeGTAO_AddSample(float ssaoValue, float edgeValue, inout float sum, inout float sumWeight)
+{
+   float weight = edgeValue;
+
+   sum += weight * ssaoValue;
+   sumWeight += weight;
+}
+
+void XeGTAO_Denoise(uint2 pixCoordBase, Texture2D sourceAOTermAndEdges, SamplerState texSampler,
+#if XE_GTAO_FINAL_APPLY
+                    RWTexture2D<float4> outputTexture // copy-source in the game AO RT's actual format; the pack pass reads only .x (AO)
+#else
+                    RWTexture2D<unorm float2> outputTexture
+#endif
+)
+{
+#if DEVELOPMENT
+   // Debug views: pass the raw working value through unblurred so the on-screen viz is exact.
+   if (DebugViewRT > 0.5)
+   {
+      for (int dside = 0; dside < 2; dside++)
+      {
+         const uint2 dpix = uint2(pixCoordBase.x + dside, pixCoordBase.y);
+         float v = sourceAOTermAndEdges.Load(int3(dpix, 0)).x;
+#if XE_GTAO_FINAL_APPLY
+         if (DebugViewRT >= 2.5 && DebugViewRT < 3.5) // 3 = AO x8 amplification (spot broad over-occlusion)
+            v = saturate(1.0 - (1.0 - v * XE_GTAO_OCCLUSION_TERM_SCALE) * 8.0);
+         outputTexture[dpix] = float4(v, 0.0, 0.0, 0.0);
+#else
+         outputTexture[dpix] = float2(v, sourceAOTermAndEdges.Load(int3(dpix, 0)).y);
+#endif
+      }
+      return;
+   }
+#endif
+
+#if XE_GTAO_FINAL_APPLY
+   const float blurAmount = DENOISE_BLUR_BETA;
+#else
+   const float blurAmount = DENOISE_BLUR_BETA / 5.0;
+#endif
+
+   const float diagWeight = 0.85 * 0.5;
+
+   float aoTerm[2]; // pixel pixCoordBase and pixel pixCoordBase + int2( 1, 0 )
+   float4 edgesC_LRTB[2];
+   float weightTL[2];
+   float weightTR[2];
+   float weightBL[2];
+   float weightBR[2];
+
+   // gather edge and visibility quads, used later
+   const float2 gatherCenter = float2(pixCoordBase.x, pixCoordBase.y) * VIEWPORT_PIXEL_SIZE;
+   float4 edgesQ0 = sourceAOTermAndEdges.GatherGreen(texSampler, gatherCenter, int2(0, 0));
+   float4 edgesQ1 = sourceAOTermAndEdges.GatherGreen(texSampler, gatherCenter, int2(2, 0));
+   float4 edgesQ2 = sourceAOTermAndEdges.GatherGreen(texSampler, gatherCenter, int2(1, 2));
+
+   float visQ0[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(0, 0)), visQ0);
+   float visQ1[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(2, 0)), visQ1);
+   float visQ2[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(0, 2)), visQ2);
+   float visQ3[4];
+   XeGTAO_DecodeGatherPartial(sourceAOTermAndEdges.GatherRed(texSampler, gatherCenter, int2(2, 2)), visQ3);
+
+   for (int side = 0; side < 2; side++)
+   {
+      const int2 pixCoord = int2(pixCoordBase.x + side, pixCoordBase.y);
+
+      float4 edgesL_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ0.x : edgesQ0.y);
+      float4 edgesT_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ0.z : edgesQ1.w);
+      float4 edgesR_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ1.x : edgesQ1.y);
+      float4 edgesB_LRTB = XeGTAO_UnpackEdges(side == 0 ? edgesQ2.w : edgesQ2.z);
+
+      edgesC_LRTB[side] = XeGTAO_UnpackEdges(side == 0 ? edgesQ0.y : edgesQ1.x);
+
+      // Edges aren't perfectly symmetrical: edge detection algorithm does not guarantee that a left edge on the right pixel will match the right edge on the left pixel (although
+      // they will match in majority of cases). This line further enforces the symmetricity, creating a slightly sharper blur. Works real nice with TAA.
+      edgesC_LRTB[side] *= float4(edgesL_LRTB.y, edgesR_LRTB.x, edgesT_LRTB.w, edgesB_LRTB.z);
+
+#if 1 // this allows some small amount of AO leaking from neighbours if there are 3 or 4 edges; this reduces both spatial and temporal aliasing
+      const float leak_threshold = 2.5;
+      const float leak_strength = 0.5;
+      float edginess = (saturate(4.0 - leak_threshold - dot(edgesC_LRTB[side], 1.0)) * rcp(4.0 - leak_threshold)) * leak_strength;
+      edgesC_LRTB[side] = saturate(edgesC_LRTB[side] + edginess);
+#endif
+
+      // for diagonals; used by first and second pass
+      weightTL[side] = diagWeight * (edgesC_LRTB[side].x * edgesL_LRTB.z + edgesC_LRTB[side].z * edgesT_LRTB.x);
+      weightTR[side] = diagWeight * (edgesC_LRTB[side].z * edgesT_LRTB.y + edgesC_LRTB[side].y * edgesR_LRTB.z);
+      weightBL[side] = diagWeight * (edgesC_LRTB[side].w * edgesB_LRTB.x + edgesC_LRTB[side].x * edgesL_LRTB.w);
+      weightBR[side] = diagWeight * (edgesC_LRTB[side].y * edgesR_LRTB.w + edgesC_LRTB[side].w * edgesB_LRTB.y);
+
+      // first pass
+      float ssaoValue = side == 0 ? visQ0[1] : visQ1[0];
+      float ssaoValueL = side == 0 ? visQ0[0] : visQ0[1];
+      float ssaoValueT = side == 0 ? visQ0[2] : visQ1[3];
+      float ssaoValueR = side == 0 ? visQ1[0] : visQ1[1];
+      float ssaoValueB = side == 0 ? visQ2[2] : visQ3[3];
+      float ssaoValueTL = side == 0 ? visQ0[3] : visQ0[2];
+      float ssaoValueBR = side == 0 ? visQ3[3] : visQ3[2];
+      float ssaoValueTR = side == 0 ? visQ1[3] : visQ1[2];
+      float ssaoValueBL = side == 0 ? visQ2[3] : visQ2[2];
+
+      float sumWeight = blurAmount;
+      float sum = ssaoValue * sumWeight;
+
+      XeGTAO_AddSample(ssaoValueL, edgesC_LRTB[side].x, sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueR, edgesC_LRTB[side].y, sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueT, edgesC_LRTB[side].z, sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueB, edgesC_LRTB[side].w, sum, sumWeight);
+
+      XeGTAO_AddSample(ssaoValueTL, weightTL[side], sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueTR, weightTR[side], sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueBL, weightBL[side], sum, sumWeight);
+      XeGTAO_AddSample(ssaoValueBR, weightBR[side], sum, sumWeight);
+
+      aoTerm[side] = sum / sumWeight;
+
+#if XE_GTAO_FINAL_APPLY
+      // Vanilla generator writes (AO, viewZ, 0, 0); the downstream pack pass 0x953119B5 reads only .x from
+      // this target (it re-reads depth from the depth texture), so .yzw can stay 0.
+      outputTexture[pixCoord] = float4(saturate(aoTerm[side] * XE_GTAO_OCCLUSION_TERM_SCALE), 0.0, 0.0, 0.0);
+#else
+      outputTexture[pixCoord] = float2(aoTerm[side], side == 0 ? edgesQ0.y : edgesQ1.x);
+#endif
+   }
+}
+
+// Implementation
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+SamplerState smp : register(s0); // point-clamp, bound by Luma (the hooked draw's s0 belongs to the pixel pipeline, not CS)
+
+Texture2D tex0 : register(t0);
+
+RWTexture2D<float> out_working_depth_mip0 : register(u0);
+RWTexture2D<float> out_working_depth_mip1 : register(u1);
+RWTexture2D<float> out_working_depth_mip2 : register(u2);
+RWTexture2D<float> out_working_depth_mip3 : register(u3);
+RWTexture2D<float> out_working_depth_mip4 : register(u4);
+RWTexture2D<unorm float2> ao_term_and_edges : register(u0);
+
+#if XE_GTAO_FINAL_APPLY
+// Plain float4 (not unorm): the copy-source texture matches the game AO RT's ACTUAL format, which is
+// rgba16_float whenever Luma's swapchain-aspect r8g8b8a8 upgrade catches it (and unorm8 otherwise) —
+// float4 UAV writes are valid against both.
+RWTexture2D<float4> final_output : register(u0);
+#else
+RWTexture2D<unorm float2> final_output : register(u0);
+#endif
+
+#define XE_GTAO_NUMTHREADS_X 8
+#define XE_GTAO_NUMTHREADS_Y 8
+
+// From https://www.shadertoy.com/view/3tB3z3 - except we're using R2 here
+#define XE_HILBERT_LEVEL 6U
+#define XE_HILBERT_WIDTH (1U << XE_HILBERT_LEVEL)
+#define XE_HILBERT_AREA  (XE_HILBERT_WIDTH * XE_HILBERT_WIDTH)
+uint HilbertIndex(uint posX, uint posY)
+{
+   uint index = 0U;
+   [unroll] for (uint curLevel = XE_HILBERT_WIDTH / 2U; curLevel > 0U; curLevel /= 2U)
+   {
+      uint regionX = (posX & curLevel) > 0U;
+      uint regionY = (posY & curLevel) > 0U;
+      index += curLevel * curLevel * ((3U * regionX) ^ regionY);
+      if (regionY == 0U)
+      {
+         if (regionX == 1U)
+         {
+            posX = XE_HILBERT_WIDTH - 1U - posX;
+            posY = XE_HILBERT_WIDTH - 1U - posY;
+         }
+         uint temp = posX;
+         posX = posY;
+         posY = temp;
+      }
+   }
+   return index;
+}
+
+// TW2 has no TAA: temporalIndex is ALWAYS 0 (frozen pattern — static noise instead of boiling).
+float2 SpatioTemporalNoise(uint2 pixCoord, uint temporalIndex)
+{
+   float2 noise;
+   uint index = HilbertIndex(pixCoord.x, pixCoord.y);
+   index += 288 * (temporalIndex % 64); // why 288? tried out a few and that's the best so far (with XE_HILBERT_LEVEL 6U) - but there's probably better :)
+   // R2 sequence - see http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+   return float2(frac(0.5 + index * float2(0.75487766624669276005, 0.5698402909980532659114)));
+}
+
+[numthreads(8, 8, 1)] // <- hard coded to 8x8; each thread computes 2x2 blocks so processing 16x16 block: Dispatch needs to be called with (width + 16-1) / 16, (height + 16-1) / 16
+    void prefilter_depths16x16_cs(uint2 dtid : SV_DispatchThreadID, uint2 gtid : SV_GroupThreadID) {
+       // tex0 = the game's half-res r32_float linear view-space depth (the hooked HBAO draw's t0)
+       XeGTAO_PrefilterDepths16x16(dtid, gtid, tex0, out_working_depth_mip0, out_working_depth_mip1, out_working_depth_mip2, out_working_depth_mip3, out_working_depth_mip4);
+    }
+
+        [numthreads(XE_GTAO_NUMTHREADS_X, XE_GTAO_NUMTHREADS_Y, 1)] void main_pass_cs(uint2 dtid : SV_DispatchThreadID)
+{
+   // tex0 = prefiltered viewspace depth MIP pyramid (our R32F)
+   // smp = point-clamp
+   // Normals are generated from depth inside XeGTAO_MainPass (XE_GTAO_GENERATE_NORMALS) — no t1 input.
+   XeGTAO_MainPass(dtid, SpatioTemporalNoise(dtid, 0), float3(0.0, 0.0, -1.0), tex0, smp, ao_term_and_edges);
+}
+
+[numthreads(XE_GTAO_NUMTHREADS_X, XE_GTAO_NUMTHREADS_Y, 1)] void denoise_pass_cs(uint2 dtid : SV_DispatchThreadID) {
+   // tex0 = g_srcWorkingAOTerm and g_srcWorkingEdges, packed
+   // smp = point-clamp
+   const uint2 pix_coord_base = dtid * uint2(2, 1); // we're computing 2 horizontal pixels at a time (performance optimization)
+   XeGTAO_Denoise(pix_coord_base, tex0, smp, final_output);
+}

--- a/Shaders/The Witcher 2/Tonemap_0x00E31BF9.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/Tonemap_0x00E31BF9.ps_5_0.hlsl
@@ -1,0 +1,25 @@
+// The Witcher 2 tonemap, adaptive TINT permutation / HDR injection point (dgVoodoo -> ps_5_0, hash
+// 0x00E31BF9; DX9 origin 0xF01A691E). Exposure + fade ramp + saturation + color tint, adaptation at t2/s2
+// (t1 holds an unused depth SRV in this permutation — the vanilla CSO does not declare it either).
+// Thin wrapper over the shared impl. See Luma_TW2_Tonemap.hlsl.
+#define TM_HAS_TINT 1
+#include "Luma_TW2_Tonemap.hlsl"
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0,
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   o0 = RunTonemap(v5);
+}

--- a/Shaders/The Witcher 2/Tonemap_0x6CF3E8B7.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/Tonemap_0x6CF3E8B7.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Tonemap, adaptive NO-TINT permutation as translated by dgVoodoo 2.81.3. Same interpolators and slot map as
+// 0x91348C0F, so the whole pass comes from that file.
+#include "Tonemap_0x91348C0F.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/Tonemap_0x91348C0F.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/Tonemap_0x91348C0F.ps_5_0.hlsl
@@ -1,0 +1,24 @@
+// The Witcher 2 tonemap, adaptive NO-TINT permutation / HDR injection point (dgVoodoo -> ps_5_0, hash
+// 0x91348C0F; DX9 origin 0xC5ADBC35). Exposure + post-scale only, alpha passthrough, adaptation at t1/s1.
+// Thin wrapper over the shared impl. See Luma_TW2_Tonemap.hlsl.
+#define TM_HAS_TINT 0
+#include "Luma_TW2_Tonemap.hlsl"
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0,
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   o0 = RunTonemap(v5);
+}

--- a/Shaders/The Witcher 2/Tonemap_0xB293C5B1.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/Tonemap_0xB293C5B1.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Tonemap, adaptive TINT permutation as translated by dgVoodoo 2.81.3. Same interpolators and slot map as
+// 0x00E31BF9, so the whole pass comes from that file.
+#include "Tonemap_0x00E31BF9.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/Video_0x30BE6D87.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/Video_0x30BE6D87.ps_5_0.hlsl
@@ -1,0 +1,102 @@
+// The Witcher 2 — pre-rendered video (USM, YUV->RGB) pass. SDR clamp + light AutoHDR for HDR (BL2 pattern).
+//
+// Plays the menu background / intro / loading movies: three YUV planes (Y=t0 2048x1024, U/V=t1/t2 1024x512,
+// value in .w of the dgVoodoo r8g8b8a8 plane views) converted BT.601 limited-range to RGB by a fullscreen
+// quad alpha-blended straight onto the fp16 scene canvas. Menu/loading frames run NO tonemap, so on Luma's
+// scRGB output this SDR video would sit flat at paper white: restore the vanilla 8-bit clamp, then apply a
+// LIGHT PumboAutoHDR for a little highlight pop in HDR.
+//
+// Body transcribed verbatim from the dgVoodoo->ps_5_0 disasm of 0x30BE6D87 (VS 0xFC80B21A): a border fade
+// (saturate(700*x) edge ramps; content is 1280x720 inside the pow2 planes -> crop at 0.625/0.703125),
+// BT.601 constants baked in code (Y-16/255 then *1.164; V*1.596/0.813; U*0.392/2.017), tint/alpha cb4[10],
+// additive bias cb4[11]. The cb3 and/or pairs are dgVoodoo's texture-format bit emulation, kept verbatim.
+// NOTE: dgVoodoo dropped the SM3 `saturate(o)` (vanilla's 8-bit UNORM target clamped for free); the fp16
+// canvas does not, so we re-add it before the AutoHDR (kills YUV overshoot + negatives).
+
+#include "Includes/Common.hlsl" // game-local: pulls GameCBuffers (LumaGameSettings VideoAutoHDR* fields) + shared Common
+
+// Light AutoHDR on videos (0 = off -> flat SDR at paper white). Peak kept low on purpose (the movies are
+// low-bitrate; pushing peak amplifies block/compression artifacts in highlights). PumboAutoHDR self-noops
+// in SDR (peak==paper).
+#ifndef ENABLE_VIDEO_AUTO_HDR
+#define ENABLE_VIDEO_AUTO_HDR 1
+#endif
+#ifndef VIDEO_AUTO_HDR_PEAK_NITS
+#define VIDEO_AUTO_HDR_PEAK_NITS 250.0
+#endif
+
+Texture2D<float4> t0 : register(t0); // Y plane (value in .w)
+Texture2D<float4> t1 : register(t1); // U plane (value in .w)
+Texture2D<float4> t2 : register(t2); // V plane (value in .w)
+
+SamplerState s0_s : register(s0);
+SamplerState s1_s : register(s1);
+SamplerState s2_s : register(s2);
+
+cbuffer cb3 : register(b3)
+{
+   float4 cb3[77];
+}
+cbuffer cb4 : register(b4)
+{
+   float4 cb4[236];
+}
+
+void main(
+    float4 v0 : SV_POSITION0,
+    float4 v1 : TEXCOORD8,
+    float4 v2 : COLOR0,
+    float4 v3 : COLOR1,
+    float4 v4 : TEXCOORD9,
+    float4 v5 : TEXCOORD0, // movie UV (only .xy used)
+    float4 v6 : TEXCOORD1,
+    float4 v7 : TEXCOORD2,
+    float4 v8 : TEXCOORD3,
+    float4 v9 : TEXCOORD4,
+    float4 v10 : TEXCOORD5,
+    float4 v11 : TEXCOORD6,
+    float4 v12 : TEXCOORD7,
+    out float4 o0 : SV_TARGET0)
+{
+   // --- border fade / content crop (verbatim): full weight inside the 1280x720 content, hard ramp at edges ---
+   float fade = saturate(700.0 * (0.703125 - v5.y)) * saturate(700.0 * (0.625 - v5.x)) * saturate(700.0 * v5.x) * saturate(700.0 * v5.y);
+   float3 rgbScale = fade * cb4[10].xyz;
+
+   // --- YUV plane fetch + dgVoodoo format-emulation mask (verbatim; plane value lives in .w) ---
+   float4 rV = t2.Sample(s2_s, v5.xy);
+   rV = asfloat((asuint(rV) & asuint(cb3[48])) | asuint(cb3[49]));
+   float V = rV.w - 0.501961;
+   float4 rU = t1.Sample(s1_s, v5.xy);
+   rU = asfloat((asuint(rU) & asuint(cb3[46])) | asuint(cb3[47]));
+   float U = rU.w - 0.501961;
+   float4 rY = t0.Sample(s0_s, v5.xy);
+   rY = asfloat((asuint(rY) & asuint(cb3[44])) | asuint(cb3[45]));
+   float Y = (rY.w - 0.062745) * 1.164;
+
+   // --- BT.601 limited-range -> RGB (verbatim constants) ---
+   float3 rgb;
+   rgb.x = Y + 1.596 * V;
+   rgb.y = Y - 0.392 * U - 0.813 * V;
+   rgb.z = Y + 2.017 * U;
+
+   o0.xyz = rgbScale * rgb + cb4[11].xyz;
+   o0.w = cb4[10].w + cb4[11].w; // vanilla alpha (src-alpha blend onto the canvas)
+
+   // --- restore vanilla 8-bit clamp, then light AutoHDR ---
+   o0.rgb = saturate(o0.rgb);
+   float3 lin = gamma_to_linear(o0.rgb);
+#if ENABLE_VIDEO_AUTO_HDR
+   if (LumaSettings.GameSettings.VideoAutoHDREnable > 0.5)
+   {
+      // boost 0 = peak at paper white -> PumboAutoHDR no-ops (off); 1 = full VIDEO_AUTO_HDR_PEAK_NITS.
+      const float peakNits = lerp(sRGB_WhiteLevelNits, VIDEO_AUTO_HDR_PEAK_NITS, saturate(LumaSettings.GameSettings.VideoAutoHDRBoost));
+      lin = PumboAutoHDR(lin, peakNits, LumaSettings.GamePaperWhiteNits);
+   }
+#endif
+#if UI_DRAW_TYPE >= 2
+   // Match the final grade's linear pre-scale: land movies at the same brightness as in-game after the
+   // composition's UIPaperWhite rescale (when UIPaperWhite != GamePaperWhite).
+   lin *= LumaSettings.GamePaperWhiteNits / max(LumaSettings.UIPaperWhiteNits, 1.0);
+#endif
+   o0.rgb = linear_to_gamma(lin); // re-encode for the gamma post buffer the composition expects
+}

--- a/Shaders/The Witcher 2/Video_0xA0C6F05C.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/Video_0xA0C6F05C.ps_5_0.hlsl
@@ -1,0 +1,3 @@
+// Video YUV->RGB pass as translated by dgVoodoo 2.81.3. Same signature and slot map as 0x30BE6D87, so the
+// whole pass comes from that file.
+#include "Video_0x30BE6D87.ps_5_0.hlsl"

--- a/Source/Games/The Witcher 2/The Witcher 2.vcxproj
+++ b/Source/Games/The Witcher 2/The Witcher 2.vcxproj
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Development-Debug|Win32">
+      <Configuration>Development-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Release|Win32">
+      <Configuration>Development-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Publishing-Release|Win32">
+      <Configuration>Publishing-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Test-Release|Win32">
+      <Configuration>Test-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8F4A1D26-93BC-4E07-A5D1-64C2E7B9F310}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Platform>Win32</Platform>
+    <ProjectName>The Witcher 2</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgTriplet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">true</GenerateManifest>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>false</VcpkgEnableManifest>
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'" Label="Vcpkg" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_DEBUG;_WINDOWS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_WITCHER2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_WITCHER2_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_WITCHER2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_WITCHER2_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;TEST=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_WITCHER2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_WITCHER2_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>../../../Shaders/$(ProjectName)/Includes/GameCBuffers.hlsl;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_WITCHER2_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_WITCHER2_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Games/The Witcher 2/The Witcher 2.vcxproj.filters
+++ b/Source/Games/The Witcher 2/The Witcher 2.vcxproj.filters
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+  </ItemGroup>
+</Project>

--- a/Source/Games/The Witcher 2/main.cpp
+++ b/Source/Games/The Witcher 2/main.cpp
@@ -1,0 +1,1328 @@
+// The Witcher 2: Assassins of Kings Enhanced Edition — Luma HDR mod (REDengine, 32-bit, DX9 -> D3D11 via dgVoodoo2).
+//
+// Hashes are the dgVoodoo-TRANSLATED ones and change with every wrapper build: 2.87.3 and 2.81.3 are keyed
+// (2.81.3 emits ps_4_0 for the same passes), any other build needs a re-dump.
+// The post chain is fp16 throughout and the "tonemap" is an adaptive exposure multiply, no curve or clamp.
+// The UI blends src-alpha onto that fp16 scene in gamma space; the main menu draws no tonemap at all.
+// Only ONE Luma .addon, and no other swapchain-hooking ReShade addon: they crash through dgVoodoo.
+
+// The MessageBox is invisible under a borderless/fullscreen game and blocks the loader -> ReShade error 1114.
+#define DISABLE_AUTO_DEBUGGER 1
+
+#define GAME_THE_WITCHER_2 1
+
+#define ENABLE_NGX 0 // NGX is x64-only and the game is 32-bit (and there are no motion vectors anyway)
+#define ENABLE_FIDELITY_SK 0
+#define GEOMETRY_SHADER_SUPPORT 0
+
+#define ENABLE_SMAA 1 // replaces the final grade's built-in FXAA with SMAA ULTRA (+RCAS); core registers the 6 "SMAA ..." passes
+// SMAA runs POST-final-grade via the post-draw callback, so it needs original_draw_dispatch_func non-null.
+#define ENABLE_POST_DRAW_DISPATCH_CALLBACK 1
+
+// No Luma bloom: the engine already draws a thresholdless glow around every light, so a pyramid on top
+// re-blooms what the canvas contains. Both that and replacing the glow were built and rejected.
+
+#include "..\..\Core\core.hpp"
+
+// Tonemap ("exposure") permutations, dgVoodoo-translated ps_5_0 hashes.
+static constexpr uint32_t kTonemapAdaptiveNoTint = 0x91348C0F; // DX9 0xC5ADBC35: exposure+scale, alpha passthrough
+static constexpr uint32_t kTonemapAdaptiveTint = 0x00E31BF9;   // DX9 0xF01A691E: + fade/saturation/tint
+// Two static permutations (exposure from PSC_LumRanges) have never been captured; their signature is 1 texture,
+// dp4 cb4[58], min cap cb4[59].x. Not declared as 0: an absent pipeline hash reads as 0 and would match.
+// Final grade (FXAA + gamma + tints + vignette), last pass before UI; hosts the HDR block and the SMAA hook.
+static constexpr uint32_t kFinalGrade = 0xDE5CF9CD;
+static constexpr uint32_t kFinalGradeNoAA = 0xCF3B72A9;       // game AA off: no FXAA block, scene alpha passed through
+static constexpr uint32_t kFinalGradeNoVignette = 0xBABBFFAD; // no FXAA and no vignette; dump-verified as the last perm
+// Native SSAO generator (HBAO variant, VS 0x5D9D0449): half-res r32_float LINEAR view depth at t0 -> half-res
+// r8g8b8a8 (.x = AO, .y = viewZ). Only this draw is replaced; the vanilla chain downstream reads just .x:
+// pack 0x953119B5 -> ping-pong 0xC131C40D x2 -> blur 0xD01CBD13 x2 -> apply 0x5C63E1C2.
+// Needs SSAO on in the game's video settings.
+static constexpr uint32_t kAOGen = 0x3FEEC0F7;
+// AO pack (t0 = full-res r32_float LINEAR depth, t1 = the AO target): depth-capture fallback for SMAA
+// predication, since it runs every frame while the tonemap capture only fires on the TINT perm.
+static constexpr uint32_t kAOPack = 0x953119B5;
+
+// The same passes as translated by dgVoodoo 2.81.3 (the build that runs under Proton), which emits ps_4_0 and
+// therefore different hashes. Dump-verified as signature-identical to their counterparts above: same
+// interpolators, t/s registers and cb slots, so the replacements and the slot-based captures are shared.
+static constexpr uint32_t kTonemapAdaptiveNoTint_v281 = 0x6CF3E8B7;
+static constexpr uint32_t kTonemapAdaptiveTint_v281 = 0xB293C5B1;
+static constexpr uint32_t kFinalGrade_v281 = 0x517DC6D5;
+static constexpr uint32_t kFinalGradeNoAA_v281 = 0xBBFEC706;
+static constexpr uint32_t kFinalGradeNoVignette_v281 = 0x2CA0631E;
+static constexpr uint32_t kAOGen_v281 = 0x6EC596CA;
+static constexpr uint32_t kAOPack_v281 = 0x495E9133;
+
+// The engine's glow chain (halo around candles and torches, distinct from the god rays) is left vanilla:
+// copy 0x5A8E5532 -> 12-tap blur 0x88C500CF x2 -> screen blend 0x12931281.
+
+// User settings, persisted in the [Luma] config section (LoadConfigs) unless noted otherwise.
+static bool g_smaa_enable = true;
+static float g_rcas_sharpness = 0.f;   // RCAS sharpen on SMAA output (0 = off)
+static bool g_smaa_predication = true; // SMAA depth predication (r32f depth captured at the tint tonemap or the AO pack pass)
+// Plane deviation counted as a full edge, as a fraction of view depth, so it is resolution independent.
+// 0.02 = ~14 cm at the measured 7 m median depth; XeGTAO uses 0.011 and ASSAO 0.040 for the same test.
+static float g_smaa_pred_tolerance = 0.02f;
+static bool g_gtao_enable = true; // XeGTAO replaces the native SSAO generator (kAOGen)
+static bool g_hide_ui = false;    // hide the game's HUD (for clean screenshots); session-only, never persisted
+
+// XeGTAO knobs CB slot, must match "register(b9)" in Luma_TW2_XeGTAO.hlsl. Not b11: core's DrawBloom owns
+// that slot for its own constants.
+static constexpr UINT kGTAOKnobsCBSlot = 9;
+// XeGTAO calibration knobs (DEV sliders, shipped at calibrated values).
+static float g_gtao_final_value_power = 1.f; // primary darkness dial (user-calibrated: matches the vanilla AO histogram, mean 0.90 vs native 0.89)
+static float g_gtao_depth_scale = 1.f;       // viewZ divisor (game units -> ~meters); dial against broad over-occlusion
+static float g_gtao_radius_override = 0.f;   // > 0 overrides the shader's EFFECT_RADIUS (view units after DepthScale)
+#if DEVELOPMENT
+static int g_gtao_debug_view = 0; // 0=off 1=depth gradient 2=normals 3=AO x8 4=edges (shader honors it under DEVELOPMENT too)
+#endif
+
+struct TheWitcher2GameDeviceData final : public GameDeviceData
+{
+   // Set when the final grade runs, cleared every Present: scopes the Hide UI skip to this frame's
+   // post-grade span.
+   bool final_grade_fired_this_frame = false;
+
+   // Repaired blend states, keyed by the ORIGINAL desc: a pointer key would go stale when a state is
+   // released and its address reused.
+   struct BlendDescCompare
+   {
+      bool operator()(const D3D11_BLEND_DESC& a, const D3D11_BLEND_DESC& b) const
+      {
+         return memcmp(&a, &b, sizeof(D3D11_BLEND_DESC)) < 0;
+      }
+   };
+   std::map<D3D11_BLEND_DESC, ComPtr<ID3D11BlendState>, BlendDescCompare> fixed_blend_states;
+
+   // ---- SMAA (see RunPostFinalGradeSMAA) ----
+   // SMAA metrics CB (b1) = (1/w,1/h,w,h) + (predication scale,0,0,0); scale 2.0 when predication on, else 1.0.
+   ComPtr<ID3D11Buffer> cb_smaa_metrics;
+   uint32_t smaa_metrics_w = 0, smaa_metrics_h = 0;
+   uint32_t smaa_core_w = 0, smaa_core_h = 0;
+   // SMAA scratch. tex_input = SRV snapshot of the canvas (already gamma, fed to both DrawSMAA color args).
+   ComPtr<ID3D11Texture2D> tex_input;
+   ComPtr<ID3D11ShaderResourceView> srv_input;
+   uint32_t smaa_temps_w = 0, smaa_temps_h = 0;
+   // RCAS input temp (SRV+RTV), allocated ONLY while sharpening is on: with RCAS off, SMAA's last pass writes
+   // the canvas directly and this stays null.
+   ComPtr<ID3D11Texture2D> tex_smaa_out;
+   ComPtr<ID3D11RenderTargetView> tex_smaa_out_rtv;
+   ComPtr<ID3D11ShaderResourceView> tex_smaa_out_srv;
+   uint32_t smaa_out_w = 0, smaa_out_h = 0;
+   // RCAS sharpen CB (b0) = (w,h,sharpness,0) + output temp (canvas format, RTV).
+   ComPtr<ID3D11Buffer> cb_sharpen;
+   uint32_t sharpen_w = 0, sharpen_h = 0;
+   float sharpen_amount = -1.f;
+   // Full-res r32_float depth, captured at whichever comes first: the TINT tonemap draw (t1) or the AO pack
+   // pass (t0). tex_pred is the R16F edge-ness from the Depth Extract CS, not a depth.
+   ComPtr<ID3D11ShaderResourceView> srv_scene_depth;
+   ComPtr<ID3D11Texture2D> tex_pred;
+   ComPtr<ID3D11UnorderedAccessView> uav_pred;
+   ComPtr<ID3D11ShaderResourceView> srv_pred;
+   uint32_t pred_w = 0, pred_h = 0;
+   ComPtr<ID3D11Buffer> cb_pred;
+   float pred_tolerance = -1.f;
+   float smaa_metrics_pred_scale = -1.f; // recreate the metrics CB when predication turns on/off
+
+   // ---- XeGTAO (see RunXeGTAO) ----
+   // Sized from the depth SRV captured at the hooked draw, so no per-present reset is needed. tex_gtao_final
+   // is our copy source: the game's AO RT is created without D3D11_BIND_UNORDERED_ACCESS.
+   ComPtr<ID3D11Texture2D> tex_gtao_depth_mips; // R32F, 5 mips (prefiltered view-space depth pyramid)
+   ComPtr<ID3D11UnorderedAccessView> gtao_depth_mip_uavs[5];
+   ComPtr<ID3D11ShaderResourceView> srv_gtao_depth_mips;
+   ComPtr<ID3D11Texture2D> tex_gtao_working[2]; // R8G8_UNORM AO+edges ping-pong
+   ComPtr<ID3D11UnorderedAccessView> uav_gtao_working[2];
+   ComPtr<ID3D11ShaderResourceView> srv_gtao_working[2];
+   ComPtr<ID3D11Texture2D> tex_gtao_final; // gtao_final_fmt, CopyResource'd into the game's AO RT
+   ComPtr<ID3D11UnorderedAccessView> uav_gtao_final;
+   uint32_t gtao_w = 0, gtao_h = 0;
+   DXGI_FORMAT gtao_final_fmt = DXGI_FORMAT_UNKNOWN; // actual (possibly Luma-upgraded) AO RT format
+   // The triple above is committed even on failure, so this latch tells "allocated" from "already failed" and
+   // stops a per-frame retry that fragments a 32-bit address space. ReleaseGTAOScratch clears it.
+   bool gtao_alloc_failed = false;
+   ComPtr<ID3D11Buffer> cb_gtao; // knobs + viewport (kGTAOKnobsCBSlot), immutable, recreated on change
+   float gtao_cb_fvp = -1.f, gtao_cb_depth_scale = -1.f, gtao_cb_radius = -1.f, gtao_cb_debug = -1.f;
+   uint32_t gtao_cb_w = 0, gtao_cb_h = 0;
+
+   void ReleaseGTAOScratch()
+   {
+      tex_gtao_depth_mips.reset();
+      for (auto& uav : gtao_depth_mip_uavs)
+         uav.reset();
+      srv_gtao_depth_mips.reset();
+      for (int i = 0; i < 2; i++)
+      {
+         tex_gtao_working[i].reset();
+         uav_gtao_working[i].reset();
+         srv_gtao_working[i].reset();
+      }
+      tex_gtao_final.reset();
+      uav_gtao_final.reset();
+      gtao_w = 0;
+      gtao_h = 0;
+      gtao_final_fmt = DXGI_FORMAT_UNKNOWN;
+      gtao_alloc_failed = false;
+   }
+
+   // Turning a feature off gives the address space back: at 4K these hold ~130 MB (SMAA) and ~30 MB (GTAO)
+   // in a 32-bit process, and everything is recreated on demand.
+   void ReleaseSMAAScratch()
+   {
+      srv_input.reset();
+      tex_input.reset();
+      smaa_temps_w = smaa_temps_h = 0;
+      ReleaseSharpenScratch();
+   }
+
+   // The RCAS intermediate exists only while sharpening is on: with RCAS at 0 the SMAA chain writes the canvas
+   // directly, so this is ~66 MB (4K rgba16f) of pure waste until the next resolution change.
+   void ReleaseSharpenScratch()
+   {
+      tex_smaa_out_rtv.reset();
+      tex_smaa_out_srv.reset();
+      tex_smaa_out.reset();
+      smaa_out_w = smaa_out_h = 0;
+      cb_sharpen.reset();
+      sharpen_w = sharpen_h = 0;
+      sharpen_amount = -1.f;
+   }
+
+   void ReleasePredicationScratch()
+   {
+      uav_pred.reset();
+      srv_pred.reset();
+      tex_pred.reset();
+      pred_w = pred_h = 0;
+      cb_pred.reset();
+      pred_tolerance = -1.f;
+   }
+};
+
+class TheWitcher2Game final : public Game
+{
+   static TheWitcher2GameDeviceData& GetGameDeviceData(DeviceData& device_data)
+   {
+      return *static_cast<TheWitcher2GameDeviceData*>(device_data.game);
+   }
+
+   // Matches a pass by both of its keyed dgVoodoo hashes.
+   static bool ContainsPixelShader(const ShaderHashesList<OneShaderPerPipeline>& shader_hashes, uint32_t hash, uint32_t hash_v281)
+   {
+      return shader_hashes.Contains(hash, reshade::api::shader_stage::pixel) || shader_hashes.Contains(hash_v281, reshade::api::shader_stage::pixel);
+   }
+
+   static bool IsTonemap(const ShaderHashesList<OneShaderPerPipeline>& shader_hashes)
+   {
+      return ContainsPixelShader(shader_hashes, kTonemapAdaptiveNoTint, kTonemapAdaptiveNoTint_v281) || ContainsPixelShader(shader_hashes, kTonemapAdaptiveTint, kTonemapAdaptiveTint_v281);
+   }
+
+   // Named injected shaders live in unordered_maps the render thread otherwise only reads: look them up with
+   // "find" (operator[] would default-insert on a miss and mutate a map DrawSMAA reads concurrently).
+   template <typename ShaderMap>
+   static auto FindShader(const ShaderMap& shaders, uint32_t name_hash)
+   {
+      const auto it = shaders.find(name_hash);
+      return it != shaders.end() ? it->second.get() : nullptr;
+   }
+
+   template <typename ShaderMap>
+   static bool AllShadersReady(const ShaderMap& shaders, std::initializer_list<uint32_t> name_hashes)
+   {
+      for (uint32_t name_hash : name_hashes)
+      {
+         if (FindShader(shaders, name_hash) == nullptr)
+            return false;
+      }
+      return true;
+   }
+
+   // Any of the three final-grade permutations (FXAA and vignette are compiled in or out independently); all
+   // three host the Luma HDR block through the same shader file.
+   static bool IsFinalGrade(const ShaderHashesList<OneShaderPerPipeline>& shader_hashes)
+   {
+      return ContainsPixelShader(shader_hashes, kFinalGrade, kFinalGrade_v281) || ContainsPixelShader(shader_hashes, kFinalGradeNoAA, kFinalGradeNoAA_v281) || ContainsPixelShader(shader_hashes, kFinalGradeNoVignette, kFinalGradeNoVignette_v281);
+   }
+
+   // dgVoodoo sometimes leaves blending ENABLED on a secondary render target while RT0 has it off. D3D9 has one
+   // global blend state and only per-RT write masks (D3DRS_COLORWRITEENABLE1/2/3), so the game never asked for
+   // it and that target is corrupted. Flotsam water (PS 0xDA16C815): RT1 is the r32_float LINEAR DEPTH fog
+   // reads, and the shader ends "mov o1.xyzw, v7.xxxx", so src_alpha IS the depth.
+   // Repair = copy RT0's blend fields onto the offending targets; write masks stay, legal per-RT in D3D9.
+   // The inverse shape is only reported: enabling blending where the wrapper left it off could only add damage.
+   static DrawOrDispatchOverrideType FixImpossiblePerRTBlend(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, TheWitcher2GameDeviceData& game_device_data, reshade::api::shader_stage stages, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass, std::function<void()>* original_draw_dispatch_func)
+   {
+      // Our own injected passes set their blend state deliberately. Re-issuing the draw is the only way to
+      // apply a different state, so without that callback there is nothing to do.
+      if (is_custom_pass || (stages & reshade::api::shader_stage::pixel) == 0 || original_draw_dispatch_func == nullptr)
+         return DrawOrDispatchOverrideType::None;
+
+      ComPtr<ID3D11BlendState> blend_state;
+      FLOAT blend_factor[4];
+      UINT sample_mask = 0;
+      native_device_context->OMGetBlendState(blend_state.put(), blend_factor, &sample_mask);
+      if (!blend_state)
+         return DrawOrDispatchOverrideType::None; // no state object = default (blending off everywhere)
+
+      D3D11_BLEND_DESC bd;
+      blend_state->GetDesc(&bd);
+      if (!bd.IndependentBlendEnable)
+         return DrawOrDispatchOverrideType::None; // one state for all targets: already D3D9-shaped
+
+      // Only BOUND targets count: the wrapper leaves stale BlendEnable in unused descriptor slots, which alone
+      // matches nearly every draw and would take over passes other hooks own. Free descriptor scan first.
+      bool disagreement = false;
+      for (UINT i = 1; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT && !disagreement; i++)
+         disagreement = bd.RenderTarget[i].BlendEnable != bd.RenderTarget[0].BlendEnable;
+      if (!disagreement)
+         return DrawOrDispatchOverrideType::None;
+
+      ID3D11RenderTargetView* rtvs[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+      native_device_context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, rtvs, nullptr);
+      bool bound[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+      for (UINT i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
+      {
+         bound[i] = rtvs[i] != nullptr;
+         if (rtvs[i])
+            rtvs[i]->Release(); // OMGetRenderTargets hands back references; only the bound/not-bound answer is kept
+      }
+
+      bool needs_fix = false;
+      [[maybe_unused]] bool inverse_shape = false;
+      for (UINT i = 1; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
+      {
+         if (!bound[i] || bd.RenderTarget[i].BlendEnable == bd.RenderTarget[0].BlendEnable)
+            continue;
+         if (bd.RenderTarget[0].BlendEnable == FALSE)
+            needs_fix = true;
+         else
+            inverse_shape = true;
+      }
+
+#if DEVELOPMENT
+      // One line per distinct shader: a session across locations and weather then names every pass carrying
+      // this, which is how a water permutation outside the captured frames would surface.
+      if (needs_fix || inverse_shape)
+      {
+         static std::unordered_set<uint64_t> logged_shaders;
+         const uint64_t pixel_shader_hash = original_shader_hashes.pixel_shaders[0];
+         if (logged_shaders.emplace(pixel_shader_hash).second)
+         {
+            reshade::log::message(reshade::log::level::warning,
+               std::format("[TW2-BlendFix] impossible per-RT blend state (dgVoodoo artefact) on pixel shader 0x{:X} - {}", pixel_shader_hash, needs_fix ? "repaired" : "inverse shape, left alone").c_str());
+         }
+      }
+#endif
+
+      if (!needs_fix)
+         return DrawOrDispatchOverrideType::None;
+
+      ComPtr<ID3D11BlendState> fixed_state;
+      if (const auto it = game_device_data.fixed_blend_states.find(bd); it != game_device_data.fixed_blend_states.end())
+      {
+         fixed_state = it->second;
+      }
+      else
+      {
+         D3D11_BLEND_DESC fixed_desc = bd;
+         for (UINT i = 1; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
+         {
+            if (fixed_desc.RenderTarget[i].BlendEnable == bd.RenderTarget[0].BlendEnable)
+               continue;
+            const UINT8 write_mask = fixed_desc.RenderTarget[i].RenderTargetWriteMask; // legal per-RT in D3D9, keep it
+            fixed_desc.RenderTarget[i] = bd.RenderTarget[0];
+            fixed_desc.RenderTarget[i].RenderTargetWriteMask = write_mask;
+         }
+         if (FAILED(native_device->CreateBlendState(&fixed_desc, fixed_state.put())) || !fixed_state)
+            return DrawOrDispatchOverrideType::None; // leave the draw untouched rather than run it half-applied
+         game_device_data.fixed_blend_states[bd] = fixed_state;
+      }
+
+      native_device_context->OMSetBlendState(fixed_state.get(), blend_factor, sample_mask);
+      (*original_draw_dispatch_func)();
+      native_device_context->OMSetBlendState(blend_state.get(), blend_factor, sample_mask); // hand the game back its own state
+      return DrawOrDispatchOverrideType::Replaced;
+   }
+
+   static bool CreateImmutableCB(ID3D11Device* device, const void* data, UINT size, ComPtr<ID3D11Buffer>& out)
+   {
+      out.reset();
+      D3D11_BUFFER_DESC bd = {};
+      bd.ByteWidth = size;
+      bd.Usage = D3D11_USAGE_IMMUTABLE;
+      bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+      D3D11_SUBRESOURCE_DATA sd = {};
+      sd.pSysMem = data;
+      return SUCCEEDED(device->CreateBuffer(&bd, &sd, out.put()));
+   }
+
+   static bool CreateDefaultTex(ID3D11Device* device, uint32_t w, uint32_t h, UINT bind_flags, ComPtr<ID3D11Texture2D>& out, DXGI_FORMAT format)
+   {
+      out.reset();
+      D3D11_TEXTURE2D_DESC td = {};
+      td.Width = w;
+      td.Height = h;
+      td.MipLevels = 1;
+      td.ArraySize = 1;
+      td.Format = format;
+      td.SampleDesc.Count = 1;
+      td.Usage = D3D11_USAGE_DEFAULT;
+      td.BindFlags = bind_flags;
+      return SUCCEEDED(device->CreateTexture2D(&td, nullptr, out.put()));
+   }
+
+#if ENABLE_SMAA
+   // SMAA on the graded gamma canvas, after the original final-grade draw and before the UI draws on it; the
+   // replaced grade skipped its own FXAA via LumaData.CustomData2.
+   void RunPostFinalGradeSMAA(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, DeviceData& device_data, TheWitcher2GameDeviceData& gd, ID3D11Resource* canvas_res, ID3D11RenderTargetView* canvas_rtv)
+   {
+      uint4 cinfo{};
+      DXGI_FORMAT cfmt = DXGI_FORMAT_UNKNOWN;
+      GetResourceInfo(canvas_res, cinfo, cfmt);
+      uint32_t w = cinfo.x, h = cinfo.y;
+      if (w == 0 || h == 0 || (uint32_t)cfmt == (uint32_t)DXGI_FORMAT_UNKNOWN)
+      {
+         return;
+      }
+
+      // Skip SMAA this frame if a pass is still missing (async loader / live reload).
+      const bool smaa_ready =
+         AllShadersReady(device_data.native_pixel_shaders, {CompileTimeStringHash("SMAA Edge Detection PS"), CompileTimeStringHash("SMAA Blending Weight Calculation PS"), CompileTimeStringHash("SMAA Neighborhood Blending PS")}) &&
+         AllShadersReady(device_data.native_vertex_shaders, {CompileTimeStringHash("SMAA Edge Detection VS"), CompileTimeStringHash("SMAA Blending Weight Calculation VS"), CompileTimeStringHash("SMAA Neighborhood Blending VS")});
+      if (!smaa_ready)
+      {
+         return;
+      }
+
+      // Drop DrawSMAA's core-managed intermediates on resolution change so they recreate at the new size.
+      if (gd.smaa_core_w != w || gd.smaa_core_h != h)
+      {
+         auto& mr = device_data.managed_resources;
+         mr.depth_stencil_views[CompileTimeStringHash("smaa_dsv")].reset();
+         mr.render_target_views[CompileTimeStringHash("smaa_edge_detection")].reset();
+         mr.render_target_views[CompileTimeStringHash("smaa_blending_weight_calculation")].reset();
+         gd.smaa_core_w = w;
+         gd.smaa_core_h = h;
+      }
+
+      // Fall back to plain ULTRA when an input is missing (never scale 2.0 with a null texture) or the depth
+      // size differs: the extract CS maps texels 1:1, so a mismatch reads a sub-rect and misaligns the mask.
+      auto* pred_cs = FindShader(device_data.native_compute_shaders, CompileTimeStringHash("TW2 Depth Extract CS"));
+      bool pred_ok = g_smaa_predication && gd.srv_scene_depth.get() != nullptr && pred_cs != nullptr;
+      if (pred_ok)
+      {
+         uint4 dinfo{};
+         DXGI_FORMAT dfmt = DXGI_FORMAT_UNKNOWN;
+         GetResourceInfo(gd.srv_scene_depth.get(), dinfo, dfmt);
+         pred_ok = dinfo.x == w && dinfo.y == h;
+      }
+      if (pred_ok)
+      {
+         if (!gd.cb_pred || gd.pred_tolerance != g_smaa_pred_tolerance)
+         {
+            const float p[4] = {g_smaa_pred_tolerance, 0.f, 0.f, 0.f};
+            if (CreateImmutableCB(native_device, p, sizeof(p), gd.cb_pred))
+               gd.pred_tolerance = g_smaa_pred_tolerance;
+         }
+         if (!gd.tex_pred || gd.pred_w != w || gd.pred_h != h)
+         {
+            gd.uav_pred.reset();
+            gd.srv_pred.reset();
+            gd.tex_pred.reset();
+            if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS, gd.tex_pred, DXGI_FORMAT_R16_FLOAT))
+            {
+               native_device->CreateUnorderedAccessView(gd.tex_pred.get(), nullptr, gd.uav_pred.put());
+               native_device->CreateShaderResourceView(gd.tex_pred.get(), nullptr, gd.srv_pred.put());
+               gd.pred_w = w;
+               gd.pred_h = h;
+            }
+         }
+         pred_ok = gd.cb_pred && gd.uav_pred && gd.srv_pred;
+      }
+
+      // Metrics CB: predication scale 2.0 when active, else 1.0. Recreate on resolution or predication flip.
+      const float pred_scale = pred_ok ? 2.0f : 1.0f;
+      if (!gd.cb_smaa_metrics || gd.smaa_metrics_w != w || gd.smaa_metrics_h != h || gd.smaa_metrics_pred_scale != pred_scale)
+      {
+         const float metrics[8] = {1.f / (float)w, 1.f / (float)h, (float)w, (float)h, pred_scale, 0.f, 0.f, 0.f};
+         if (CreateImmutableCB(native_device, metrics, sizeof(metrics), gd.cb_smaa_metrics))
+         {
+            gd.smaa_metrics_w = w;
+            gd.smaa_metrics_h = h;
+            gd.smaa_metrics_pred_scale = pred_scale;
+         }
+      }
+      if (!gd.cb_smaa_metrics)
+         return;
+
+      // Resolve RCAS before allocating: it decides whether the last pass writes the canvas RTV directly,
+      // which removes both the copy back and the intermediate.
+      auto* sharpen_vs = FindShader(device_data.native_vertex_shaders, CompileTimeStringHash("Copy VS"));
+      auto* sharpen_ps = FindShader(device_data.native_pixel_shaders, CompileTimeStringHash("TW2 Sharpen PS"));
+      bool do_sharpen = g_rcas_sharpness > 0.f && sharpen_vs != nullptr && sharpen_ps != nullptr;
+      if (do_sharpen)
+      {
+         if (!gd.cb_sharpen || gd.sharpen_w != w || gd.sharpen_h != h || gd.sharpen_amount != g_rcas_sharpness)
+         {
+            const float sp[4] = {(float)w, (float)h, g_rcas_sharpness, 0.f};
+            if (CreateImmutableCB(native_device, sp, sizeof(sp), gd.cb_sharpen))
+            {
+               gd.sharpen_w = w;
+               gd.sharpen_h = h;
+               gd.sharpen_amount = g_rcas_sharpness;
+            }
+         }
+         if (!gd.tex_smaa_out || gd.smaa_out_w != w || gd.smaa_out_h != h)
+         {
+            gd.tex_smaa_out_rtv.reset();
+            gd.tex_smaa_out_srv.reset();
+            gd.tex_smaa_out.reset();
+            if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, gd.tex_smaa_out, cfmt))
+            {
+               native_device->CreateRenderTargetView(gd.tex_smaa_out.get(), nullptr, gd.tex_smaa_out_rtv.put());
+               native_device->CreateShaderResourceView(gd.tex_smaa_out.get(), nullptr, gd.tex_smaa_out_srv.put());
+               gd.smaa_out_w = w;
+               gd.smaa_out_h = h;
+            }
+         }
+         if (!gd.cb_sharpen || !gd.tex_smaa_out_rtv || !gd.tex_smaa_out_srv)
+            do_sharpen = false;
+      }
+
+      if (!gd.tex_input || gd.smaa_temps_w != w || gd.smaa_temps_h != h)
+      {
+         gd.srv_input.reset();
+         gd.tex_input.reset();
+         if (CreateDefaultTex(native_device, w, h, D3D11_BIND_SHADER_RESOURCE, gd.tex_input, cfmt))
+         {
+            native_device->CreateShaderResourceView(gd.tex_input.get(), nullptr, gd.srv_input.put());
+            gd.smaa_temps_w = w;
+            gd.smaa_temps_h = h;
+         }
+      }
+      if (!gd.srv_input)
+         return;
+
+      // Snapshot the canvas color: the chain writes the canvas, so it must sample this copy, not the canvas.
+      native_device_context->CopyResource(gd.tex_input.get(), canvas_res);
+
+      // Predication signal: the game's linear r32f depth -> plane-deviation edge-ness in R16F (gd.tex_pred);
+      // see Luma_TW2_DepthExtract.hlsl for why this is an edge test rather than a depth rescale.
+      if (pred_ok)
+      {
+         DrawStateStack<DrawStateStackType::Compute> pred_cs_state;
+         pred_cs_state.Cache(native_device_context, device_data.uav_max_count);
+
+         ID3D11ShaderResourceView* ps_srv = gd.srv_scene_depth.get();
+         ID3D11UnorderedAccessView* ps_uav = gd.uav_pred.get();
+         ID3D11Buffer* ps_cb = gd.cb_pred.get();
+         native_device_context->CSSetShaderResources(0, 1, &ps_srv);
+         native_device_context->CSSetUnorderedAccessViews(0, 1, &ps_uav, nullptr);
+         native_device_context->CSSetConstantBuffers(0, 1, &ps_cb);
+         native_device_context->CSSetShader(pred_cs, nullptr, 0);
+         native_device_context->Dispatch((w + 7) / 8, (h + 7) / 8, 1);
+
+         pred_cs_state.Restore(native_device_context);
+      }
+
+      // SMAA (3 passes). Metrics CB at VS+PS b1 (DrawSMAA restores VS/PS/SRVs/RTs, not cbuffers).
+      ComPtr<ID3D11Buffer> vs_cb1_orig, ps_cb1_orig;
+      native_device_context->VSGetConstantBuffers(1, 1, vs_cb1_orig.put());
+      native_device_context->PSGetConstantBuffers(1, 1, ps_cb1_orig.put());
+      ID3D11Buffer* mcb = gd.cb_smaa_metrics.get();
+      native_device_context->VSSetConstantBuffers(1, 1, &mcb);
+      native_device_context->PSSetConstantBuffers(1, 1, &mcb);
+
+      // The last pass of the chain renders straight into the canvas RTV — no write-back copy. Reading the
+      // canvas is safe because SMAA/RCAS sample the snapshot (tex_input), never the canvas itself.
+      DrawSMAA(native_device, native_device_context, device_data,
+         do_sharpen ? gd.tex_smaa_out_rtv.get() : canvas_rtv, gd.srv_input.get(), gd.srv_input.get(),
+         pred_ok ? gd.srv_pred.get() : nullptr /*predication signal*/);
+
+      if (do_sharpen)
+      {
+         DrawStateStack<DrawStateStackType::FullGraphics> sharpen_state;
+         sharpen_state.Cache(native_device_context, device_data.uav_max_count);
+
+         ID3D11Buffer* scb = gd.cb_sharpen.get();
+         native_device_context->PSSetConstantBuffers(0, 1, &scb);
+         DrawCustomPixelShader(native_device_context, device_data.default_depth_stencil_state.get(), device_data.default_blend_state.get(), nullptr,
+            sharpen_vs, sharpen_ps, gd.tex_smaa_out_srv.get(), canvas_rtv, w, h, false);
+
+         sharpen_state.Restore(native_device_context);
+      }
+
+      ID3D11Buffer* vcb = vs_cb1_orig.get();
+      ID3D11Buffer* pcb = ps_cb1_orig.get();
+      native_device_context->VSSetConstantBuffers(1, 1, &vcb);
+      native_device_context->PSSetConstantBuffers(1, 1, &pcb);
+   }
+#endif // ENABLE_SMAA
+
+   // Take over the kAOGen draw: 4 XeGTAO compute passes into our scratch, then CopyResource into the game's AO
+   // RT so the vanilla chain keeps working. Inputs come from the hooked draw (depth SRV t0, RTV, cb4 for the
+   // NDC->view ray scale); a missing one returns None so the native HBAO draw runs.
+   DrawOrDispatchOverrideType RunXeGTAO(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, DeviceData& device_data, TheWitcher2GameDeviceData& gd)
+   {
+      // Resolve the four passes once (async loader / live reload) and reuse the pointers at dispatch.
+      auto* cs_prefilter = FindShader(device_data.native_compute_shaders, CompileTimeStringHash("TW2 XeGTAO Prefilter Depths CS"));
+      auto* cs_main = FindShader(device_data.native_compute_shaders, CompileTimeStringHash("TW2 XeGTAO Main Pass CS"));
+      auto* cs_denoise_1 = FindShader(device_data.native_compute_shaders, CompileTimeStringHash("TW2 XeGTAO Denoise Pass 1 CS"));
+      auto* cs_denoise_2 = FindShader(device_data.native_compute_shaders, CompileTimeStringHash("TW2 XeGTAO Denoise Pass 2 CS"));
+      if (cs_prefilter == nullptr || cs_main == nullptr || cs_denoise_1 == nullptr || cs_denoise_2 == nullptr)
+         return DrawOrDispatchOverrideType::None;
+
+      // Game depth (the hooked draw's t0): half-res r32_float linear view-space depth.
+      ComPtr<ID3D11ShaderResourceView> srv_depth;
+      native_device_context->PSGetShaderResources(0, 1, srv_depth.put());
+      if (!srv_depth)
+         return DrawOrDispatchOverrideType::None;
+      uint4 dinfo{};
+      DXGI_FORMAT dfmt = DXGI_FORMAT_UNKNOWN;
+      GetResourceInfo(srv_depth.get(), dinfo, dfmt);
+      const uint32_t w = dinfo.x, h = dinfo.y;
+      if (w == 0 || h == 0)
+         return DrawOrDispatchOverrideType::None;
+
+      // The game's AO render target; must match the depth size (both half render res).
+      ComPtr<ID3D11RenderTargetView> rtv;
+      native_device_context->OMGetRenderTargets(1, rtv.put(), nullptr);
+      if (!rtv)
+         return DrawOrDispatchOverrideType::None;
+      ComPtr<ID3D11Resource> rt_res;
+      rtv->GetResource(rt_res.put());
+      ComPtr<ID3D11Texture2D> rt_tex;
+      if (!rt_res || FAILED(rt_res->QueryInterface(rt_tex.put())))
+         return DrawOrDispatchOverrideType::None;
+      // Read the ACTUAL descriptor: our own indirect upgrade can make this RT rgba16_float while ReShade
+      // metadata still reports the original, and CopyResource silently no-ops on a family mismatch (frozen AO).
+      D3D11_TEXTURE2D_DESC rt_desc;
+      rt_tex->GetDesc(&rt_desc);
+      if (rt_desc.Width != w || rt_desc.Height != h)
+         return DrawOrDispatchOverrideType::None;
+      // Typeless family -> typed equivalent, since our UAV-written copy source needs a typed format.
+      DXGI_FORMAT final_fmt = rt_desc.Format;
+      if (final_fmt == DXGI_FORMAT_R8G8B8A8_TYPELESS)
+         final_fmt = DXGI_FORMAT_R8G8B8A8_UNORM;
+      else if (final_fmt == DXGI_FORMAT_R16G16B16A16_TYPELESS)
+         final_fmt = DXGI_FORMAT_R16G16B16A16_FLOAT;
+      // Typed UAV store is only guaranteed for these two, and they are the only formats the upgrade list can
+      // produce. Anything else would pass the copy check below and then fail at CreateTexture2D.
+      if (final_fmt != DXGI_FORMAT_R8G8B8A8_UNORM && final_fmt != DXGI_FORMAT_R16G16B16A16_FLOAT)
+         return DrawOrDispatchOverrideType::None;
+      if (!AreFormatsCopyCompatible(rt_desc.Format, final_fmt))
+         return DrawOrDispatchOverrideType::None;
+
+      // The XeGTAO shader derives its NDC->view ray scale from the game's cb4 (bound to the PS stage at the
+      // hooked draw); it is copied to the CS stage below (in-place takeover, same frame state).
+      ComPtr<ID3D11Buffer> game_cb4;
+      native_device_context->PSGetConstantBuffers(4, 1, game_cb4.put());
+      if (!game_cb4)
+         return DrawOrDispatchOverrideType::None;
+
+      // (Re)create the scratch set on first use, resolution change, or RT format change (all-or-nothing).
+      if (gd.gtao_w != w || gd.gtao_h != h || gd.gtao_final_fmt != final_fmt || !gd.tex_gtao_depth_mips || !gd.tex_gtao_working[1] || !gd.tex_gtao_final)
+      {
+         if (gd.gtao_alloc_failed && gd.gtao_w == w && gd.gtao_h == h && gd.gtao_final_fmt == final_fmt)
+            return DrawOrDispatchOverrideType::None;
+
+         gd.ReleaseGTAOScratch();
+
+         D3D11_TEXTURE2D_DESC td = {};
+         td.Width = w;
+         td.Height = h;
+         td.MipLevels = 5; // XE_GTAO_DEPTH_MIP_LEVELS
+         td.ArraySize = 1;
+         td.Format = DXGI_FORMAT_R32_FLOAT;
+         td.SampleDesc.Count = 1;
+         td.Usage = D3D11_USAGE_DEFAULT;
+         td.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+         bool ok = SUCCEEDED(native_device->CreateTexture2D(&td, nullptr, gd.tex_gtao_depth_mips.put()));
+         D3D11_UNORDERED_ACCESS_VIEW_DESC ud = {};
+         ud.Format = td.Format;
+         ud.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+         for (int i = 0; ok && i < 5; i++)
+         {
+            ud.Texture2D.MipSlice = i;
+            ok = SUCCEEDED(native_device->CreateUnorderedAccessView(gd.tex_gtao_depth_mips.get(), &ud, gd.gtao_depth_mip_uavs[i].put()));
+         }
+         ok = ok && SUCCEEDED(native_device->CreateShaderResourceView(gd.tex_gtao_depth_mips.get(), nullptr, gd.srv_gtao_depth_mips.put()));
+
+         td.MipLevels = 1;
+         td.Format = DXGI_FORMAT_R8G8_UNORM;
+         for (int i = 0; ok && i < 2; i++)
+         {
+            ok = ok && SUCCEEDED(native_device->CreateTexture2D(&td, nullptr, gd.tex_gtao_working[i].put()));
+            ok = ok && SUCCEEDED(native_device->CreateUnorderedAccessView(gd.tex_gtao_working[i].get(), nullptr, gd.uav_gtao_working[i].put()));
+            ok = ok && SUCCEEDED(native_device->CreateShaderResourceView(gd.tex_gtao_working[i].get(), nullptr, gd.srv_gtao_working[i].put()));
+         }
+
+         // Final AO in the game's channel layout (.x = AO), in the RT's ACTUAL format so CopyResource is legal.
+         // The shader writes a plain float4 UAV, valid against both unorm8 and fp16.
+         td.Format = final_fmt;
+         ok = ok && SUCCEEDED(native_device->CreateTexture2D(&td, nullptr, gd.tex_gtao_final.put()));
+         ok = ok && SUCCEEDED(native_device->CreateUnorderedAccessView(gd.tex_gtao_final.get(), nullptr, gd.uav_gtao_final.put()));
+
+         if (!ok)
+            gd.ReleaseGTAOScratch(); // drop the partials (this also resets the triple below and the latch)
+         // Commit the target triple either way: on failure it is what the latch is keyed to.
+         gd.gtao_w = w;
+         gd.gtao_h = h;
+         gd.gtao_final_fmt = final_fmt;
+         gd.gtao_alloc_failed = !ok;
+         if (!ok)
+            return DrawOrDispatchOverrideType::None; // leaves the native draw active
+      }
+
+#if DEVELOPMENT
+      const float dbg = (float)g_gtao_debug_view;
+#else
+      const float dbg = 0.f;
+#endif
+      // Knobs + viewport CB. The viewport rides along so the shader never trusts game constants for it.
+      if (!gd.cb_gtao || gd.gtao_cb_fvp != g_gtao_final_value_power || gd.gtao_cb_depth_scale != g_gtao_depth_scale ||
+          gd.gtao_cb_radius != g_gtao_radius_override || gd.gtao_cb_debug != dbg || gd.gtao_cb_w != w || gd.gtao_cb_h != h)
+      {
+         const float knobs[8] = {g_gtao_final_value_power, g_gtao_depth_scale, g_gtao_radius_override, dbg, 1.f / (float)w, 1.f / (float)h, 0.f, 0.f};
+         if (CreateImmutableCB(native_device, knobs, sizeof(knobs), gd.cb_gtao))
+         {
+            gd.gtao_cb_fvp = g_gtao_final_value_power;
+            gd.gtao_cb_depth_scale = g_gtao_depth_scale;
+            gd.gtao_cb_radius = g_gtao_radius_override;
+            gd.gtao_cb_debug = dbg;
+            gd.gtao_cb_w = w;
+            gd.gtao_cb_h = h;
+         }
+      }
+      if (!gd.cb_gtao)
+         return DrawOrDispatchOverrideType::None;
+
+      DrawStateStack<DrawStateStackType::Compute> st;
+      st.Cache(native_device_context, device_data.uav_max_count);
+
+      ID3D11Buffer* gcb = game_cb4.get();
+      native_device_context->CSSetConstantBuffers(4, 1, &gcb);
+      ID3D11Buffer* kcb = gd.cb_gtao.get();
+      native_device_context->CSSetConstantBuffers(kGTAOKnobsCBSlot, 1, &kcb);
+      ID3D11SamplerState* smp = device_data.sampler_state_point.get();
+      native_device_context->CSSetSamplers(0, 1, &smp);
+
+      static constexpr std::array<ID3D11UnorderedAccessView*, 5> uav_nulls5 = {};
+      static constexpr std::array<ID3D11ShaderResourceView*, 2> srv_nulls2 = {};
+
+      // Prefilter game depth into the R32F mip pyramid; each thread covers 2x2 pixels.
+      {
+         native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+         ID3D11ShaderResourceView* srv = srv_depth.get();
+         ID3D11UnorderedAccessView* uavs[5] = {gd.gtao_depth_mip_uavs[0].get(), gd.gtao_depth_mip_uavs[1].get(),
+            gd.gtao_depth_mip_uavs[2].get(), gd.gtao_depth_mip_uavs[3].get(), gd.gtao_depth_mip_uavs[4].get()};
+         native_device_context->CSSetUnorderedAccessViews(0, 5, uavs, nullptr);
+         native_device_context->CSSetShaderResources(0, 1, &srv);
+         native_device_context->CSSetShader(cs_prefilter, nullptr, 0);
+         native_device_context->Dispatch((w + 15) / 16, (h + 15) / 16, 1);
+         native_device_context->CSSetUnorderedAccessViews(0, 5, uav_nulls5.data(), nullptr);
+      }
+      // Bind each destination UAV before its source SRVs: D3D11 otherwise keeps the previous UAV hazard and
+      // silently nulls the conflicting SRV. Normals are generated from depth inside the shader.
+      {
+         native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+         ID3D11ShaderResourceView* srv = gd.srv_gtao_depth_mips.get();
+         ID3D11UnorderedAccessView* uav = gd.uav_gtao_working[0].get();
+         native_device_context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+         native_device_context->CSSetShaderResources(0, 1, &srv);
+         native_device_context->CSSetShader(cs_main, nullptr, 0);
+         native_device_context->Dispatch((w + 7) / 8, (h + 7) / 8, 1);
+      }
+      // First denoiser writes working1, two horizontal pixels per thread.
+      {
+         native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+         ID3D11ShaderResourceView* srv = gd.srv_gtao_working[0].get();
+         ID3D11UnorderedAccessView* uav = gd.uav_gtao_working[1].get();
+         native_device_context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+         native_device_context->CSSetShaderResources(0, 1, &srv);
+         native_device_context->CSSetShader(cs_denoise_1, nullptr, 0);
+         native_device_context->Dispatch((w + 15) / 16, (h + 7) / 8, 1);
+      }
+      {
+         native_device_context->CSSetShaderResources(0, 2, srv_nulls2.data());
+         ID3D11ShaderResourceView* srv = gd.srv_gtao_working[1].get();
+         ID3D11UnorderedAccessView* uav = gd.uav_gtao_final.get();
+         native_device_context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+         native_device_context->CSSetShaderResources(0, 1, &srv);
+         native_device_context->CSSetShader(cs_denoise_2, nullptr, 0);
+         native_device_context->Dispatch((w + 15) / 16, (h + 7) / 8, 1);
+         native_device_context->CSSetUnorderedAccessViews(0, 1, uav_nulls5.data(), nullptr);
+      }
+
+      st.Restore(native_device_context);
+
+      // The destination is still bound as the draw's render target, and copying into an OM-bound resource is a
+      // D3D11 hazard the runtime does not resolve: unbind around the copy, then restore the game's binding.
+      {
+         ComPtr<ID3D11DepthStencilView> dsv_orig;
+         native_device_context->OMGetRenderTargets(0, nullptr, dsv_orig.put());
+         native_device_context->OMSetRenderTargets(0, nullptr, nullptr);
+         native_device_context->CopyResource(rt_res.get(), gd.tex_gtao_final.get());
+         ID3D11RenderTargetView* rtv_raw = rtv.get();
+         native_device_context->OMSetRenderTargets(1, &rtv_raw, dsv_orig.get());
+      }
+
+      return DrawOrDispatchOverrideType::Replaced;
+   }
+
+public:
+   void OnInit(bool async) override
+   {
+      // Game-specific HDR toggle consumed by the replaced tonemap shaders (Luma_TW2_Tonemap.hlsl).
+      std::vector<ShaderDefineData> game_shader_defines_data = {
+         {"TONEMAP_TYPE", '1', true, false, "0 - SDR: Vanilla (bit-exact reference)\n1 - HDR: highlight expansion + DICE display map", 1},
+         {"XE_GTAO_QUALITY", '3', true, false, "XeGTAO quality (slice count)\n0 - Low\n1 - Medium\n2 - High\n3 - Very High\n4 - Ultra", 4},
+      };
+      shader_defines_data.append_range(game_shader_defines_data);
+      assert(shader_defines_data.size() < MAX_SHADER_DEFINES);
+
+      // DX9-era gamma-2.2 SDR: post buffers stay GAMMA so the gamma-SDR HUD blends like vanilla. The final
+      // grade pre-scales by GamePaperWhite/UIPaperWhite (UI_DRAW_TYPE 2) so the HUD lands at its own level.
+      GetShaderDefineData(POST_PROCESS_SPACE_TYPE_HASH).SetDefaultValue('0');
+      GetShaderDefineData(EARLY_DISPLAY_ENCODING_HASH).SetDefaultValue('0');
+      GetShaderDefineData(VANILLA_ENCODING_TYPE_HASH).SetDefaultValue('1'); // Gamma 2.2 in and out
+      GetShaderDefineData(GAMMA_CORRECTION_TYPE_HASH).SetDefaultValue('1');
+      GetShaderDefineData(GAMUT_MAPPING_TYPE_HASH).SetDefaultValue('1'); // gamut-map wild colors in composition
+      GetShaderDefineData(UI_DRAW_TYPE_HASH).SetDefaultValue('2');       // HUD gets its own UIPaperWhite + gamma blend
+
+      // Manual Scene + UI Paper White sliders instead of the OS HDR reference level (UI default 203 nits, BT.2408).
+      use_os_reference_white_level = false;
+
+      // The game (via dgVoodoo) binds b0-b5 only (runtime-verified); b12/b13 are free for Luma.
+      luma_settings_cbuffer_index = 13;
+      luma_data_cbuffer_index = 12;
+      luma_ui_cbuffer_index = -1;
+
+      // Grade controls: Exposure in Luma_TW2_Tonemap.hlsl, the rest in the final grade, all vanilla no-ops by
+      // default. No highlight-expansion knob: the fp16 overshoot already reaches ~2-6x.
+      default_luma_global_game_settings.Exposure = 1.f;               // scene multiplier (1x)
+      default_luma_global_game_settings.Saturation = 1.f;             // Oklab saturation
+      default_luma_global_game_settings.HighlightDechroma = 0.f;      // off; only mandatory DICE/gamut desat applies
+      default_luma_global_game_settings.Dithering = 1.f;              // animated triangular dither at output (HDR and SDR), anti-banding on
+      default_luma_global_game_settings.VideoAutoHDREnable = 1.f;     // light AutoHDR on pre-rendered videos (HDR only)
+      default_luma_global_game_settings.VideoAutoHDRBoost = 0.5f;     // highlight-expansion strength (peak ~165 nits at 0.5)
+      default_luma_global_game_settings.VignetteIntensity = 1.f;      // vanilla vignette darkening (0 = none)
+      default_luma_global_game_settings.HighlightsHueChroma = 0.4f;   // vanilla clip whitening: reproduces 40% of the clip's measured chroma loss (see the shader)
+      default_luma_global_game_settings.HighlightsHueStrength = 0.8f; // hue adoption; never 1.0 — a fully clipped reference is achromatic (see the shader)
+      default_luma_global_game_settings.Contrast = 1.f;               // slope contrast around 18% mid-gray (HDR path)
+      default_luma_global_game_settings.BloomIntensity = 1.f;         // engine glow scale (0 = no halo around lights)
+      default_luma_global_game_settings.ColorGradingIntensity = 1.f;  // vanilla highlight/shadow tint strength (0 = untinted grade)
+      cb_luma_global_settings.GameSettings = default_luma_global_game_settings;
+
+#if ENABLE_SMAA
+      // Core auto-registers the 6 SMAA passes. The canvas is GAMMA space and feeds both DrawSMAA color args
+      // directly, with no color-prep CS.
+      // RCAS sharpen PS (drawn via core "Copy VS" + DrawCustomPixelShader after SMAA).
+      native_shaders_definitions.emplace(CompileTimeStringHash("TW2 Sharpen PS"),
+         ShaderDefinition{"Luma_TW2_Sharpen", reshade::api::pipeline_subobject_type::pixel_shader, nullptr, "sharpen_ps"});
+      // Depth-extract CS for SMAA predication: game r32f LINEAR view-space depth -> R16F edge-ness in [0,1].
+      native_shaders_definitions.emplace(CompileTimeStringHash("TW2 Depth Extract CS"),
+         ShaderDefinition("Luma_TW2_DepthExtract", reshade::api::pipeline_subobject_type::compute_shader));
+#endif
+
+      // XeGTAO compute passes (Luma_TW2_XeGTAO.hlsl); the two denoisers differ only by XE_GTAO_FINAL_APPLY.
+      native_shaders_definitions.emplace(CompileTimeStringHash("TW2 XeGTAO Prefilter Depths CS"),
+         ShaderDefinition{"Luma_TW2_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "prefilter_depths16x16_cs"});
+      native_shaders_definitions.emplace(CompileTimeStringHash("TW2 XeGTAO Main Pass CS"),
+         ShaderDefinition{"Luma_TW2_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "main_pass_cs"});
+      native_shaders_definitions.emplace(CompileTimeStringHash("TW2 XeGTAO Denoise Pass 1 CS"),
+         ShaderDefinition{"Luma_TW2_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "denoise_pass_cs", {{"XE_GTAO_FINAL_APPLY", "0"}}});
+      native_shaders_definitions.emplace(CompileTimeStringHash("TW2 XeGTAO Denoise Pass 2 CS"),
+         ShaderDefinition{"Luma_TW2_XeGTAO", reshade::api::pipeline_subobject_type::compute_shader, nullptr, "denoise_pass_cs", {{"XE_GTAO_FINAL_APPLY", "1"}}});
+   }
+
+   void OnCreateDevice(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+      device_data.game = new TheWitcher2GameDeviceData;
+   }
+
+   void OnDestroyDeviceData(DeviceData& device_data) override
+   {
+      // GameDeviceData lacks a virtual destructor; delete through the concrete type to release derived members.
+      delete static_cast<TheWitcher2GameDeviceData*>(device_data.game);
+      device_data.game = nullptr;
+   }
+
+   DrawOrDispatchOverrideType OnDrawOrDispatch(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, CommandListData& cmd_list_data, DeviceData& device_data, reshade::api::shader_stage stages, const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes, bool is_custom_pass, bool& updated_cbuffers, std::function<void()>* original_draw_dispatch_func) override
+   {
+      auto& game_device_data = GetGameDeviceData(device_data);
+
+      // After the final grade the HUD is the only alpha-blended geometry while the post chain is opaque, so
+      // keying on blend state within this frame's post-grade span hides it without touching the scene.
+      if (g_hide_ui && game_device_data.final_grade_fired_this_frame && !is_custom_pass && !IsFinalGrade(original_shader_hashes))
+      {
+         ComPtr<ID3D11BlendState> blend_state;
+         FLOAT blend_factor[4];
+         UINT sample_mask = 0;
+         native_device_context->OMGetBlendState(blend_state.put(), blend_factor, &sample_mask);
+         if (blend_state)
+         {
+            D3D11_BLEND_DESC bd;
+            blend_state->GetDesc(&bd);
+            if (bd.RenderTarget[0].BlendEnable != FALSE)
+               return DrawOrDispatchOverrideType::Skip;
+         }
+      }
+
+      if (IsTonemap(original_shader_hashes))
+      {
+         // One permutation, two roles: the MAIN grade draws at swapchain resolution, aux draws feed DoF/flare
+         // smaller. Both stay bit-exact vanilla; the role only picks which draw marks main post processing.
+         bool is_main = false;
+         ComPtr<ID3D11RenderTargetView> rtv;
+         native_device_context->OMGetRenderTargets(1, rtv.put(), nullptr);
+         if (rtv)
+         {
+            ComPtr<ID3D11Resource> rt_resource;
+            rtv->GetResource(rt_resource.put());
+            ComPtr<ID3D11Texture2D> rt_texture;
+            if (rt_resource && SUCCEEDED(rt_resource->QueryInterface(rt_texture.put())))
+            {
+               D3D11_TEXTURE2D_DESC rt_desc;
+               rt_texture->GetDesc(&rt_desc);
+               // Not an equality test: with UberSampling the scene renders LARGER than the swapchain. Matching
+               // aspect plus at-least-swapchain size still excludes the smaller aux targets.
+               const UINT out_w = (UINT)device_data.output_resolution.x;
+               const UINT out_h = (UINT)device_data.output_resolution.y;
+               const bool at_least_full_res = rt_desc.Width >= out_w && rt_desc.Height >= out_h;
+               const bool aspect_matches = out_h != 0 && rt_desc.Height != 0 && fabsf(((float)rt_desc.Width / (float)rt_desc.Height) - ((float)out_w / (float)out_h)) < 0.05f;
+               is_main = at_least_full_res && aspect_matches;
+            }
+         }
+
+         if (is_main)
+         {
+            device_data.has_drawn_main_post_processing = true;
+         }
+
+#if ENABLE_SMAA
+         // The tint perm binds the full-res r32_float depth at t1 (declared-but-unused there); capture it for
+         // SMAA predication. Bindings are read regardless of the pass being hash-replaced.
+         if (ContainsPixelShader(original_shader_hashes, kTonemapAdaptiveTint, kTonemapAdaptiveTint_v281))
+         {
+            game_device_data.srv_scene_depth = nullptr;
+            native_device_context->PSGetShaderResources(1, 1, game_device_data.srv_scene_depth.put());
+         }
+#endif
+
+         // Upload BOTH: once updated_cbuffers is set core skips its own upload, and sending only LumaData
+         // would leave LumaSettings (b13) zeroed -> GamePaperWhiteNits 0 -> UI prescale blacks the screen.
+         SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, stages, LumaConstantBufferType::LumaSettings);
+         SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, stages, LumaConstantBufferType::LumaData, is_main ? 1u : 0u);
+         updated_cbuffers = true;
+      }
+      else if (IsFinalGrade(original_shader_hashes))
+      {
+         // CustomData2 = SMAA active, which makes the grade skip its built-in FXAA.
+         game_device_data.final_grade_fired_this_frame = true; // opens the Hide UI window for the rest of the frame
+
+         const uint32_t smaa_active = g_smaa_enable ? 1u : 0u;
+
+         SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, stages, LumaConstantBufferType::LumaSettings);
+         SetLumaConstantBuffers(native_device_context, cmd_list_data, device_data, stages, LumaConstantBufferType::LumaData, 0u, smaa_active);
+         updated_cbuffers = true;
+
+#if ENABLE_SMAA
+         // Run the original grade draw, then SMAA on its output. Without the callback this falls back to a
+         // normal draw, and the grade has already skipped FXAA for this frame: one frame of no AA.
+         if (g_smaa_enable && original_draw_dispatch_func != nullptr)
+         {
+            (*original_draw_dispatch_func)();
+            ComPtr<ID3D11RenderTargetView> grade_rtv;
+            native_device_context->OMGetRenderTargets(1, grade_rtv.put(), nullptr);
+            if (grade_rtv)
+            {
+               ComPtr<ID3D11Resource> canvas_res;
+               grade_rtv->GetResource(canvas_res.put());
+               if (canvas_res)
+                  RunPostFinalGradeSMAA(native_device, native_device_context, device_data, game_device_data, canvas_res.get(), grade_rtv.get());
+            }
+            return DrawOrDispatchOverrideType::Replaced; // we ran the original draw ourselves
+         }
+#endif
+      }
+      // Native SSAO generator -> XeGTAO takeover; independent of the tonemap/grade chain above.
+      if (g_gtao_enable && ContainsPixelShader(original_shader_hashes, kAOGen, kAOGen_v281))
+      {
+         return RunXeGTAO(native_device, native_device_context, device_data, game_device_data);
+      }
+#if ENABLE_SMAA
+      if (ContainsPixelShader(original_shader_hashes, kAOPack, kAOPack_v281))
+      {
+         // Fallback depth capture: the AO pack pass binds the same r32_float depth at t0 every frame, while
+         // the tonemap capture only fires on the TINT perm. First capture of the frame wins, same buffer.
+         if (g_smaa_predication && !game_device_data.srv_scene_depth)
+         {
+            native_device_context->PSGetShaderResources(0, 1, game_device_data.srv_scene_depth.put());
+         }
+      }
+#endif
+
+      // LAST on purpose: this one re-issues the draw itself, so it must yield to every hook above, or it runs
+      // vanilla a pass another hook meant to take over (the native SSAO draw XeGTAO replaces).
+      return FixImpossiblePerRTBlend(native_device, native_device_context, game_device_data, stages, original_shader_hashes, is_custom_pass, original_draw_dispatch_func);
+   }
+
+   void OnPresent(ID3D11Device* native_device, DeviceData& device_data) override
+   {
+      auto& game_device_data = GetGameDeviceData(device_data);
+
+      // Menu/loading frames run no tonemap: "has_drawn_main_post_processing" stays false there so the core
+      // display composition treats the frame as plain SDR UI at UIPaperWhite (do NOT force it here).
+      game_device_data.final_grade_fired_this_frame = false; // re-arm the Hide UI window for the next frame
+
+      // Give the scratch back when a feature is switched off; it is all lazily recreated. Predication and the
+      // RCAS intermediate are separate because either can be off while SMAA runs.
+      if (!g_gtao_enable && game_device_data.gtao_w != 0)
+         game_device_data.ReleaseGTAOScratch();
+#if ENABLE_SMAA
+      if (!g_smaa_enable && game_device_data.tex_input)
+         game_device_data.ReleaseSMAAScratch();
+      if ((!g_smaa_enable || !g_smaa_predication) && game_device_data.tex_pred)
+         game_device_data.ReleasePredicationScratch();
+      if (g_rcas_sharpness <= 0.f && game_device_data.tex_smaa_out)
+         game_device_data.ReleaseSharpenScratch();
+      // Per-frame capture: never let a stale depth SRV from a previous scene leak into a frame whose
+      // tonemap didn't re-capture it (menus; the SMAA pass then falls back to null predication).
+      game_device_data.srv_scene_depth = nullptr;
+#endif
+   }
+
+   void LoadConfigs() override
+   {
+#if ENABLE_SMAA
+      reshade::get_config_value(nullptr, NAME, "SMAAEnable", g_smaa_enable);
+      reshade::get_config_value(nullptr, NAME, "RCASSharpness", g_rcas_sharpness);
+      reshade::get_config_value(nullptr, NAME, "SMAAPredication", g_smaa_predication);
+#endif
+      reshade::get_config_value(nullptr, NAME, "GTAOEnable", g_gtao_enable);
+
+      // HDR grade sliders (cb_luma_global_settings_dirty is already true at init -> uploaded on first frame).
+      auto& gs = cb_luma_global_settings.GameSettings;
+      reshade::get_config_value(nullptr, NAME, "Exposure", gs.Exposure);
+      reshade::get_config_value(nullptr, NAME, "Saturation", gs.Saturation);
+      reshade::get_config_value(nullptr, NAME, "HighlightDechroma", gs.HighlightDechroma);
+      reshade::get_config_value(nullptr, NAME, "Dithering", gs.Dithering);
+      reshade::get_config_value(nullptr, NAME, "VignetteIntensity", gs.VignetteIntensity);
+      reshade::get_config_value(nullptr, NAME, "Contrast", gs.Contrast);
+      reshade::get_config_value(nullptr, NAME, "BloomIntensity", gs.BloomIntensity);
+      reshade::get_config_value(nullptr, NAME, "ColorGradingIntensity", gs.ColorGradingIntensity);
+      // "Hide Gameplay UI" is deliberately NOT persisted: a saved HUD-less state makes the
+      // next launch look broken.
+      {
+         bool video_auto_hdr = gs.VideoAutoHDREnable > 0.5f;
+         reshade::get_config_value(nullptr, NAME, "VideoAutoHDREnable", video_auto_hdr);
+         gs.VideoAutoHDREnable = video_auto_hdr ? 1.f : 0.f;
+      }
+      reshade::get_config_value(nullptr, NAME, "VideoAutoHDRBoost", gs.VideoAutoHDRBoost);
+   }
+
+   void DrawImGuiSettings(DeviceData& device_data) override
+   {
+#if ENABLE_SMAA
+      ImGui::SeparatorText("Anti-Aliasing");
+      if (ImGui::Checkbox("SMAA Enable", &g_smaa_enable))
+         reshade::set_config_value(nullptr, NAME, "SMAAEnable", g_smaa_enable);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's FXAA with SMAA (works with the game's Anti-aliasing setting on or off).");
+      ImGui::BeginDisabled(!g_smaa_enable);
+      ImGui::SliderFloat("RCAS Sharpness", &g_rcas_sharpness, 0.f, 1.f);
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, NAME, "RCASSharpness", g_rcas_sharpness);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Sharpening applied on top of SMAA (0 = off).");
+      if (DrawResetButton<float, false>(g_rcas_sharpness, 0.f, "RCASSharpness"))
+         reshade::set_config_value(nullptr, NAME, "RCASSharpness", g_rcas_sharpness);
+#if DEVELOPMENT || TEST
+      if (ImGui::Checkbox("SMAA Predication", &g_smaa_predication))
+         reshade::set_config_value(nullptr, NAME, "SMAAPredication", g_smaa_predication);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Relaxes the edge threshold back to base ULTRA on geometric silhouettes only. Off = plain ULTRA everywhere (threshold scale 1.0).");
+      ImGui::SliderFloat("SMAA Predication Tolerance", &g_smaa_pred_tolerance, 0.002f, 0.1f, "%.3f", ImGuiSliderFlags_Logarithmic);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Plane deviation counted as a full edge, as a fraction of view depth. The ONLY predication dial — the shader threshold stays 0.5 by design (see Luma_TW2_DepthExtract.hlsl). AO precedents: 0.011 (XeGTAO) .. 0.040 (ASSAO).");
+#endif
+      ImGui::EndDisabled();
+#endif
+
+      // Exposure and Color Grading Intensity act on SDR and HDR alike; the gated block below is HDR-only.
+      ImGui::SeparatorText("Grade");
+      auto& gs = cb_luma_global_settings.GameSettings;
+      auto& gs_def = default_luma_global_game_settings;
+
+      if (ImGui::SliderFloat("Exposure", &gs.Exposure, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, NAME, "Exposure", gs.Exposure);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Overall image brightness (1 = vanilla).");
+      if (DrawResetButton<float, false>(gs.Exposure, gs_def.Exposure, "Exposure"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, NAME, "Exposure", gs.Exposure);
+      }
+
+      // Not HDR-gated: the tint lerps this fades live in the vanilla grade tail, so it applies in SDR as well.
+      if (ImGui::SliderFloat("Color Grading Intensity", &gs.ColorGradingIntensity, 0.f, 1.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, NAME, "ColorGradingIntensity", gs.ColorGradingIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Strength of the game's own color grading (1 = vanilla, 0 = neutral).");
+      if (DrawResetButton<float, false>(gs.ColorGradingIntensity, gs_def.ColorGradingIntensity, "ColorGradingIntensity"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, NAME, "ColorGradingIntensity", gs.ColorGradingIntensity);
+      }
+
+      // Hidden outside HDR: the final grade's SDR branch skips the whole HDR block, so these would be dead
+      // controls. Matches the shader's own "DisplayMode == 1" test.
+      if (cb_luma_global_settings.DisplayMode == DisplayModeType::HDR)
+      {
+         if (ImGui::SliderFloat("Contrast", &gs.Contrast, 0.f, 2.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, NAME, "Contrast", gs.Contrast);
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Overall image contrast, HDR only (1 = vanilla).");
+         if (DrawResetButton<float, false>(gs.Contrast, gs_def.Contrast, "Contrast"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, NAME, "Contrast", gs.Contrast);
+         }
+
+         if (ImGui::SliderFloat("Saturation", &gs.Saturation, 0.f, 2.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, NAME, "Saturation", gs.Saturation);
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Color saturation, HDR only (1 = vanilla).");
+         if (DrawResetButton<float, false>(gs.Saturation, gs_def.Saturation, "Saturation"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, NAME, "Saturation", gs.Saturation);
+         }
+
+         if (ImGui::SliderFloat("Highlights Desaturation", &gs.HighlightDechroma, 0.f, 1.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, NAME, "HighlightDechroma", gs.HighlightDechroma);
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("How soon bright sources fade to neutral white, HDR only (0 = keep color at any brightness).");
+         if (DrawResetButton<float, false>(gs.HighlightDechroma, gs_def.HighlightDechroma, "HighlightDechroma"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, NAME, "HighlightDechroma", gs.HighlightDechroma);
+         }
+
+#if DEVELOPMENT || TEST
+         // Calibration knobs for the vanilla highlight emulation (not persisted, so the defaults above are
+         // what ship — see the RestoreHueAndChrominance call in FinalGrade_0xDE5CF9CD.ps_5_0.hlsl).
+         if (ImGui::SliderFloat("Vanilla Clip Whitening", &gs.HighlightsHueChroma, 0.f, 1.f, "%.2f"))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("chrominanceStrength of the vanilla highlight emulation: the fraction of the vanilla clip's own chroma loss that gets reproduced (0.40 = 40% of it, 1 = the vanilla amount exactly, 0 = vanilla hue but our saturation). The only one of the two knobs that can whiten; calibration in FinalGrade_0xDE5CF9CD.ps_5_0.hlsl.");
+         if (ImGui::SliderFloat("Vanilla Clip Hue", &gs.HighlightsHueStrength, 0.f, 1.f, "%.2f"))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("hueStrength of the same call: how much of the vanilla clip's hue angle is adopted (0.8 default). Never changes saturation by itself. Keep it below 1.0 — the hue runs away as the helper's chrominance ratio goes singular; measured margins in FinalGrade_0xDE5CF9CD.ps_5_0.hlsl.");
+#endif
+      }
+
+      // No "Luma Bloom Enable": the engine's glow is kept and only scaled. Applies in SDR too.
+      ImGui::SeparatorText("Bloom");
+      if (ImGui::SliderFloat("Bloom Intensity", &gs.BloomIntensity, 0.f, 2.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, NAME, "BloomIntensity", gs.BloomIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Bloom strength (1 = vanilla, 0 = none).");
+      if (DrawResetButton<float, false>(gs.BloomIntensity, gs_def.BloomIntensity, "BloomIntensity"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, NAME, "BloomIntensity", gs.BloomIntensity);
+      }
+
+      ImGui::SeparatorText("Ambient Occlusion");
+      if (ImGui::Checkbox("XeGTAO Enable", &g_gtao_enable))
+         reshade::set_config_value(nullptr, NAME, "GTAOEnable", g_gtao_enable);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Replaces the game's SSAO with XeGTAO (cleaner, more accurate ambient occlusion; requires SSAO enabled in the game's video settings).");
+#if DEVELOPMENT || TEST
+      ImGui::BeginDisabled(!g_gtao_enable);
+      ImGui::SliderFloat("GTAO Final Value Power", &g_gtao_final_value_power, 0.3f, 4.5f, "%.2f");
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Primary darkness dial (higher = darker AO). Calibrated to 1.0 here: the native HBAO histogram mean is 0.89 against XeGTAO's 0.90.");
+      ImGui::SliderFloat("GTAO Depth Scale", &g_gtao_depth_scale, 0.01f, 200.f, "%.2f", ImGuiSliderFlags_Logarithmic);
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("viewZ divisor (game depth units -> meters). Stays 1.0 in this game: its depth buffer is already LINEAR view-space metres (measured p50 7.3, max 686).");
+      ImGui::SliderFloat("GTAO Radius Override", &g_gtao_radius_override, 0.f, 5.f, "%.3f");
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("0 = shader EFFECT_RADIUS define (0.81, anchored to the native 1.18 m radius from cb4[11]); > 0 overrides it, in metres.");
+      ImGui::Combo("GTAO Debug View", &g_gtao_debug_view, "Off\0Depth gradient\0Normals\0AO x8\0Edges\0");
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+         ImGui::SetTooltip("Draws diagnostics through the game's AO apply (multiplied into the scene; DEVELOPMENT shader only). Depth gradient dead/flat or normals blocky = wrong input; AO x8 = spot broad over-occlusion.");
+      ImGui::EndDisabled();
+#endif
+
+      ImGui::SeparatorText("Effects");
+
+      // Vignette lives in the vanilla grade tail, so this applies in SDR as well as HDR.
+      if (ImGui::SliderFloat("Vignette Intensity", &gs.VignetteIntensity, 0.f, 1.f))
+         device_data.cb_luma_global_settings_dirty = true;
+      if (ImGui::IsItemDeactivatedAfterEdit())
+         reshade::set_config_value(nullptr, NAME, "VignetteIntensity", gs.VignetteIntensity);
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Scales the game's vignette darkening (1 = vanilla, 0 = none).");
+      if (DrawResetButton<float, false>(gs.VignetteIntensity, gs_def.VignetteIntensity, "VignetteIntensity"))
+      {
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, NAME, "VignetteIntensity", gs.VignetteIntensity);
+      }
+
+      // HDR-path only: PumboAutoHDR self-noops when peak == paper white, which both SDR modes force.
+      if (cb_luma_global_settings.DisplayMode == DisplayModeType::HDR)
+      {
+         bool video_auto_hdr = gs.VideoAutoHDREnable > 0.5f;
+         if (ImGui::Checkbox("Video AutoHDR", &video_auto_hdr))
+         {
+            gs.VideoAutoHDREnable = video_auto_hdr ? 1.f : 0.f;
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, NAME, "VideoAutoHDREnable", video_auto_hdr);
+         }
+         if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Adds HDR highlights to pre-rendered videos (HDR only).");
+         ImGui::BeginDisabled(!video_auto_hdr);
+         if (ImGui::SliderFloat("Video HDR Boost", &gs.VideoAutoHDRBoost, 0.f, 1.f))
+            device_data.cb_luma_global_settings_dirty = true;
+         if (ImGui::IsItemDeactivatedAfterEdit())
+            reshade::set_config_value(nullptr, NAME, "VideoAutoHDRBoost", gs.VideoAutoHDRBoost);
+         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+            ImGui::SetTooltip("Video highlight strength (0 = off).");
+         if (DrawResetButton<float, false>(gs.VideoAutoHDRBoost, gs_def.VideoAutoHDRBoost, "VideoAutoHDRBoost"))
+         {
+            device_data.cb_luma_global_settings_dirty = true;
+            reshade::set_config_value(nullptr, NAME, "VideoAutoHDRBoost", gs.VideoAutoHDRBoost);
+         }
+         ImGui::EndDisabled();
+      }
+
+      // The final grade dithers in gamma either way, so this stays outside the HDR gate above.
+      bool dithering = gs.Dithering > 0.5f;
+      if (ImGui::Checkbox("Dithering", &dithering))
+      {
+         gs.Dithering = dithering ? 1.f : 0.f;
+         device_data.cb_luma_global_settings_dirty = true;
+         reshade::set_config_value(nullptr, NAME, "Dithering", gs.Dithering);
+      }
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Reduces gradient banding.");
+
+      ImGui::SeparatorText("UI");
+      ImGui::Checkbox("Hide Gameplay UI", &g_hide_ui); // Session-only to avoid a confusing HUD-less restart.
+      if (ImGui::IsItemHovered())
+         ImGui::SetTooltip("Disables the in-game UI.");
+   }
+
+   void PrintImGuiAbout() override
+   {
+      ImGui::PushTextWrapPos(0.f);
+      ImGui::Text(
+         "Luma for \"The Witcher 2: Assassins of Kings Enhanced Edition\" is developed by DristoforColumb and is open source and free.\n"
+         "It adds HDR and replaces the game's FXAA with SMAA and its SSAO with XeGTAO, plus 16x anisotropic filtering.\n"
+         "It runs through dgVoodoo2 (DirectX 9 -> 11).\n"
+         "Enable SSAO in the game's video settings for XeGTAO to apply; SMAA works either way.\n"
+         "Keep the in-game Brightness and Gamma sliders at their defaults.\n"
+         "Do NOT run another HDR mod (e.g. RenoDX) alongside it.\n"
+         "Thanks to the Luma team and contributors.\n"
+         "If you enjoy it, consider donating.");
+      ImGui::PopTextWrapPos();
+
+      ImGui::NewLine();
+      ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(70, 134, 0, 255));
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(70 + 9, 134 + 9, 0, 255));
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(70 + 18, 134 + 18, 0, 255));
+      static const std::string donation_link = std::string("Buy DristoforColumb a Coffee on ko-fi ") + std::string(ICON_FK_OK);
+      if (ImGui::Button(donation_link.c_str()))
+         ShellExecuteA(nullptr, "open", "https://ko-fi.com/dristoforcolumb", nullptr, nullptr, SW_SHOWNORMAL);
+      ImGui::PopStyleColor(3);
+
+      ImGui::NewLine();
+      static const std::string social_link = std::string("Join our \"HDR Den\" Discord ") + std::string(ICON_FK_SEARCH);
+      if (ImGui::Button(social_link.c_str()))
+      {
+         // Unique link for Luma's HDR Den (tracks the origin of people joining); do not share for other purposes.
+         static const std::string discord_link = std::string("https://discord.gg/J9fM") + std::string("3EVuEZ");
+         ShellExecuteA(nullptr, "open", discord_link.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+      }
+      static const std::string contributing_link = std::string("Contribute on Github ") + std::string(ICON_FK_FILE_CODE);
+      if (ImGui::Button(contributing_link.c_str()))
+         ShellExecuteA(nullptr, "open", "https://github.com/Filoppi/Luma-Framework", nullptr, nullptr, SW_SHOWNORMAL);
+
+      ImGui::NewLine();
+      ImGui::Text("Build Date: %s %s", __DATE__, __TIME__);
+
+      ImGui::NewLine();
+      ImGui::Text("Credits:"
+                  "\n\nMain:"
+                  "\nDristoforColumb"
+                  "\n\nThird Party:"
+                  "\nReShade"
+                  "\nImGui"
+                  "\nDICE (HDR tonemapper)"
+                  "\nOklab (hue/chroma restoration)"
+                  "\nSMAA (Iryoku)"
+                  "\nXeGTAO (Intel)"
+                  "\nAMD FidelityFX (RCAS)"
+                  "\ndgVoodoo2 (DirectX 9 -> 11 wrapper, required)");
+   }
+};
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+   {
+      Globals::SetGlobals(PROJECT_NAME, "The Witcher 2 Luma mod");
+      Globals::DEVELOPMENT_STATE = Globals::ModDevelopmentState::Finished;
+
+      // scRGB fp16 swapchain (the game's backbuffer is b8g8r8x8/b8g8r8a8 8-bit).
+      swapchain_format_upgrade_type = TextureFormatUpgradesType::AllowedEnabled;
+      swapchain_upgrade_type = SwapchainUpgradeType::scRGB;
+
+      // Exclusive fullscreen -> borderless. force_borderless extends that to LEAVING fullscreen, so the title
+      // bar cannot come back after a mode switch or an alt-tab.
+      prevent_fullscreen_state = true;
+      force_borderless = true;
+
+      // The only resource still clipping the HDR signal is dgVoodoo's swapchain-resolution present-blit
+      // intermediate. Upgrade it INDIRECTLY: it is wrapper-internal, and changing its creation format breaks
+      // the translator's bookkeeping, giving a black screen even in menus.
+      // One format plus the size filters keeps this to a single extra fp16 mirror at 4K; a broad list hit
+      // bad_alloc in this 32-bit process. Fullscreen only: that path's intermediate is r8g8b8a8_typeless.
+      texture_format_upgrades_type = TextureFormatUpgradesType::AllowedEnabled;
+      enable_indirect_texture_format_upgrades = true; // creation-time mirrors, substituted at bind
+      enable_chain_indirect_texture_format_upgrades = ChainTextureFormatUpgradesType::DirectDependencies;
+      texture_upgrade_formats = {
+         reshade::api::format::r8g8b8a8_typeless, // dgVoodoo's present-blit intermediates (narrow list: 32-bit VA budget)
+      };
+      texture_format_upgrades_2d_size_filters = (uint32_t)TextureFormatUpgrades2DSizeFilters::SwapchainResolution | (uint32_t)TextureFormatUpgrades2DSizeFilters::SwapchainAspectRatio;
+
+      // AF16x. A sampler census found only MIN_MAG_MIP_LINEAR (0x15, world), MIN_MAG_LINEAR_MIP_POINT (0x14,
+      // post/UI) and MIN_MAG_MIP_POINT, not one anisotropic sampler: the game has no AF option. Mode 4 alone is
+      // therefore a no-op, and force_upgrade_linear_samplers is what buys AF by promoting the trilinear class.
+      // The census also reports MipLODBias 0.000 everywhere, so there is no negative bias to clamp.
+      enable_samplers_upgrade = true; // boot-time only (cannot change after device creation)
+      samplers_upgrade_mode = 4;
+      force_upgrade_linear_samplers = true;
+
+      game = new TheWitcher2Game();
+   }
+
+   CoreMain(hModule, ul_reason_for_call, lpReserved);
+
+   return TRUE;
+}


### PR DESCRIPTION
Luma addon for The Witcher 2: Assassins of Kings Enhanced Edition
- Native HDR: scRGB fp16 swapchain
- AA: replaces the final grade's built-in FXAA with SMAA + optional RCAS sharpen
- AO: replaces the native SSAO with XeGTAO
- Forces 16x anisotropic filtering
- AutoHDR for the pre-rendered videos
- Grade controls (exposure, contrast, saturation, highlight desaturation, color grading intensity, bloom, vignette, dithering) + Hide Gameplay UI toggle