### PR TITLE
The Witcher 2: Fix the missing FXAA + no-vignette grade permutation and adjust XeGTAO power

### DIFF
--- a/Shaders/The Witcher 2/FinalGradeAANoVignette_0x058E2498.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGradeAANoVignette_0x058E2498.ps_5_0.hlsl
@@ -1,0 +1,14 @@
+// The Witcher 2 final grade, FXAA + NO-VIGNETTE permutation (dgVoodoo -> ps_5_0, hash 0x058E2498): the fourth
+// corner of the 2x2 matrix the engine compiles (FXAA in/out x vignette in/out). Disassembly diff vs
+// 0xDE5CF9CD: byte-for-byte the same shader minus the t2/s2 mask sample, the cb3[48..49] fixup and the
+// cb4[66..67] weight/color lerp; the FXAA block, the grade tail and the o0.w = 0 write are unchanged.
+//
+// Without this file the pass fell through unreplaced whenever the user ran the game's Anti-aliasing ON with
+// the vignette OFF, which silently costs the whole Luma tail on those frames: no HDR block, no SMAA (the
+// post-draw callback keys on the grade hash) and no Hide UI gate.
+//
+// No dgVoodoo 2.81.3 counterpart is keyed: that build's dump was captured with the vignette on and never
+// produced this permutation. It needs a re-dump under 2.81.3 with the vignette off.
+
+#define LUMA_TW2_NO_VIGNETTE_PERM 1
+#include "FinalGrade_0xDE5CF9CD.ps_5_0.hlsl"

--- a/Shaders/The Witcher 2/FinalGradeAANoVignette_0xA966D512.ps_5_0.hlsl
+++ b/Shaders/The Witcher 2/FinalGradeAANoVignette_0xA966D512.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// Final grade, FXAA + NO-VIGNETTE permutation as translated by dgVoodoo 2.81.3 (which emits ps_4_0). Same
+// signature and slot map as 0x058E2498 - the disassembly diff against this build's 0x517DC6D5 is the same
+// three declarations and the same eight vignette-tail instructions - so the whole pass comes from that file.
+#include "FinalGradeAANoVignette_0x058E2498.ps_5_0.hlsl"

--- a/Source/Games/The Witcher 2/main.cpp
+++ b/Source/Games/The Witcher 2/main.cpp
@@ -32,7 +32,9 @@ static constexpr uint32_t kTonemapAdaptiveTint = 0x00E31BF9;   // DX9 0xF01A691E
 // Final grade (FXAA + gamma + tints + vignette), last pass before UI; hosts the HDR block and the SMAA hook.
 static constexpr uint32_t kFinalGrade = 0xDE5CF9CD;
 static constexpr uint32_t kFinalGradeNoAA = 0xCF3B72A9;       // game AA off: no FXAA block, scene alpha passed through
-static constexpr uint32_t kFinalGradeNoVignette = 0xBABBFFAD; // no FXAA and no vignette; dump-verified as the last perm
+static constexpr uint32_t kFinalGradeNoVignette = 0xBABBFFAD; // no FXAA and no vignette
+// FXAA on, vignette off: the fourth corner of the 2x2 permutation matrix.
+static constexpr uint32_t kFinalGradeAANoVignette = 0x058E2498;
 // Native SSAO generator (HBAO variant, VS 0x5D9D0449): half-res r32_float LINEAR view depth at t0 -> half-res
 // r8g8b8a8 (.x = AO, .y = viewZ). Only this draw is replaced; the vanilla chain downstream reads just .x:
 // pack 0x953119B5 -> ping-pong 0xC131C40D x2 -> blur 0xD01CBD13 x2 -> apply 0x5C63E1C2.
@@ -50,6 +52,7 @@ static constexpr uint32_t kTonemapAdaptiveTint_v281 = 0xB293C5B1;
 static constexpr uint32_t kFinalGrade_v281 = 0x517DC6D5;
 static constexpr uint32_t kFinalGradeNoAA_v281 = 0xBBFEC706;
 static constexpr uint32_t kFinalGradeNoVignette_v281 = 0x2CA0631E;
+static constexpr uint32_t kFinalGradeAANoVignette_v281 = 0xA966D512;
 static constexpr uint32_t kAOGen_v281 = 0x6EC596CA;
 static constexpr uint32_t kAOPack_v281 = 0x495E9133;
 
@@ -236,11 +239,11 @@ class TheWitcher2Game final : public Game
       return true;
    }
 
-   // Any of the three final-grade permutations (FXAA and vignette are compiled in or out independently); all
-   // three host the Luma HDR block through the same shader file.
+   // Any of the four final-grade permutations (FXAA and vignette are compiled in or out independently); all
+   // four host the Luma HDR block through the same shader file.
    static bool IsFinalGrade(const ShaderHashesList<OneShaderPerPipeline>& shader_hashes)
    {
-      return ContainsPixelShader(shader_hashes, kFinalGrade, kFinalGrade_v281) || ContainsPixelShader(shader_hashes, kFinalGradeNoAA, kFinalGradeNoAA_v281) || ContainsPixelShader(shader_hashes, kFinalGradeNoVignette, kFinalGradeNoVignette_v281);
+      return ContainsPixelShader(shader_hashes, kFinalGrade, kFinalGrade_v281) || ContainsPixelShader(shader_hashes, kFinalGradeNoAA, kFinalGradeNoAA_v281) || ContainsPixelShader(shader_hashes, kFinalGradeNoVignette, kFinalGradeNoVignette_v281) || ContainsPixelShader(shader_hashes, kFinalGradeAANoVignette, kFinalGradeAANoVignette_v281);
    }
 
    // dgVoodoo sometimes leaves blending ENABLED on a secondary render target while RT0 has it off. D3D9 has one

--- a/Source/Games/The Witcher 2/main.cpp
+++ b/Source/Games/The Witcher 2/main.cpp
@@ -72,10 +72,12 @@ static bool g_hide_ui = false;    // hide the game's HUD (for clean screenshots)
 // XeGTAO knobs CB slot, must match "register(b9)" in Luma_TW2_XeGTAO.hlsl. Not b11: core's DrawBloom owns
 // that slot for its own constants.
 static constexpr UINT kGTAOKnobsCBSlot = 9;
-// XeGTAO calibration knobs (DEV sliders, shipped at calibrated values).
-static float g_gtao_final_value_power = 1.f; // primary darkness dial (user-calibrated: matches the vanilla AO histogram, mean 0.90 vs native 0.89)
-static float g_gtao_depth_scale = 1.f;       // viewZ divisor (game units -> ~meters); dial against broad over-occlusion
-static float g_gtao_radius_override = 0.f;   // > 0 overrides the shader's EFFECT_RADIUS (view units after DepthScale)
+// XeGTAO calibration knobs (DEV sliders). DepthScale and RadiusOverride ship at their calibrated values;
+// FinalValuePower does NOT - 2.2 is a preference, while 1.0 is the value whose AO histogram matches the
+// game's own HBAO (mean 0.90 against native 0.89).
+static float g_gtao_final_value_power = 2.2f; // primary darkness dial (higher = darker)
+static float g_gtao_depth_scale = 1.f;        // viewZ divisor (game units -> ~meters); dial against broad over-occlusion
+static float g_gtao_radius_override = 0.f;    // > 0 overrides the shader's EFFECT_RADIUS (view units after DepthScale)
 #if DEVELOPMENT || TEST
 static int g_gtao_debug_view = 0; // 0=off 1=depth gradient 2=normals 3=AO x8 4=edges (shader honors it under DEVELOPMENT too)
 #endif
@@ -1159,7 +1161,7 @@ public:
       ImGui::BeginDisabled(!g_gtao_enable);
       ImGui::SliderFloat("GTAO Final Value Power", &g_gtao_final_value_power, 0.3f, 4.5f, "%.2f");
       if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-         ImGui::SetTooltip("Primary darkness dial (higher = darker AO). Calibrated to 1.0 here: the native HBAO histogram mean is 0.89 against XeGTAO's 0.90.");
+         ImGui::SetTooltip("Primary darkness dial (higher = darker AO). Shipped at 2.2 by preference; 1.0 is the value that matches the native HBAO histogram, mean 0.89 against XeGTAO's 0.90.");
       ImGui::SliderFloat("GTAO Depth Scale", &g_gtao_depth_scale, 0.01f, 200.f, "%.2f", ImGuiSliderFlags_Logarithmic);
       if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
          ImGui::SetTooltip("viewZ divisor (game depth units -> meters). Stays 1.0 in this game: its depth buffer is already LINEAR view-space metres (measured p50 7.3, max 686).");


### PR DESCRIPTION
- Adjust XeGTAO strength
- Add AA on Vignette off shader permutation